### PR TITLE
Refactor ViewModel creation and data retrieval

### DIFF
--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditfix/AdditionalListFragment.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditfix/AdditionalListFragment.kt
@@ -13,6 +13,7 @@ import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.credit.IAdditional
 import co.com.japl.module.credit.controllers.list.AdditionalViewModel
 import co.com.japl.module.credit.views.lists.Additional
+import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.japl.android.myapplication.databinding.FragmentAdditionalListBinding
 import co.japl.android.myapplication.finanzas.controller.ViewModelFactory
 import dagger.hilt.android.AndroidEntryPoint

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditfix/AdditionalListFragment.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditfix/AdditionalListFragment.kt
@@ -8,19 +8,24 @@ import android.view.ViewGroup
 import androidx.annotation.RequiresApi
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.credit.IAdditional
 import co.com.japl.module.credit.controllers.list.AdditionalViewModel
 import co.com.japl.module.credit.views.lists.Additional
-import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.japl.android.myapplication.databinding.FragmentAdditionalListBinding
-import co.japl.android.myapplication.finanzas.putParams.CreditFixParams
+import co.japl.android.myapplication.finanzas.controller.ViewModelFactory
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
 class AdditionalListFragment : Fragment() {
     @Inject lateinit var additionalSvc : IAdditional
+    private val viewModel: AdditionalViewModel by viewModels {
+        ViewModelFactory(this,AdditionalViewModel::class.java){
+            AdditionalViewModel(requireContext(),it,additionalSvc)
+        }
+    }
 
 
     @RequiresApi(Build.VERSION_CODES.S)
@@ -29,15 +34,11 @@ class AdditionalListFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         val root = FragmentAdditionalListBinding.inflate(inflater)
-        val code = arguments?.let {
-            CreditFixParams.downloadAdditionalList(it)
-        } ?: 0
-        val viewModel = AdditionalViewModel(context = context?.applicationContext!!,code.toInt(),additionalSvc,findNavController())
         root.composeViewFal.apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
                 MaterialThemeComposeUI {
-                    Additional(viewModel)
+                    Additional(viewModel,findNavController())
                 }
             }
         }

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditfix/CreditListFragment.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditfix/CreditListFragment.kt
@@ -8,20 +8,24 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.credit.ICreditPort
 import co.com.japl.module.credit.controllers.recap.RecapViewModel
 import co.com.japl.module.credit.views.recap.Recap
-import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.japl.android.myapplication.databinding.FragmentCreditListBinding
+import co.japl.android.myapplication.finanzas.controller.ViewModelFactory
 import dagger.hilt.android.AndroidEntryPoint
-import java.time.YearMonth
 import javax.inject.Inject
 
 @AndroidEntryPoint
 class CreditListFragment : Fragment(){
-    private lateinit var period:YearMonth
     @Inject lateinit var creditList:ICreditPort
+    private val viewModel: RecapViewModel by viewModels {
+        ViewModelFactory(this,RecapViewModel::class.java){
+            RecapViewModel(creditList,it)
+        }
+    }
 
 
     @RequiresApi(Build.VERSION_CODES.S)
@@ -30,13 +34,11 @@ class CreditListFragment : Fragment(){
         savedInstanceState: Bundle?
     ): View {
         val root =  FragmentCreditListBinding. inflate(inflater, container, false)
-        period = YearMonth.now()
-        val viewModel = RecapViewModel(creditList,period,findNavController())
         root.cvComponentCl.apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
                 MaterialThemeComposeUI  {
-                    Recap(viewModel)
+                    Recap(viewModel,findNavController())
                 }
             }
         }

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditfix/CreditListFragment.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditfix/CreditListFragment.kt
@@ -13,6 +13,7 @@ import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.credit.ICreditPort
 import co.com.japl.module.credit.controllers.recap.RecapViewModel
 import co.com.japl.module.credit.views.recap.Recap
+import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.japl.android.myapplication.databinding.FragmentCreditListBinding
 import co.japl.android.myapplication.finanzas.controller.ViewModelFactory
 import dagger.hilt.android.AndroidEntryPoint

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditfix/MonthlyCreditListFragment.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditfix/MonthlyCreditListFragment.kt
@@ -14,6 +14,7 @@ import co.com.japl.finances.iports.inbounds.credit.ICreditPort
 import co.com.japl.finances.iports.inbounds.credit.IPeriodGracePort
 import co.com.japl.module.credit.controllers.list.ListViewModel
 import co.com.japl.module.credit.views.CreditList
+import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.japl.android.myapplication.databinding.FragmentMonthlyCreditListBinding
 import co.japl.android.myapplication.finanzas.controller.ViewModelFactory
 import dagger.hilt.android.AndroidEntryPoint

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditfix/MonthlyCreditListFragment.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditfix/MonthlyCreditListFragment.kt
@@ -8,24 +8,26 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.credit.ICreditPort
 import co.com.japl.finances.iports.inbounds.credit.IPeriodGracePort
 import co.com.japl.module.credit.controllers.list.ListViewModel
 import co.com.japl.module.credit.views.CreditList
-import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.japl.android.myapplication.databinding.FragmentMonthlyCreditListBinding
-import co.japl.android.myapplication.finanzas.bussiness.DTO.CreditDTO
+import co.japl.android.myapplication.finanzas.controller.ViewModelFactory
 import dagger.hilt.android.AndroidEntryPoint
-import java.time.YearMonth
 import javax.inject.Inject
 
 @AndroidEntryPoint
 class MonthlyCreditListFragment : Fragment(){
-    private lateinit var credit:CreditDTO
-
     @Inject lateinit var creditPort:ICreditPort
     @Inject lateinit var periodGracePort:IPeriodGracePort
+    private val viewModel: ListViewModel by viewModels {
+        ViewModelFactory(this,ListViewModel::class.java){
+            ListViewModel(it,creditPort,periodGracePort)
+        }
+    }
 
     @RequiresApi(Build.VERSION_CODES.S)
     override fun onCreateView(
@@ -33,12 +35,11 @@ class MonthlyCreditListFragment : Fragment(){
         savedInstanceState: Bundle?
     ): View {
         val root = FragmentMonthlyCreditListBinding.inflate(inflater,container,false)
-        val viewModel = ListViewModel(YearMonth.now(),creditPort,periodGracePort,findNavController())
         root.cvMcl.apply{
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
                 MaterialThemeComposeUI {
-                    CreditList(viewModel)
+                    CreditList(viewModel,findNavController())
                 }
 
             }

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditfix/PeriodCreditListFragment.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditfix/PeriodCreditListFragment.kt
@@ -8,17 +8,23 @@ import android.view.ViewGroup
 import androidx.annotation.RequiresApi
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import co.com.japl.finances.iports.inbounds.credit.IPeriodCreditPort
 import co.com.japl.module.credit.controllers.list.PeriodsViewModel
 import co.com.japl.module.credit.views.lists.Periods
-import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.japl.android.myapplication.databinding.FragmentPeriodCreditListBinding
+import co.japl.android.myapplication.finanzas.controller.ViewModelFactory
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
 class PeriodCreditListFragment : Fragment(){
     @Inject lateinit var periodSvc: IPeriodCreditPort
+    private val viewModel: PeriodsViewModel by viewModels {
+        ViewModelFactory(this,PeriodsViewModel::class.java){
+            PeriodsViewModel(it,periodSvc)
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -30,7 +36,6 @@ class PeriodCreditListFragment : Fragment(){
         savedInstanceState: Bundle?
     ): View? {
         val root = FragmentPeriodCreditListBinding.inflate(inflater)
-        val viewModel = PeriodsViewModel( periodSvc )
         root.composeViewPcl.apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditfix/PeriodCreditListFragment.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditfix/PeriodCreditListFragment.kt
@@ -12,6 +12,7 @@ import androidx.fragment.app.viewModels
 import co.com.japl.finances.iports.inbounds.credit.IPeriodCreditPort
 import co.com.japl.module.credit.controllers.list.PeriodsViewModel
 import co.com.japl.module.credit.views.lists.Periods
+import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.japl.android.myapplication.databinding.FragmentPeriodCreditListBinding
 import co.japl.android.myapplication.finanzas.controller.ViewModelFactory
 import dagger.hilt.android.AndroidEntryPoint

--- a/credit/src/main/java/co/com/japl/module/credit/controllers/list/AdditionalViewModel.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/controllers/list/AdditionalViewModel.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.compose.material.SnackbarDuration
 import androidx.compose.material.SnackbarHostState
 import androidx.compose.runtime.mutableStateListOf
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.NavController
@@ -11,31 +12,30 @@ import co.com.japl.finances.iports.dtos.AdditionalCreditDTO
 import co.com.japl.finances.iports.inbounds.credit.IAdditional
 import co.com.japl.module.credit.R
 import co.com.japl.module.credit.navigations.AdditionalList
-import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.scopes.ViewModelScoped
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import javax.inject.Inject
 
 @ViewModelScoped
-class AdditionalViewModel constructor(private val context: Context,private val code:Int=0, private val additionalSvc: IAdditional?, private val navController: NavController? ): ViewModel(){
+class AdditionalViewModel constructor(private val context: Context,private val savedStateHandle: SavedStateHandle, private val additionalSvc: IAdditional?): ViewModel(){
 
     val list = mutableStateListOf<AdditionalCreditDTO>()
     private val _loading = MutableStateFlow<Boolean>(false)
     val loading = _loading.asStateFlow()
     val hostState: SnackbarHostState = SnackbarHostState()
+    var code:Int = 0
+    private set
 
 
     init{
+        savedStateHandle.get<Int>("code")?.let{ code = it }
         main()
     }
 
-    fun addAdditional(){
-        navController?.let{
-            AdditionalList.navigateForm(code,it)
-        }
+    fun addAdditional(navController: NavController){
+        AdditionalList.navigateForm(code,navController)
     }
 
     fun deleteAdditional(idCode:Int){
@@ -63,10 +63,8 @@ class AdditionalViewModel constructor(private val context: Context,private val c
         }
     }
 
-    fun updateAdditional(id:Int){
-        navController?.let{
-            AdditionalList.navigateForm(id,code,it)
-        }
+    fun updateAdditional(id:Int, navController: NavController){
+        AdditionalList.navigateForm(id,code,navController)
     }
 
     fun main()= runBlocking {

--- a/credit/src/main/java/co/com/japl/module/credit/controllers/list/ListViewModel.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/controllers/list/ListViewModel.kt
@@ -2,6 +2,7 @@ package co.com.japl.module.credit.controllers.list
 
 import android.widget.Toast
 import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.navigation.NavController
 import co.com.japl.finances.iports.dtos.CreditDTO
@@ -19,55 +20,61 @@ import java.time.LocalDate
 import java.time.YearMonth
 
 @ViewModelScoped
-class ListViewModel constructor(private val period:YearMonth,private val creditSvc:ICreditPort?,val periodGraceSvc:IPeriodGracePort?, private val navController: NavController?) : ViewModel() {
+class ListViewModel constructor(private val savedStateHandle: SavedStateHandle,private val creditSvc:ICreditPort?,val periodGraceSvc:IPeriodGracePort?) : ViewModel() {
 
     val progress = mutableStateOf(true)
     val list = mutableListOf<CreditPeriodGraceDTO>()
+    var period:YearMonth = YearMonth.now()
+    private set
 
-    fun delete(id:Int){
+    init{
+        savedStateHandle.get<YearMonth>("period")?.let { period = it }
+    }
+
+    fun delete(id:Int,navController: NavController){
        creditSvc?.let{
            if(it.delete(id)){
-               Toast.makeText(navController?.context, R.string.toast_successful_deleted, Toast.LENGTH_LONG).show().apply {
+               Toast.makeText(navController.context, R.string.toast_successful_deleted, Toast.LENGTH_LONG).show().apply {
                    progress.value = true
                }
            }else{
-               Toast.makeText(navController?.context, R.string.toast_dont_successful_deleted, Toast.LENGTH_LONG).show()
+               Toast.makeText(navController.context, R.string.toast_dont_successful_deleted, Toast.LENGTH_LONG).show()
            }
        }
     }
 
-    fun deletePeriodGrace(id:Int){
+    fun deletePeriodGrace(id:Int,navController: NavController){
         periodGraceSvc?.let{
             if(it.delete(id)){
-                Toast.makeText(navController?.context, R.string.toast_period_grace_successful_deleted, Toast.LENGTH_LONG).show().apply {
+                Toast.makeText(navController.context, R.string.toast_period_grace_successful_deleted, Toast.LENGTH_LONG).show().apply {
                     progress.value = true
                 }
             }else{
-                Toast.makeText(navController?.context, R.string.toast_period_grace_dont_successful_deleted, Toast.LENGTH_LONG).show()
+                Toast.makeText(navController.context, R.string.toast_period_grace_dont_successful_deleted, Toast.LENGTH_LONG).show()
             }
         }
     }
 
-    fun amortization(id:Int){
+    fun amortization(id:Int,navController: NavController){
         val credit = list.first { credit -> credit.credit.id == id }
-        navController?.let{CreditList.amortization(credit.credit,LocalDate.now(),navController)}
+        CreditList.amortization(credit.credit,LocalDate.now(),navController)
     }
 
-    fun periodGrace(codeCredit:Int,period:Int,startDate: LocalDate,endDate: LocalDate){
+    fun periodGrace(codeCredit:Int,period:Int,startDate: LocalDate,endDate: LocalDate,navController: NavController){
         val dto = GracePeriodDTO(0,startDate,endDate,codeCredit.toLong(),period.toShort())
         periodGraceSvc?.let{
             if(it.add(dto)){
-                Toast.makeText(navController?.context, R.string.toast_period_grace_successful_added, Toast.LENGTH_LONG).show().apply {
+                Toast.makeText(navController.context, R.string.toast_period_grace_successful_added, Toast.LENGTH_LONG).show().apply {
                     progress.value = true
                 }
             }else{
-                Toast.makeText(navController?.context, R.string.toast_period_grace_dont_successful_added, Toast.LENGTH_LONG).show()
+                Toast.makeText(navController.context, R.string.toast_period_grace_dont_successful_added, Toast.LENGTH_LONG).show()
             }
         }
     }
 
-    fun additional(id:Int){
-        navController?.let{CreditList.additional(id,navController)}
+    fun additional(id:Int,navController: NavController){
+        CreditList.additional(id,navController)
     }
 
     fun execute() {

--- a/credit/src/main/java/co/com/japl/module/credit/controllers/list/PeriodsViewModel.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/controllers/list/PeriodsViewModel.kt
@@ -1,12 +1,12 @@
 package co.com.japl.module.credit.controllers.list
 
 import androidx.compose.runtime.mutableStateListOf
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.com.japl.finances.iports.dtos.PeriodCreditDTO
 import co.com.japl.finances.iports.inbounds.credit.IPeriodCreditPort
 import co.com.japl.ui.utils.FormUIState
-import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.scopes.ViewModelScoped
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -17,7 +17,7 @@ import javax.inject.Inject
 
 
 @ViewModelScoped
-class PeriodsViewModel constructor(private val periodSvc: IPeriodCreditPort?): ViewModel(){
+class PeriodsViewModel constructor(private val savedStateHandle: SavedStateHandle,private val periodSvc: IPeriodCreditPort?): ViewModel(){
     val records  = mutableStateListOf<PeriodCreditDTO>()
     private val _uiState = MutableStateFlow<FormUIState>(FormUIState.Loading)
     val viewState: StateFlow<FormUIState> = _uiState.asStateFlow()

--- a/credit/src/main/java/co/com/japl/module/credit/controllers/recap/RecapViewModel.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/controllers/recap/RecapViewModel.kt
@@ -2,6 +2,7 @@ package co.com.japl.module.credit.controllers.recap
 
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.navigation.NavController
 import co.com.japl.finances.iports.dtos.RecapCreditDTO
@@ -13,21 +14,27 @@ import kotlinx.coroutines.launch
 import java.time.YearMonth
 import javax.inject.Inject
 
-class RecapViewModel @Inject constructor(private val creditsSvc:ICreditPort?, val yearMonth:YearMonth,private val navController: NavController?) : ViewModel() {
+class RecapViewModel @Inject constructor(private val creditsSvc:ICreditPort?, private val savedStateHandle: SavedStateHandle) : ViewModel() {
     val loader = mutableStateOf(true)
     val progress = mutableFloatStateOf(0f)
     val listCredits = mutableListOf<RecapCreditDTO>()
+    var yearMonth:YearMonth = YearMonth.now()
+        private set
 
-    fun addCredit() {
-        navController?.let( CreditList::addCredit)
+    init{
+        savedStateHandle.get<YearMonth>("period")?.let { yearMonth = it }
     }
 
-    fun detailCredits() {
-        navController?.let(CreditList::detailCredits)
+    fun addCredit(navController: NavController) {
+        CreditList.addCredit(navController)
     }
 
-    fun periodCredits() {
-        navController?.let(CreditList::periodCredits)
+    fun detailCredits(navController: NavController) {
+        CreditList.detailCredits(navController)
+    }
+
+    fun periodCredits(navController: NavController) {
+        CreditList.periodCredits(navController)
     }
 
     fun execute() = CoroutineScope(Dispatchers.IO).launch {

--- a/credit/src/main/java/co/com/japl/module/credit/views/lists/Additional.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/views/lists/Additional.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
 import co.com.japl.finances.iports.dtos.AdditionalCreditDTO
 import co.com.japl.module.credit.R
 import co.com.japl.module.credit.controllers.list.AdditionalViewModel
@@ -43,41 +44,41 @@ import co.com.japl.utils.NumbersUtil
 import java.time.LocalDate
 
 @Composable
-fun Additional(viewModel: AdditionalViewModel = viewModel()){
+fun Additional(viewModel: AdditionalViewModel,navController: NavController){
     val loading = viewModel.loading.collectAsState()
     if(loading.value) {
         LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
     }else {
-        ScaffoldBody(viewModel=viewModel)
+        ScaffoldBody(viewModel=viewModel, navController = navController)
     }
 }
 
 @Composable
-private fun ScaffoldBody(viewModel: AdditionalViewModel ){
+private fun ScaffoldBody(viewModel: AdditionalViewModel,navController: NavController ){
     val state = remember{ viewModel.hostState }
     Scaffold (
         snackbarHost = {
             SnackbarHost(hostState = state)
         },
         floatingActionButton = {
-            ButtonsFloating(viewModel=viewModel)
+            ButtonsFloating(viewModel=viewModel, navController = navController)
         }
     ){
-        Body(viewModel=viewModel,modifier = Modifier.padding(it))
+        Body(viewModel=viewModel,modifier = Modifier.padding(it), navController = navController)
     }
 
 
 }
 
 @Composable
-private fun Body(viewModel: AdditionalViewModel ,modifier:Modifier = Modifier){
+private fun Body(viewModel: AdditionalViewModel ,modifier:Modifier = Modifier,navController: NavController){
     Column (modifier=Modifier.padding(Dimensions.PADDING_SHORT)){
-        ListBody(viewModel=viewModel)
+        ListBody(viewModel=viewModel, navController = navController)
     }
 }
 
 @Composable
-private fun ListBody(viewModel: AdditionalViewModel){
+private fun ListBody(viewModel: AdditionalViewModel,navController: NavController){
     val list = remember { viewModel.list}
     val listHeaders = arrayListOf(Header(
             title = stringResource(R.string.title_name_additional_list),
@@ -87,17 +88,17 @@ private fun ListBody(viewModel: AdditionalViewModel){
             title = stringResource(R.string.title_value_additional_list),
             tooltip = stringResource(R.string.tooltip_value_additional_list),
             weight = 1f
-        )) 
+        ))
     DataTable(
         listHeader =  { _-> listHeaders} ,
         sizeBody = list.size,
         footer = { _ -> RowFooter(viewModel) },
-        listBody = { pos,_->RowListBody(pos, viewModel) }
+        listBody = { pos,_->RowListBody(pos, viewModel, navController) }
     )
 }
 
 @Composable
-private  fun RowScope.RowListBody(index:Int,viewModel: AdditionalViewModel) {
+private  fun RowScope.RowListBody(index:Int,viewModel: AdditionalViewModel,navController: NavController) {
     val moreStatus = remember { mutableStateOf(false) }
     val deleteStatus = remember { mutableStateOf(false) }
     val value = viewModel.list[index]
@@ -133,7 +134,7 @@ private  fun RowScope.RowListBody(index:Int,viewModel: AdditionalViewModel) {
             onDismiss = { moreStatus.value = false}
         ) { optSelected ->
             when(optSelected.first){
-                1 -> viewModel.updateAdditional(value.id)
+                1 -> viewModel.updateAdditional(value.id,navController)
                 2 -> deleteStatus.value = true
                 else -> moreStatus.value = false
             }
@@ -180,11 +181,11 @@ private fun RowScope.RowFooter(viewModel: AdditionalViewModel){
 }
 
 @Composable
-private fun ButtonsFloating(viewModel: AdditionalViewModel ){
+private fun ButtonsFloating(viewModel: AdditionalViewModel,navController: NavController ){
     Column {
         FloatButton(imageVector = Icons.Rounded.Add,
             descriptionIcon = R.string.Add) {
-            viewModel.addAdditional()
+            viewModel.addAdditional(navController)
         }
     }
 }
@@ -195,7 +196,7 @@ private fun ButtonsFloating(viewModel: AdditionalViewModel ){
 private fun AdditionalPreview(){
     val vm = getViewModel()
     MaterialThemeComposeUI {
-        Additional(vm)
+        Additional(vm,navController = NavController(LocalContext.current))
     }
 }
 
@@ -205,13 +206,13 @@ private fun AdditionalPreview(){
 private fun AdditionalPreviewNight(){
     val vm = getViewModel()
     MaterialThemeComposeUI {
-        Additional(vm)
+        Additional(vm,navController = NavController(LocalContext.current))
     }
 }
 
 @Composable
 private fun getViewModel(): AdditionalViewModel{
-    val vm = AdditionalViewModel(LocalContext.current,0,null,null)
+    val vm = AdditionalViewModel(LocalContext.current, SavedStateHandle(),null)
     vm.list.add(AdditionalCreditDTO(
         id = 1,
         name = "Test",

--- a/credit/src/main/java/co/com/japl/module/credit/views/lists/Additional.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/views/lists/Additional.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import co.com.japl.finances.iports.dtos.AdditionalCreditDTO

--- a/credit/src/main/java/co/com/japl/module/credit/views/lists/Periods.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/views/lists/Periods.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.SavedStateHandle
 import co.com.japl.finances.iports.dtos.PeriodCreditDTO
 import co.com.japl.module.credit.controllers.list.PeriodsViewModel
 import co.com.japl.ui.theme.MaterialThemeComposeUI
@@ -122,7 +123,7 @@ internal fun previewDark(){
 }
 
 private fun getViewModel(): PeriodsViewModel{
-    val vw = PeriodsViewModel(null)
+    val vw = PeriodsViewModel(SavedStateHandle(),null)
     vw.records.add(PeriodCreditDTO(YearMonth.of(2024,10),1, BigDecimal.TEN))
     vw.records.add(PeriodCreditDTO(YearMonth.of(2024,11),1, BigDecimal.TEN))
     vw.records.add(PeriodCreditDTO(YearMonth.of(2024,12),1, BigDecimal.TEN))

--- a/credit/src/main/java/co/com/japl/module/credit/views/main_list.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/views/main_list.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
 import co.com.japl.finances.iports.dtos.CreditDTO
 import co.com.japl.finances.iports.enums.KindOfTaxEnum
 import co.com.japl.finances.iports.enums.KindPaymentsEnums
@@ -47,20 +48,20 @@ import java.time.YearMonth
 
 @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
 @Composable
-fun CreditList(viewModel:ListViewModel) {
+fun CreditList(viewModel:ListViewModel,navController: NavController) {
     val progress by remember { viewModel.progress}
 
     if(progress){
         viewModel.execute()
         LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
     }else {
-        Credit(viewModel)
+        Credit(viewModel,navController)
     }
 }
 
 @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
 @Composable
-private fun Credit(viewModel:ListViewModel){
+private fun Credit(viewModel:ListViewModel,navController: NavController){
     val list = remember {viewModel.list}
     val listHeader = arrayListOf(
             Header(title= stringResource(id = R.string.quote_payment_date_short), tooltip = stringResource(id = R.string.quote_payment_date),weight=1f),
@@ -92,11 +93,11 @@ private fun Credit(viewModel:ListViewModel){
             sizeBody = list.size,
             footer = {_->}) {pos,_->
             Item(dto = list[pos],
-                delete = {viewModel.delete(it)},
-                amortization = {viewModel.amortization(it)},
-                periodGrace = {id,period,date-> viewModel.periodGrace(id,period,date,date.plusMonths(period.toLong()))},
-                additional = {viewModel.additional(it)},
-                deletePeriodGrace = {viewModel.deletePeriodGrace(it)})
+                delete = {viewModel.delete(it,navController)},
+                amortization = {viewModel.amortization(it,navController)},
+                periodGrace = {id,period,date-> viewModel.periodGrace(id,period,date,date.plusMonths(period.toLong()),navController)},
+                additional = {viewModel.additional(it,navController)},
+                deletePeriodGrace = {viewModel.deletePeriodGrace(it,navController)})
         }
     }
 }
@@ -187,7 +188,7 @@ private fun Options(dto:CreditPeriodGraceDTO,state:MutableState<Boolean>,delete:
 
     @Composable
     fun getViewModel():ListViewModel{
-        return ListViewModel(YearMonth.now(),null,null,null).apply {
+        return ListViewModel(SavedStateHandle(),null,null).apply {
             list.add(CreditPeriodGraceDTO(CreditDTO(1,"test",LocalDate.now(),1.2,36,(1500000).toBigDecimal(),(50000).toBigDecimal(),
                 KindPaymentsEnums.MONTHLY,
                 KindOfTaxEnum.MONTHLY_EFFECTIVE),false))
@@ -203,7 +204,7 @@ private fun Options(dto:CreditPeriodGraceDTO,state:MutableState<Boolean>,delete:
         val viewModel = getViewModel()
         viewModel.progress.value = false
         MaterialThemeComposeUI {
-            CreditList(viewModel)
+            CreditList(viewModel,NavController(LocalContext.current))
         }
     }
 
@@ -214,7 +215,7 @@ private fun Options(dto:CreditPeriodGraceDTO,state:MutableState<Boolean>,delete:
         val viewModel = getViewModel()
         viewModel.progress.value = false
         MaterialThemeComposeUI {
-            CreditList(viewModel)
+            CreditList(viewModel,NavController(LocalContext.current))
         }
     }
 

--- a/credit/src/main/java/co/com/japl/module/credit/views/main_list.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/views/main_list.kt
@@ -22,10 +22,12 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavController
 import co.com.japl.finances.iports.dtos.CreditDTO
 import co.com.japl.finances.iports.enums.KindOfTaxEnum

--- a/credit/src/main/java/co/com/japl/module/credit/views/recap/RecapCredit.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/views/recap/RecapCredit.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavController
 import co.com.japl.finances.iports.dtos.RecapCreditDTO
 import co.com.japl.module.credit.R

--- a/credit/src/main/java/co/com/japl/module/credit/views/recap/RecapCredit.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/views/recap/RecapCredit.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
 import co.com.japl.finances.iports.dtos.RecapCreditDTO
 import co.com.japl.module.credit.R
 import co.com.japl.module.credit.controllers.recap.RecapViewModel
@@ -47,7 +48,7 @@ import co.com.japl.ui.components.FieldView
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
-fun Recap(viewModel:RecapViewModel){
+fun Recap(viewModel:RecapViewModel,navController: NavController){
     val loader = remember { viewModel.loader }
     val progression = remember { viewModel.progress }
     if(loader.value){
@@ -57,14 +58,14 @@ fun Recap(viewModel:RecapViewModel){
             modifier = Modifier.fillMaxWidth(),
         )
     }else{
-        Body(viewModel)
+        Body(viewModel,navController)
     }
 }
 
 @Composable
-private fun Body(viewModel:RecapViewModel){
+private fun Body(viewModel:RecapViewModel,navController: NavController){
     Scaffold(floatingActionButton = {
-        Buttons(viewModel)
+        Buttons(viewModel,navController)
     }) {
         if(viewModel.listCredits.isEmpty()){
             Column {
@@ -78,23 +79,23 @@ private fun Body(viewModel:RecapViewModel){
 }
 
  @Composable
- private fun Buttons(viewModel:RecapViewModel){
+ private fun Buttons(viewModel:RecapViewModel,navController: NavController){
      Column {
          if(viewModel.listCredits.isNotEmpty()) {
              FloatButton(
                  imageVector = Icons.Rounded.CalendarMonth,
                  descriptionIcon = R.string.check_periods,
-                 onClick = { viewModel.periodCredits() })
+                 onClick = { viewModel.periodCredits(navController) })
 
              FloatButton(
                  imageVector = Icons.Rounded.RemoveRedEye,
                  descriptionIcon = R.string.detail_credits,
-                 onClick = { viewModel.detailCredits() })
+                 onClick = { viewModel.detailCredits(navController) })
          }
          FloatButton(
              imageVector = Icons.Rounded.Add,
              descriptionIcon = R.string.add_credit,
-             onClick = { viewModel.addCredit() })
+             onClick = { viewModel.addCredit(navController) })
      }
  }
 
@@ -199,7 +200,7 @@ private fun GraphList(list:List<RecapCreditDTO>){
 @Preview(showBackground = true, showSystemUi = true, backgroundColor = 0x111000)
 fun RecapPreview(){
     MaterialThemeComposeUI {
-        Recap(viewModel())
+        Recap(viewModel(),navController = NavController(LocalContext.current))
     }
 }
 
@@ -208,7 +209,7 @@ fun RecapPreview(){
 @Preview(showBackground = true, showSystemUi = true, backgroundColor = 0xffffff, uiMode = Configuration.UI_MODE_NIGHT_YES)
 fun RecapPreviewDark(){
     MaterialThemeComposeUI {
-        Recap(viewModel())
+        Recap(viewModel(),navController = NavController(LocalContext.current))
     }
 }
 
@@ -220,12 +221,12 @@ fun RecapEmptyPreviewDark(){
     viewModel.listCredits.clear()
 
     MaterialThemeComposeUI {
-        Recap(viewModel)
+        Recap(viewModel,navController = NavController(LocalContext.current))
     }
 }
 
 fun viewModel():RecapViewModel{
-    val viewModel = RecapViewModel(null, YearMonth.now(),null)
+    val viewModel = RecapViewModel(null, SavedStateHandle())
     viewModel.listCredits.add(
         RecapCreditDTO(
             month = 4,


### PR DESCRIPTION
This commit refactors the ViewModel creation in the fragments located in `app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditfix/`.

The manual instantiation of ViewModels has been replaced with the `by viewModels` delegate, using a custom `ViewModelFactory`. This standardizes the ViewModel creation process across the fragments.

The ViewModels have also been refactored to receive the `SavedStateHandle` in their constructor, and retrieve their initial data from it in the `init` block. This is a more robust and recommended way to handle ViewModel initialization.

The NavController is no longer a property of the ViewModel. It is now passed as a parameter to the methods that need it, directly from the Composable views.