### PR TITLE
Refactor ViewModel creation in credit module

### DIFF
--- a/CreditCardModule/build.gradle.kts
+++ b/CreditCardModule/build.gradle.kts
@@ -81,6 +81,7 @@ dependencies {
     implementation("androidx.compose.ui:ui:1.6.7")
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.material:material:1.6.7")
+    implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
 
 
     testImplementation("junit:junit:4.13.2")

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/account/CreditCardListViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/account/CreditCardListViewModel.kt
@@ -13,7 +13,7 @@ import co.com.japl.module.creditcard.navigations.CreditCard
 import co.com.japl.module.creditcard.navigations.ListCreditCardSettings
 import kotlinx.coroutines.runBlocking
 
-class CreditCardListViewModel constructor(private val creditCardSvc:ICreditCardPort?, private val navController:NavController?) : ViewModel(){
+class CreditCardListViewModel constructor(private val creditCardSvc:ICreditCardPort) : ViewModel(){
 
 
     val list = mutableStateListOf<CreditCardDTO?>()
@@ -21,19 +21,19 @@ class CreditCardListViewModel constructor(private val creditCardSvc:ICreditCardP
     var progress = mutableFloatStateOf(0f)
     var showProgress = mutableStateOf(true)
 
-    fun onClick(){
-        navController?.let{CreditCard.navigate(it)}
+    fun onClick(navController: NavController){
+        navController.let{CreditCard.navigate(it)}
     }
 
-    fun goToSettings(id:Int){
+    fun goToSettings(id:Int,navController:NavController){
         navController?.let { ListCreditCardSettings.navigate(id,it) }
     }
 
-    fun edit(id:Int){
+    fun edit(id:Int,navController: NavController){
         navController?.let { CreditCard.navigate(id,it) }
     }
 
-    fun delete(id:Int){
+    fun delete(id:Int,navController: NavController){
         creditCardSvc?.let{
             if(it.delete(id)){
                 Toast.makeText(navController?.context, R.string.toast_successful_deleted,Toast.LENGTH_LONG).show()

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/account/CreditCardViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/account/CreditCardViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import android.widget.Toast
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.navigation.NavController
 import co.com.japl.finances.iports.dtos.CreditCardDTO
@@ -15,7 +16,9 @@ import kotlinx.coroutines.runBlocking
 import java.math.BigDecimal
 import java.time.LocalDateTime
 
-class CreditCardViewModel constructor(private val codeCreditCard:Int?,private val creditCardSvc:ICreditCardPort, private val navController: NavController):ViewModel() {
+class CreditCardViewModel constructor(private val savedStateHandle: SavedStateHandle, private val creditCardSvc:ICreditCardPort):ViewModel() {
+    var codeCreditCard:Int=0
+
     var showProgress = mutableStateOf(true)
     var progress = mutableFloatStateOf(0f)
     var showButtonUpdate = mutableStateOf(false)
@@ -35,6 +38,10 @@ class CreditCardViewModel constructor(private val codeCreditCard:Int?,private va
     var hasErrorWarning = mutableStateOf(false)
 
     private var _creditCardDto:CreditCardDTO? = CreditCardDTO(id=0,name="", maxQuotes = 0, cutOffDay = 1, warningValue = BigDecimal.ZERO, create = LocalDateTime.now(), status = true, interest1Quote = false, interest1NotQuote = false)
+
+    init{
+        codeCreditCard = savedStateHandle.get<Int>("codeCreditCard")?:0
+    }
 
     fun validate(){
 
@@ -57,7 +64,7 @@ class CreditCardViewModel constructor(private val codeCreditCard:Int?,private va
         }
     }
 
-    fun create(){
+    fun create(navController: NavController){
         if(showButtons.value) {
             _creditCardDto?.let {
                 val id = creditCardSvc.create(it)
@@ -81,7 +88,7 @@ class CreditCardViewModel constructor(private val codeCreditCard:Int?,private va
         }
     }
 
-    fun update(){
+    fun update(navController: NavController){
         _creditCardDto?.let{
             if(creditCardSvc.update(_creditCardDto!!)){
                 Toast.makeText(navController.context, R.string.toast_successful_update,Toast.LENGTH_LONG).show()
@@ -91,7 +98,7 @@ class CreditCardViewModel constructor(private val codeCreditCard:Int?,private va
             }
         }
     }
-    fun goSettings(){
+    fun goSettings(navController: NavController){
         navController?.let {
             codeCreditCard?.let {id->
                 ListCreditCardSettings.navigate(codeCreditCard,navController)

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/amortization/AmortizationViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/amortization/AmortizationViewModel.kt
@@ -1,6 +1,7 @@
 package co.com.japl.module.creditcard.controllers.amortization;
 
 import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.NavController
@@ -12,12 +13,14 @@ import dagger.hilt.android.scopes.ViewModelScoped
 import kotlinx.coroutines.launch
 
 @HiltViewModel
-class  AmortizationViewModel constructor(private val id:Int, private val svc: IAmortizationTablePort?=null, private val navController: NavController?=null):
+class  AmortizationViewModel constructor(private val savedStateHandle: SavedStateHandle, private val svc: IAmortizationTablePort):
 	ViewModel(){
+	private var id:Int = 0
 	val progressStatus = mutableStateOf(true)
 	val list = mutableListOf<AmortizationRowDTO>()
 
 	init{
+		 id = savedStateHandle.get<Int>("credit_code")?:0
 		execute()	
 	}
 	

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/creditrate/lists/CreditRateListViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/creditrate/lists/CreditRateListViewModel.kt
@@ -14,26 +14,26 @@ import co.com.japl.module.creditcard.R
 import co.com.japl.module.creditcard.navigations.ListCreditRate
 import kotlinx.coroutines.runBlocking
 
-class CreditRateListViewModel constructor(private val context:Context?,private val creditCardSvc:ICreditCardPort?,private val creditRateSvc:ITaxPort?,private val navController: NavController?):ViewModel() {
+class CreditRateListViewModel constructor(private val creditCardSvc:ICreditCardPort?,private val creditRateSvc:ITaxPort?):ViewModel() {
 
     var progress = mutableFloatStateOf(0f)
     var showProgress = mutableStateOf(true)
 
     var creditCard:MutableMap<CreditCardDTO?,List<TaxDTO>>? = HashMap<CreditCardDTO?,List<TaxDTO>>()
 
-    fun add(){
+    fun add(navController: NavController){
         navController?.let { ListCreditRate.navigate(navigate = it)}
     }
 
-    fun add(codeCreditCard:Int?){
+    fun add(codeCreditCard:Int?,navController: NavController){
         if(codeCreditCard == null){
-            add()
+            add(navController)
         }else {
             navController?.let { ListCreditRate.navigate(codeCreditCard,navigate = it)}
         }
     }
 
-    fun delete(code:Int){
+    fun delete(code:Int,context:Context){
         creditRateSvc?.let {
             if (creditRateSvc.delete(code)) {
                 val found =
@@ -54,7 +54,7 @@ class CreditRateListViewModel constructor(private val context:Context?,private v
         }
     }
 
-    fun clone(code:Int){
+    fun clone(code:Int,context:Context){
         creditRateSvc?.let {
             if (creditRateSvc.clone(code)) {
                 Toast.makeText(context, R.string.toast_successful_cloned, Toast.LENGTH_SHORT)
@@ -68,7 +68,7 @@ class CreditRateListViewModel constructor(private val context:Context?,private v
         }
     }
 
-    fun enable(code:Int){
+    fun enable(code:Int,context:Context){
         creditRateSvc?.let {
 
 
@@ -82,7 +82,7 @@ class CreditRateListViewModel constructor(private val context:Context?,private v
         }
     }
 
-    fun disable(code:Int){
+    fun disable(code:Int,context:Context){
         creditRateSvc?.let {
             if (creditRateSvc.disable(code)) {
                 Toast.makeText(context, R.string.toast_successful_disabled, Toast.LENGTH_SHORT)
@@ -94,8 +94,8 @@ class CreditRateListViewModel constructor(private val context:Context?,private v
         }
     }
 
-    fun edit(codeCreditCard:Int, codeCreditRate:Int){
-        navController?.let { ListCreditRate.navigate(codeCreditCard,codeCreditRate,navigate = navController)}
+    fun edit(codeCreditCard:Int, codeCreditRate:Int,navController: NavController){
+        ListCreditRate.navigate(codeCreditCard,codeCreditRate,navigate = navController)
     }
 
     fun main() = runBlocking {

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/paid/BoughtCreditCardViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/paid/BoughtCreditCardViewModel.kt
@@ -2,6 +2,7 @@ package co.com.japl.module.creditcard.controllers.paid
 
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.navigation.NavController
 import co.com.japl.finances.iports.dtos.BoughtCreditCardPeriodDTO
@@ -11,12 +12,18 @@ import co.com.japl.ui.Prefs
 import kotlinx.coroutines.runBlocking
 import java.time.LocalDateTime
 
-class BoughtCreditCardViewModel constructor(private val service:IBoughtListPort?,private val idCreditCard:Int,private val navController: NavController,private val prefs:Prefs):ViewModel() {
+class BoughtCreditCardViewModel constructor(private val savedStateHandle: SavedStateHandle,private val service:IBoughtListPort?,private val prefs:Prefs):ViewModel() {
+    private val idCreditCard:Int
+
     val cache = mutableStateOf(prefs.simulator)
     val progress = mutableFloatStateOf(0f)
     val loader = mutableStateOf(false)
     private var _list:Map<Long,List<BoughtCreditCardPeriodDTO>> = mapOf()
     val periodList get() = _list
+
+    init{
+        idCreditCard = savedStateHandle.get<Int>("codeCreditCard")!!
+    }
 
     fun main() = runBlocking {
         progress.floatValue = 0.2f
@@ -32,7 +39,7 @@ class BoughtCreditCardViewModel constructor(private val service:IBoughtListPort?
         loader.value = true
     }
 
-    fun goToListDetail(cutOffDay:Short,cutOff:LocalDateTime){
+    fun goToListDetail(cutOffDay:Short,cutOff:LocalDateTime,navController: NavController){
         Bought.navigate(idCreditCard,cutOffDay,cutOff, navController)
     }
 

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/setting/CreditCardSettingListViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/setting/CreditCardSettingListViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.navigation.NavController
 import co.com.japl.finances.iports.dtos.CreditCardSettingDTO
@@ -14,28 +15,32 @@ import co.com.japl.module.creditcard.R
 import co.com.japl.module.creditcard.navigations.CreditCardSetting
 import kotlinx.coroutines.runBlocking
 
-class CreditCardSettingListViewModel constructor(private val codCreditCard:Int, private val creditCardSettingSvc:ICreditCardSettingPort?, private val navController: NavController?):ViewModel() {
-
+class CreditCardSettingListViewModel constructor(private val savedStateHandle: SavedStateHandle, private val creditCardSettingSvc:ICreditCardSettingPort):ViewModel() {
+    private val codCreditCard:Int
     var showProgress : MutableState<Boolean> = mutableStateOf(true)
     var progress : MutableFloatState = mutableFloatStateOf(0f)
 
     var list = mutableStateListOf<CreditCardSettingDTO>()
 
-    fun onClick(){
-        navController?.let { CreditCardSetting.navigate(codCreditCard,it) }
+    init{
+        codCreditCard = savedStateHandle.get<Int>("codeCreditCard")!!
     }
 
-    fun delete(id:Int){
-        if(creditCardSettingSvc?.let{it.delete(codCreditCard,id)} == true){
-            navController?.navigateUp()
-            navController?.let { Toast.makeText(it.context, R.string.toast_successful_deleted,Toast.LENGTH_LONG).show() }
+    fun onClick(navController: NavController){
+        CreditCardSetting.navigate(codCreditCard,navController)
+    }
+
+    fun delete(id:Int,navController: NavController){
+        if(creditCardSettingSvc.delete(codCreditCard,id)){
+            navController.navigateUp()
+            Toast.makeText(navController.context, R.string.toast_successful_deleted,Toast.LENGTH_LONG).show()
         }else{
-            navController?.let { Toast.makeText(it.context,R.string.toast_dont_successful_deleted,Toast.LENGTH_LONG).show() }
+            Toast.makeText(navController.context,R.string.toast_dont_successful_deleted,Toast.LENGTH_LONG).show()
         }
     }
 
-    fun edit(codSetting:Int){
-        navController?.let{CreditCardSetting.navigate(codCreditCard,codSetting,it)}
+    fun edit(codSetting:Int,navController: NavController){
+        CreditCardSetting.navigate(codCreditCard,codSetting,navController)
     }
 
 

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/setting/CreditCardSettingViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/setting/CreditCardSettingViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import android.widget.Toast
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.navigation.NavController
 import co.com.japl.finances.iports.dtos.CreditCardDTO
@@ -15,7 +16,10 @@ import co.com.japl.utils.NumbersUtil
 import kotlinx.coroutines.runBlocking
 import java.time.LocalDateTime
 
-class CreditCardSettingViewModel constructor(private val codeCreditCard:Int?,private val codeCreditCardSetting:Int?,private val creditCardSvc:ICreditCardPort?,private val creditCardSettingSvc:ICreditCardSettingPort?,private val navController: NavController?) : ViewModel() {
+class CreditCardSettingViewModel constructor(private val savedStateHandle: SavedStateHandle,private val creditCardSvc:ICreditCardPort,private val creditCardSettingSvc:ICreditCardSettingPort) : ViewModel() {
+
+    private var codeCreditCard:Int? = null
+    private var codeCreditCardSetting:Int? = null
 
     var progress = mutableFloatStateOf(0f)
     var showProgress = mutableStateOf(true)
@@ -34,6 +38,12 @@ class CreditCardSettingViewModel constructor(private val codeCreditCard:Int?,pri
     var active = mutableStateOf(false)
     var showButtons = mutableStateOf(false)
 
+    init{
+        codeCreditCard = savedStateHandle.get<Int>("codeCreditCard")
+        codeCreditCardSetting = savedStateHandle.get<Int>("codeSetting")
+
+    }
+
     fun validate(){
         name.value.takeIf { it.isEmpty() }?.let{ nameIsError.value = true}
         name.value.takeIf{it.isNotEmpty()}?.let{nameIsError.value = false}
@@ -44,7 +54,7 @@ class CreditCardSettingViewModel constructor(private val codeCreditCard:Int?,pri
         showButtons.value = !validation()
     }
 
-    fun update(){
+    fun update(navController: NavController){
         dto?.let {
             it.name = name.value
             it.value = value . value
@@ -63,7 +73,7 @@ class CreditCardSettingViewModel constructor(private val codeCreditCard:Int?,pri
         return nameIsError.value || valueIsError.value || typeIsError.value
     }
 
-    fun create(){
+    fun create(navController: NavController){
         Log.d(javaClass.name,"<<<=== Create $dto")
         dto = CreditCardSettingDTO(id = 0, codeCreditCard = codeCreditCard?:0, name = "", value = "", type = "",create=LocalDateTime.now(), active = 1)
         dto?.let {
@@ -75,9 +85,9 @@ class CreditCardSettingViewModel constructor(private val codeCreditCard:Int?,pri
         dto?.let {  dto->
             creditCardSettingSvc?.create(dto)?.let{
                 dto.id = it
-                navController?.navigateUp()
-                Toast.makeText(navController?.context, R.string.toast_successful_insert,Toast.LENGTH_LONG).show()
-            }?:Toast.makeText(navController?.context, R.string.toast_unsuccessful_insert,Toast.LENGTH_LONG).show()
+                navController.navigateUp()
+                Toast.makeText(navController.context, R.string.toast_successful_insert,Toast.LENGTH_LONG).show()
+            }?:Toast.makeText(navController.context, R.string.toast_unsuccessful_insert,Toast.LENGTH_LONG).show()
 
         }
 

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/simulator/SimulatorListItemViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/simulator/SimulatorListItemViewModel.kt
@@ -8,7 +8,7 @@ import co.com.japl.finances.iports.inbounds.creditcard.ISimulatorCreditVariableP
 import co.com.japl.module.creditcard.R
 import java.util.Optional
 
-class SimulatorListItemViewModel constructor(private val itemValue: SimulatorCreditDTO?=null, private val simulatorVariableSvc: ISimulatorCreditVariablePort?=null, private val navController: NavController?=null){
+class SimulatorListItemViewModel constructor(private val itemValue: SimulatorCreditDTO?=null, private val simulatorVariableSvc: ISimulatorCreditVariablePort){
 
     val showOptions = mutableStateOf(false)
     var item: Optional<SimulatorCreditDTO> = Optional.empty()
@@ -20,13 +20,11 @@ class SimulatorListItemViewModel constructor(private val itemValue: SimulatorCre
         }
     }
 
-    fun gotoAmortization(code:Int){
-        navController?.let{
+    fun gotoAmortization(code:Int,navController: NavController){
             simulatorVariableSvc?.let{
                 it.setSimulation(item.get())
             }
             val path = navController.context.getString(R.string.navigate_form_simulator_amortization,code).toUri()
-            it.navigate(path)
-        }
+            navController.navigate(path)
     }
 }

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/smscreditcard/form/SmsCreditCardViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/smscreditcard/form/SmsCreditCardViewModel.kt
@@ -4,6 +4,7 @@ import android.widget.Toast
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.navigation.NavController
 import co.com.japl.finances.iports.dtos.CreditCardDTO
@@ -14,7 +15,8 @@ import co.com.japl.finances.iports.inbounds.creditcard.ISMSCreditCardPort
 import co.com.japl.module.creditcard.R
 import kotlinx.coroutines.runBlocking
 
-class SmsCreditCardViewModel constructor(private val codeSMSCC:Int?,private val svc:ISMSCreditCardPort?,private val creditCardSvc:ICreditCardPort?,private val navController: NavController?): ViewModel() {
+class SmsCreditCardViewModel constructor(private val savedStateHandle: SavedStateHandle,private val svc:ISMSCreditCardPort,private val creditCardSvc:ICreditCardPort): ViewModel() {
+    private val codeSMSCC:Int?
 
     val  load = mutableStateOf(true)
     val  progress = mutableFloatStateOf(0.0f)
@@ -37,8 +39,11 @@ class SmsCreditCardViewModel constructor(private val codeSMSCC:Int?,private val 
 
     val validate = mutableStateOf("")
 
+    init{
+        codeSMSCC = savedStateHandle.get<Int>("code_sms_credit_Card")
+    }
 
-    fun save(){
+    fun save(navController: NavController){
         if(smsCreditCard != null && !errorKindInterestRate.value && !errorPhoneNumber.value && !errorPattern.value) {
             smsCreditCard?.takeIf { it.id == 0 }?.let{
                 svc?.create(it)?.takeIf { it > 0 }?.let{

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/smscreditcard/list/SmsCreditCardViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/smscreditcard/list/SmsCreditCardViewModel.kt
@@ -4,6 +4,7 @@ import android.widget.Toast
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.navigation.NavController
 import co.com.japl.finances.iports.dtos.CreditCardDTO
@@ -14,25 +15,25 @@ import co.com.japl.finances.iports.inbounds.creditcard.ISMSCreditCardPort
 import co.com.japl.module.creditcard.R
 import kotlinx.coroutines.runBlocking
 
-class SmsCreditCardViewModel constructor(private val svc:ISMSCreditCardPort?,private val creditCardSvc:ICreditCardPort?,private val navController: NavController?): ViewModel() {
+class SmsCreditCardViewModel constructor(private val svc:ISMSCreditCardPort,private val creditCardSvc:ICreditCardPort): ViewModel() {
 
     val  load = mutableStateOf(true)
     val  progress = mutableFloatStateOf(0.0f)
 
     val list = mutableStateListOf<Map<Int,List<SMSCreditCard>>>()
 
-    fun edit(code:Int){
+    fun edit(code:Int,navController: NavController){
         require(code > 0){"The code must be greater than 0"}
         navController?.let{
             co.com.japl.module.creditcard.navigations.SMSCreditCard.navigate(code,navController)
         }
     }
 
-    fun add(){
+    fun add(navController: NavController){
         navController?.let{co.com.japl.module.creditcard.navigations.SMSCreditCard.navigate(navController)}
     }
 
-    fun enabled(code:Int){
+    fun enabled(code:Int,navController: NavController){
         require(code > 0){"The code must be greater than 0"}
         svc?.enable(code).takeIf { it == true }?.let {
             navController?.let { Toast.makeText(it.context, R.string.toast_successful_enabled, Toast.LENGTH_SHORT).show() }?.also {
@@ -41,7 +42,7 @@ class SmsCreditCardViewModel constructor(private val svc:ISMSCreditCardPort?,pri
         }?:navController?.let { Toast.makeText(it.context, R.string.toast_dont_successful_enabled, Toast.LENGTH_SHORT).show() }
     }
 
-    fun disabled(code:Int){
+    fun disabled(code:Int,navController: NavController){
         require(code > 0){"The code must be greater than 0"}
         svc?.disable(code).takeIf { it == true }?.let {
             navController?.let { Toast.makeText(it.context, R.string.toast_successful_disabled, Toast.LENGTH_SHORT).show() }?.also {
@@ -50,7 +51,7 @@ class SmsCreditCardViewModel constructor(private val svc:ISMSCreditCardPort?,pri
         }?:navController?.let { Toast.makeText(it.context, R.string.toast_dont_successful_disabled, Toast.LENGTH_SHORT).show() }
     }
 
-    fun delete(code:Int){
+    fun delete(code:Int,navController: NavController){
         require(code > 0){"The code must be greater than 0"}
         svc?.delete(code)?.takeIf { it }?.let{
             navController?.let { Toast.makeText(it.context, R.string.toast_successful_deleted, Toast.LENGTH_SHORT).show().also {

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/account/forms/CreditCard.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/account/forms/CreditCard.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import co.com.japl.module.creditcard.R
 import co.com.japl.module.creditcard.controllers.account.CreditCardViewModel
@@ -30,9 +31,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 @Composable
-fun CreditCard(viewModel: CreditCardViewModel){
+fun CreditCard(viewModel: CreditCardViewModel,navController: NavController){
 
-    val navController = rememberNavController()
     val progression = remember{viewModel.progress}
     val showProgress = remember{viewModel.showProgress}
 

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/account/forms/CreditCard.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/account/forms/CreditCard.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import androidx.navigation.compose.rememberNavController
 import co.com.japl.module.creditcard.R
 import co.com.japl.module.creditcard.controllers.account.CreditCardViewModel
 import co.com.japl.ui.components.CheckBoxField
@@ -31,6 +32,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun CreditCard(viewModel: CreditCardViewModel){
 
+    val navController = rememberNavController()
     val progression = remember{viewModel.progress}
     val showProgress = remember{viewModel.showProgress}
 
@@ -53,19 +55,19 @@ fun CreditCard(viewModel: CreditCardViewModel){
                                     imageVector = Icons.Rounded.Settings,
                                     descriptionIcon = R.string.setting_redirect
                                 ) {
-                                    viewModel.goSettings()
+                                    viewModel.goSettings(navController)
                                 }
 
                                 FloatButton(
                                     imageVector = Icons.Rounded.Update,
                                     descriptionIcon = R.string.update
                                 ) {
-                                    viewModel.update()
+                                    viewModel.update(navController)
                                 }
                             }
                         }else {
                             FloatButton(imageVector = Icons.Rounded.Create,
-                                descriptionIcon =  R.string.create){ viewModel.create() }
+                                descriptionIcon =  R.string.create){ viewModel.create(navController) }
                         }
                     }
             }

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/account/lists/CreditCardList.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/account/lists/CreditCardList.kt
@@ -14,7 +14,6 @@ import androidx.compose.material.FloatingActionButtonDefaults
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.AddCircleOutline
 import androidx.compose.material3.Card
-import androidx.compose.material3.Divider
 import androidx.compose.material.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -28,16 +27,16 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.navigation.compose.rememberNavController
+import androidx.navigation.NavController
 import co.com.japl.finances.iports.dtos.CreditCardDTO
 import co.com.japl.module.creditcard.R
 import co.com.japl.module.creditcard.controllers.account.CreditCardListViewModel
-import co.com.japl.module.creditcard.controllers.account.CreditCardViewModel
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.com.japl.ui.theme.values.Dimensions
 import co.com.japl.ui.theme.values.ModifiersCustom.AlignCenterVerticalAndPaddingRightSpace
@@ -46,7 +45,7 @@ import co.com.japl.ui.theme.values.ModifiersCustom.Weight1fAndAlightCenterVertic
 import co.com.japl.ui.theme.values.ModifiersCustom.Weight1fAndAlightCenterVerticalAndPaddingRightSpace
 import co.com.japl.ui.theme.values.ModifiersCustom.Weight1fAndPaddintRightSpace
 import co.com.japl.module.creditcard.enums.MoreOptionsItemsCreditCardList
-import co.com.japl.module.creditcard.views.bought.forms.FakeCreditCardPort
+import co.com.japl.module.creditcard.views.fakeSvc.FakeCreditCardPort
 import co.com.japl.ui.utils.WindowWidthSize
 import co.com.japl.ui.components.AlertDialogOkCancel
 import co.com.japl.ui.components.HelpWikiButton
@@ -58,7 +57,7 @@ import kotlinx.coroutines.launch
 
 
 @Composable
-fun CreditCardList(creditCardViewModel:CreditCardListViewModel){
+fun CreditCardList(creditCardViewModel:CreditCardListViewModel,navController: NavController){
     val progress = remember {
         creditCardViewModel.progress
     }
@@ -76,14 +75,13 @@ fun CreditCardList(creditCardViewModel:CreditCardListViewModel){
             modifier = Modifier.fillMaxWidth(),
         )
     }else {
-        Body(creditCardViewModel = creditCardViewModel)
+        Body(creditCardViewModel = creditCardViewModel,navController)
     }
 }
 
 @Composable
-private fun Body(creditCardViewModel:CreditCardListViewModel){
+private fun Body(creditCardViewModel:CreditCardListViewModel,navController: NavController){
     val listState = remember {creditCardViewModel.list}
-    val navController = rememberNavController()
     Scaffold(floatingActionButton = {
         FloatingActionButton(onClick = { creditCardViewModel.onClick(navController) },
             elevation = FloatingActionButtonDefaults.elevation(8.dp),
@@ -218,7 +216,7 @@ private fun ItemLarge(dto:CreditCardDTO,state:MutableState<Boolean>,edit:(Int)->
 fun CreditCardListPreview(){
     val creditCardViewModel = getViewModel()
     MaterialThemeComposeUI {
-        CreditCardList(creditCardViewModel)
+        CreditCardList(creditCardViewModel, NavController(LocalContext.current))
     }
 }
 
@@ -228,7 +226,7 @@ fun CreditCardListPreview(){
 fun CreditCardListPreviewDark(){
     val creditCardViewModel = getViewModel()
     MaterialThemeComposeUI {
-        CreditCardList(creditCardViewModel)
+        CreditCardList(creditCardViewModel, NavController(LocalContext.current))
     }
 }
 

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/account/lists/CreditCardList.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/account/lists/CreditCardList.kt
@@ -1,5 +1,6 @@
 package co.com.japl.module.creditcard.views.account.lists
 
+import android.annotation.SuppressLint
 import android.content.res.Configuration
 import android.os.Build
 import androidx.annotation.RequiresApi
@@ -32,6 +33,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.navigation.compose.rememberNavController
 import co.com.japl.finances.iports.dtos.CreditCardDTO
 import co.com.japl.module.creditcard.R
 import co.com.japl.module.creditcard.controllers.account.CreditCardListViewModel
@@ -44,6 +46,7 @@ import co.com.japl.ui.theme.values.ModifiersCustom.Weight1fAndAlightCenterVertic
 import co.com.japl.ui.theme.values.ModifiersCustom.Weight1fAndAlightCenterVerticalAndPaddingRightSpace
 import co.com.japl.ui.theme.values.ModifiersCustom.Weight1fAndPaddintRightSpace
 import co.com.japl.module.creditcard.enums.MoreOptionsItemsCreditCardList
+import co.com.japl.module.creditcard.views.bought.forms.FakeCreditCardPort
 import co.com.japl.ui.utils.WindowWidthSize
 import co.com.japl.ui.components.AlertDialogOkCancel
 import co.com.japl.ui.components.HelpWikiButton
@@ -80,8 +83,9 @@ fun CreditCardList(creditCardViewModel:CreditCardListViewModel){
 @Composable
 private fun Body(creditCardViewModel:CreditCardListViewModel){
     val listState = remember {creditCardViewModel.list}
+    val navController = rememberNavController()
     Scaffold(floatingActionButton = {
-        FloatingActionButton(onClick = { creditCardViewModel.onClick() },
+        FloatingActionButton(onClick = { creditCardViewModel.onClick(navController) },
             elevation = FloatingActionButtonDefaults.elevation(8.dp),
             backgroundColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f)) {
             Icon(
@@ -96,12 +100,13 @@ private fun Body(creditCardViewModel:CreditCardListViewModel){
                     descriptionContent = R.string.wiki_credit_card_description)
             }
         listState.forEach {item->
-                Item(item!!,{creditCardViewModel.edit(it)},{creditCardViewModel.delete(it)},{creditCardViewModel.goToSettings(it)})
+                Item(item!!,{creditCardViewModel.edit(it,navController)},{creditCardViewModel.delete(it,navController)},{creditCardViewModel.goToSettings(it,navController)})
             }
         }
     }
 }
 
+@SuppressLint("UnusedBoxWithConstraintsScope")
 @Composable
 private fun Item(dto:CreditCardDTO,edit:(Int)->Unit,delete:(Int)->Unit,goToSettings:(Int)->Unit){
     val state = remember{ mutableStateOf(false) }
@@ -228,7 +233,7 @@ fun CreditCardListPreviewDark(){
 }
 
 fun getViewModel():CreditCardListViewModel{
- val viewModel = CreditCardListViewModel(creditCardSvc = null,navController = null)
+ val viewModel = CreditCardListViewModel(creditCardSvc = FakeCreditCardPort())
     viewModel.showProgress.value = false
     viewModel.progress.floatValue = 0.7f
     return viewModel

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/amortization/AmortizationTable.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/amortization/AmortizationTable.kt
@@ -25,10 +25,12 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.SavedStateHandle
 import co.com.japl.finances.iports.dtos.AmortizationRowDTO
 import co.com.japl.finances.iports.enums.KindOfTaxEnum
 import co.com.japl.module.creditcard.R
 import co.com.japl.module.creditcard.controllers.amortization.AmortizationViewModel
+import co.com.japl.module.creditcard.views.fakeSvc.FakeAmortizationTable
 import co.com.japl.ui.components.DataTable
 import co.com.japl.ui.components.FieldView
 import co.com.japl.ui.model.datatable.Header
@@ -346,7 +348,8 @@ private fun AmortizationDarkVertical(){
 }
 
 private fun getViewModel(): AmortizationViewModel{
-	return AmortizationViewModel(2).also {
+	val svc = FakeAmortizationTable()
+	return AmortizationViewModel(savedStateHandle = SavedStateHandle(),svc = svc).also {
 		it.list.add(
 			AmortizationRowDTO(
 				id=1,

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/bought/forms/Advance.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/bought/forms/Advance.kt
@@ -36,19 +36,11 @@ import co.com.japl.ui.components.FloatButton
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavController
-import co.com.japl.finances.iports.dtos.CreditCardBoughtDTO
-import co.com.japl.finances.iports.dtos.CreditCardDTO
-import co.com.japl.finances.iports.dtos.TaxDTO
-import co.com.japl.finances.iports.enums.KindInterestRateEnum
-import co.com.japl.finances.iports.enums.KindOfTaxEnum
-import co.com.japl.finances.iports.inbounds.creditcard.ICreditCardPort
-import co.com.japl.finances.iports.inbounds.creditcard.ITaxPort
-import co.com.japl.finances.iports.inbounds.creditcard.bought.IBoughtPort
+import co.com.japl.module.creditcard.views.fakeSvc.FakeBoughtPort
+import co.com.japl.module.creditcard.views.fakeSvc.FakeCreditCardPort
+import co.com.japl.module.creditcard.views.fakeSvc.FakeTaxPort
 import co.com.japl.ui.theme.values.Dimensions
 import co.com.japl.ui.theme.values.ModifiersCustom
-import co.com.japl.utils.NumbersUtil
-import java.math.BigDecimal
-import java.time.LocalDateTime
 
 @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
 @Composable

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/bought/forms/Quote.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/bought/forms/Quote.kt
@@ -1,11 +1,9 @@
 package co.com.japl.module.creditcard.views.bought.forms
 
-import android.app.Application
 import android.content.res.Configuration
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -22,16 +20,13 @@ import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.Edit
 import androidx.compose.material.icons.rounded.Save
 import androidx.compose.material.icons.rounded.SaveAs
-import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.TooltipBox
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshots.SnapshotStateList
@@ -39,16 +34,12 @@ import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import co.com.japl.finances.iports.dtos.TagDTO
 import co.com.japl.module.creditcard.R
 import co.com.japl.module.creditcard.controllers.bought.forms.QuoteViewModel
-import co.com.japl.module.creditcard.controllers.bought.forms.WalletViewModel
 import co.com.japl.ui.Prefs
 import co.com.japl.ui.components.CheckBoxField
 import co.com.japl.ui.components.FieldDatePicker
@@ -62,26 +53,13 @@ import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.com.japl.ui.theme.values.Dimensions
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavController
-import co.com.japl.finances.iports.dtos.CreditCardBoughtDTO
-import co.com.japl.finances.iports.dtos.CreditCardDTO
-import co.com.japl.finances.iports.dtos.TaxDTO
-import co.com.japl.finances.iports.enums.KindInterestRateEnum
-import co.com.japl.finances.iports.enums.KindOfTaxEnum
-import co.com.japl.finances.iports.inbounds.creditcard.IBuyCreditCardSettingPort
-import co.com.japl.finances.iports.inbounds.creditcard.ICreditCardPort
-import co.com.japl.finances.iports.inbounds.creditcard.ICreditCardSettingPort
-import co.com.japl.finances.iports.inbounds.creditcard.ITagPort
-import co.com.japl.finances.iports.inbounds.creditcard.ITaxPort
-import co.com.japl.finances.iports.inbounds.creditcard.bought.IBoughtPort
+import co.com.japl.module.creditcard.views.fakeSvc.FakeBoughtPort
+import co.com.japl.module.creditcard.views.fakeSvc.FakeBuyCreditCardSettingPort
+import co.com.japl.module.creditcard.views.fakeSvc.FakeCreditCardPort
+import co.com.japl.module.creditcard.views.fakeSvc.FakeCreditCardSettingPort
+import co.com.japl.module.creditcard.views.fakeSvc.FakeTagPort
+import co.com.japl.module.creditcard.views.fakeSvc.FakeTaxPort
 import co.com.japl.ui.theme.values.ModifiersCustom
-import co.com.japl.utils.NumbersUtil
-import kotlinx.coroutines.CoroutineDispatcher
-import java.math.BigDecimal
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import java.time.LocalDate
-import java.time.LocalDateTime
 
 @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
 @Composable

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/bought/forms/Wallet.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/bought/forms/Wallet.kt
@@ -1,6 +1,5 @@
 package co.com.japl.module.creditcard.views.bought.forms
 
-import android.app.Application
 import android.content.res.Configuration
 import android.os.Build
 import androidx.annotation.RequiresApi
@@ -20,11 +19,9 @@ import androidx.compose.material.icons.rounded.Save
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
@@ -39,14 +36,11 @@ import co.com.japl.ui.components.FieldView
 import co.com.japl.ui.components.FloatButton
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import androidx.navigation.NavController
+import co.com.japl.module.creditcard.views.fakeSvc.FakeBoughtPort
+import co.com.japl.module.creditcard.views.fakeSvc.FakeCreditCardPort
+import co.com.japl.module.creditcard.views.fakeSvc.FakeTaxPort
 import co.com.japl.ui.theme.values.Dimensions
 import co.com.japl.ui.theme.values.ModifiersCustom
-import co.com.japl.utils.NumbersUtil
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import java.time.LocalDateTime
 
 @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
 @Composable

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/creditrate/forms/CreditRate.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/creditrate/forms/CreditRate.kt
@@ -21,12 +21,14 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import co.com.japl.finances.iports.enums.KindInterestRateEnum
 import co.com.japl.finances.iports.enums.KindOfTaxEnum
@@ -45,8 +47,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 @Composable
-fun CreditRate(viewModel:CreateRateViewModel){
-    var navController = rememberNavController()
+fun CreditRate(viewModel:CreateRateViewModel,navController: NavController){
     var statePogress = remember {
         viewModel.loader
     }
@@ -229,7 +230,7 @@ fun CreditRatePreview(){
     val viewModel = CreateRateViewModel(SavedStateHandle(), CreditRateFake(), CreditCardFake())
     viewModel.loader.value = false
     MaterialThemeComposeUI {
-        CreditRate(viewModel)
+        CreditRate(viewModel, NavController(LocalContext.current))
     }
 }
 
@@ -240,6 +241,6 @@ fun CreditRatePreviewDark(){
     val viewModel = CreateRateViewModel(SavedStateHandle(), CreditRateFake(), CreditCardFake())
     viewModel.loader.value = false
     MaterialThemeComposeUI {
-        CreditRate(viewModel)
+        CreditRate(viewModel, NavController(LocalContext.current))
     }
 }

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/creditrate/forms/CreditRate.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/creditrate/forms/CreditRate.kt
@@ -26,10 +26,14 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.compose.rememberNavController
 import co.com.japl.finances.iports.enums.KindInterestRateEnum
 import co.com.japl.finances.iports.enums.KindOfTaxEnum
 import co.com.japl.module.creditcard.R
 import co.com.japl.module.creditcard.controllers.creditrate.forms.CreateRateViewModel
+import co.com.japl.module.creditcard.views.fakeSvc.CreditCardFake
+import co.com.japl.module.creditcard.views.fakeSvc.CreditRateFake
 import co.com.japl.ui.components.CheckBoxField
 import co.com.japl.ui.components.FieldSelect
 import co.com.japl.ui.components.FieldText
@@ -42,6 +46,7 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun CreditRate(viewModel:CreateRateViewModel){
+    var navController = rememberNavController()
     var statePogress = remember {
         viewModel.loader
     }
@@ -60,7 +65,7 @@ fun CreditRate(viewModel:CreateRateViewModel){
 
         Scaffold(
             floatingActionButton = {
-                FloatingActionButton(onClick = { viewModel.save() },
+                FloatingActionButton(onClick = { viewModel.save(navController) },
                     elevation=FloatingActionButtonDefaults.elevation(10.dp),
                     backgroundColor= MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f)) {
                     Icon(
@@ -221,7 +226,7 @@ private fun getKind(value:String):String{
 @Composable
 @Preview(showSystemUi = true, showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_NO)
 fun CreditRatePreview(){
-    val viewModel = CreateRateViewModel(null,null,null,null,null)
+    val viewModel = CreateRateViewModel(SavedStateHandle(), CreditRateFake(), CreditCardFake())
     viewModel.loader.value = false
     MaterialThemeComposeUI {
         CreditRate(viewModel)
@@ -232,7 +237,7 @@ fun CreditRatePreview(){
 @Composable
 @Preview(showSystemUi = true, showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 fun CreditRatePreviewDark(){
-    val viewModel = CreateRateViewModel(null,null,null,null,null)
+    val viewModel = CreateRateViewModel(SavedStateHandle(), CreditRateFake(), CreditCardFake())
     viewModel.loader.value = false
     MaterialThemeComposeUI {
         CreditRate(viewModel)

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/creditrate/lists/CreditRateList.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/creditrate/lists/CreditRateList.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import co.com.japl.finances.iports.dtos.CreditCardDTO
 import co.com.japl.finances.iports.dtos.TaxDTO
@@ -64,7 +65,7 @@ import java.math.BigDecimal
 import java.time.LocalDateTime
 
 @Composable
-fun CreditRateList(viewModel: CreditRateListViewModel){
+fun CreditRateList(viewModel: CreditRateListViewModel,navController: NavController){
     val navController = rememberNavController()
     val showProgress = remember {
         viewModel.showProgress
@@ -92,7 +93,7 @@ fun CreditRateList(viewModel: CreditRateListViewModel){
                 }
             }
         ) {
-            Body(viewModel,Modifier.padding(it))
+            Body(viewModel,Modifier.padding(it),navController)
         }
 
     }
@@ -100,7 +101,7 @@ fun CreditRateList(viewModel: CreditRateListViewModel){
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun Body(viewModel: CreditRateListViewModel,modifier:Modifier=Modifier){
+private fun Body(viewModel: CreditRateListViewModel,modifier:Modifier=Modifier,navController: NavController){
     val mapState = remember {viewModel.creditCard}
     Column {
         Row(horizontalArrangement = Arrangement.End, modifier = Modifier.fillMaxWidth()) {
@@ -109,16 +110,15 @@ private fun Body(viewModel: CreditRateListViewModel,modifier:Modifier=Modifier){
         mapState?.let { list ->
             Carousel(size = list.size, modifier = Modifier.fillMaxHeight()) {
                 val value = list.entries.toList()[it]
-                CreditCard(value = value, viewModel = viewModel)
+                CreditCard(value = value, viewModel = viewModel,navController)
             }
         }
     }
 }
 
 @Composable
-private fun CreditCard(value:Map.Entry<CreditCardDTO?,List<TaxDTO>>,viewModel: CreditRateListViewModel){
+private fun CreditCard(value:Map.Entry<CreditCardDTO?,List<TaxDTO>>,viewModel: CreditRateListViewModel,navController: NavController){
     val listState = remember{ mutableListOf(value.value) }
-    val navController = rememberNavController()
     val context = LocalContext.current
 
     OutlinedCard(modifier = Modifier
@@ -264,7 +264,7 @@ private fun getKindInterestRate(kind:KindInterestRateEnum,context: Context):Stri
 fun CreditRateListPreview(){
     val viewModel = getViewModel()
     MaterialThemeComposeUI {
-        CreditRateList(viewModel)
+        CreditRateList(viewModel, NavController(LocalContext.current))
     }
 }
 
@@ -274,7 +274,7 @@ fun CreditRateListPreview(){
 fun CreditRateListPreviewDark(){
     val viewModel = getViewModel()
     MaterialThemeComposeUI {
-        CreditRateList(viewModel)
+        CreditRateList(viewModel, NavController(LocalContext.current))
     }
 }
 

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/creditrate/lists/CreditRateList.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/creditrate/lists/CreditRateList.kt
@@ -66,7 +66,6 @@ import java.time.LocalDateTime
 
 @Composable
 fun CreditRateList(viewModel: CreditRateListViewModel,navController: NavController){
-    val navController = rememberNavController()
     val showProgress = remember {
         viewModel.showProgress
     }

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/creditrate/lists/CreditRateList.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/creditrate/lists/CreditRateList.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.navigation.compose.rememberNavController
 import co.com.japl.finances.iports.dtos.CreditCardDTO
 import co.com.japl.finances.iports.dtos.TaxDTO
 import co.com.japl.finances.iports.enums.KindInterestRateEnum
@@ -46,6 +47,8 @@ import co.com.japl.finances.iports.enums.KindOfTaxEnum
 import co.com.japl.module.creditcard.R
 import co.com.japl.module.creditcard.controllers.creditrate.lists.CreditRateListViewModel
 import co.com.japl.module.creditcard.enums.MoreOptionsItemCreditRate
+import co.com.japl.module.creditcard.views.fakeSvc.CreditCardFake
+import co.com.japl.module.creditcard.views.fakeSvc.CreditRateFake
 import co.com.japl.ui.components.AlertDialogOkCancel
 import co.com.japl.ui.components.Carousel
 import co.com.japl.ui.components.FieldView
@@ -62,6 +65,7 @@ import java.time.LocalDateTime
 
 @Composable
 fun CreditRateList(viewModel: CreditRateListViewModel){
+    val navController = rememberNavController()
     val showProgress = remember {
         viewModel.showProgress
     }
@@ -81,7 +85,7 @@ fun CreditRateList(viewModel: CreditRateListViewModel){
         Scaffold(
             floatingActionButton = {
                 FloatingActionButton(onClick = {
-                    viewModel.add()
+                    viewModel.add(navController)
                 },elevation=FloatingActionButtonDefaults.elevation(10.dp),
                     backgroundColor= MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f)) {
                     Icon(imageVector = Icons.Rounded.AddCircleOutline, contentDescription = stringResource(id = R.string.add_credit_rate))
@@ -114,6 +118,8 @@ private fun Body(viewModel: CreditRateListViewModel,modifier:Modifier=Modifier){
 @Composable
 private fun CreditCard(value:Map.Entry<CreditCardDTO?,List<TaxDTO>>,viewModel: CreditRateListViewModel){
     val listState = remember{ mutableListOf(value.value) }
+    val navController = rememberNavController()
+    val context = LocalContext.current
 
     OutlinedCard(modifier = Modifier
         .fillMaxWidth()
@@ -126,7 +132,7 @@ private fun CreditCard(value:Map.Entry<CreditCardDTO?,List<TaxDTO>>,viewModel: C
                         .fillMaxWidth()
                         .padding(Dimensions.PADDING_SHORT),
                     suffix = {
-                        IconButton(onClick = { viewModel.add(value.key?.id) }) {
+                        IconButton(onClick = { viewModel.add(value.key?.id,navController) }) {
                             Icon(
                                 imageVector = Icons.Rounded.AddCircleOutline,
                                 contentDescription = stringResource(id = R.string.add_credit_rate)
@@ -142,15 +148,16 @@ private fun CreditCard(value:Map.Entry<CreditCardDTO?,List<TaxDTO>>,viewModel: C
                         items(list.size){ pos ->
                             Rate(
                                 rate = list[pos],
-                                { viewModel.delete(it) },
-                                { viewModel.enable(it) },
-                                { viewModel.disable(it) },
+                                { viewModel.delete(it,context) },
+                                { viewModel.enable(it,context) },
+                                { viewModel.disable(it,context) },
                                 { codeCreditCard, codeCreditRate ->
                                     viewModel.edit(
                                         codeCreditCard,
-                                        codeCreditRate
+                                        codeCreditRate,
+                                        navController
                                     )
-                                },{ viewModel.clone(it)})
+                                },{ viewModel.clone(it,context)})
                         }
                     }
                 }
@@ -273,7 +280,7 @@ fun CreditRateListPreviewDark(){
 
 @Composable
 private fun getViewModel():CreditRateListViewModel{
-    val viewModel = CreditRateListViewModel(LocalContext.current, null,null, null)
+    val viewModel = CreditRateListViewModel(CreditCardFake(), CreditRateFake())
     viewModel.showProgress.value = false
     viewModel.creditCard?.put(CreditCardDTO(0,"credit card 1",24,24,
         BigDecimal.ZERO, LocalDateTime.now(),false,false,false),

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/fakeSvc/CreditCardFake.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/fakeSvc/CreditCardFake.kt
@@ -1,0 +1,26 @@
+package co.com.japl.module.creditcard.views.fakeSvc
+
+import co.com.japl.finances.iports.dtos.CreditCardDTO
+import co.com.japl.finances.iports.inbounds.creditcard.ICreditCardPort
+
+class CreditCardFake : ICreditCardPort{
+    override fun getCreditCard(codeCreditCard: Int): CreditCardDTO? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getAll(): List<CreditCardDTO> {
+        TODO("Not yet implemented")
+    }
+
+    override fun delete(id: Int): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun create(dto: CreditCardDTO): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun update(dto: CreditCardDTO): Boolean {
+        TODO("Not yet implemented")
+    }
+}

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/fakeSvc/CreditCardSettingFake.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/fakeSvc/CreditCardSettingFake.kt
@@ -1,0 +1,32 @@
+package co.com.japl.module.creditcard.views.fakeSvc
+
+import co.com.japl.finances.iports.dtos.CreditCardSettingDTO
+import co.com.japl.finances.iports.inbounds.creditcard.ICreditCardSettingPort
+
+class CreditCardSettingFake : ICreditCardSettingPort{
+    override fun getAll(codeCreditCard: Int): List<CreditCardSettingDTO> {
+        TODO("Not yet implemented")
+    }
+
+    override fun get(
+        codeCreditCard: Int,
+        codeCreditCardSetting: Int
+    ): CreditCardSettingDTO? {
+        TODO("Not yet implemented")
+    }
+
+    override fun delete(
+        codeCreditCard: Int,
+        codeCreditCardSetting: Int
+    ): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun update(dto: CreditCardSettingDTO): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun create(dto: CreditCardSettingDTO): Int {
+        TODO("Not yet implemented")
+    }
+}

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/fakeSvc/CreditRateFake.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/fakeSvc/CreditRateFake.kt
@@ -1,0 +1,56 @@
+package co.com.japl.module.creditcard.views.fakeSvc
+
+import co.com.japl.finances.iports.dtos.TaxDTO
+import co.com.japl.finances.iports.enums.KindInterestRateEnum
+import co.com.japl.finances.iports.inbounds.creditcard.ITaxPort
+import java.time.LocalDate
+
+class CreditRateFake : ITaxPort {
+    override fun get(
+        codCreditCard: Int,
+        month: Int,
+        year: Int,
+        kind: KindInterestRateEnum
+    ): TaxDTO? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getById(codeCreditRate: Int): TaxDTO? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getByCreditCard(codCreditCard: Int): List<TaxDTO>? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getByCreditCard(
+        codeCreditCard: Int,
+        cutOff: LocalDate
+    ): List<TaxDTO> {
+        TODO("Not yet implemented")
+    }
+
+    override fun delete(code: Int): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun enable(code: Int): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun disable(code: Int): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun create(dto: TaxDTO): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun update(dto: TaxDTO): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun clone(code: Int): Boolean {
+        TODO("Not yet implemented")
+    }
+}

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/fakeSvc/FakeAmortizationTable.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/fakeSvc/FakeAmortizationTable.kt
@@ -1,0 +1,16 @@
+package co.com.japl.module.creditcard.views.fakeSvc
+
+import co.com.japl.finances.iports.dtos.AmortizationRowDTO
+import co.com.japl.finances.iports.enums.KindAmortization
+import co.com.japl.finances.iports.inbounds.creditcard.IAmortizationTablePort
+
+
+class FakeAmortizationTable : IAmortizationTablePort{
+    override fun getAmortization(
+        code: Int,
+        kind: KindAmortization,
+        cache: Boolean
+    ): List<AmortizationRowDTO> {
+        TODO("Not yet implemented")
+    }
+}

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/fakeSvc/FakeBoughtPort.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/fakeSvc/FakeBoughtPort.kt
@@ -1,4 +1,4 @@
-package co.com.japl.module.creditcard.views.bought.forms
+package co.com.japl.module.creditcard.views.fakeSvc
 
 import co.com.japl.finances.iports.dtos.CreditCardBoughtDTO
 import co.com.japl.finances.iports.dtos.CreditCardDTO
@@ -6,7 +6,6 @@ import co.com.japl.finances.iports.dtos.RecapMonthly
 import co.com.japl.finances.iports.enums.KindInterestRateEnum
 import co.com.japl.finances.iports.enums.KindOfTaxEnum
 import co.com.japl.finances.iports.inbounds.creditcard.bought.IBoughtPort
-import java.math.BigDecimal
 import java.time.LocalDateTime
 
 class FakeBoughtPort : IBoughtPort {

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/fakeSvc/FakeBuyCreditCardSettingPort.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/fakeSvc/FakeBuyCreditCardSettingPort.kt
@@ -1,4 +1,4 @@
-package co.com.japl.module.creditcard.views.bought.forms
+package co.com.japl.module.creditcard.views.fakeSvc
 
 import co.com.japl.finances.iports.dtos.BuyCreditCardSettingDTO
 import co.com.japl.finances.iports.inbounds.creditcard.IBuyCreditCardSettingPort

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/fakeSvc/FakeCreditCardPort.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/fakeSvc/FakeCreditCardPort.kt
@@ -1,4 +1,4 @@
-package co.com.japl.module.creditcard.views.bought.forms
+package co.com.japl.module.creditcard.views.fakeSvc
 
 import co.com.japl.finances.iports.dtos.CreditCardDTO
 import co.com.japl.finances.iports.inbounds.creditcard.ICreditCardPort

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/fakeSvc/FakeCreditCardSettingPort.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/fakeSvc/FakeCreditCardSettingPort.kt
@@ -1,4 +1,4 @@
-package co.com.japl.module.creditcard.views.bought.forms
+package co.com.japl.module.creditcard.views.fakeSvc
 
 import co.com.japl.finances.iports.dtos.CreditCardSettingDTO
 import co.com.japl.finances.iports.inbounds.creditcard.ICreditCardSettingPort

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/fakeSvc/FakeTagPort.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/fakeSvc/FakeTagPort.kt
@@ -1,4 +1,4 @@
-package co.com.japl.module.creditcard.views.bought.forms
+package co.com.japl.module.creditcard.views.fakeSvc
 
 import co.com.japl.finances.iports.dtos.TagDTO
 import co.com.japl.finances.iports.inbounds.creditcard.ITagPort

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/fakeSvc/FakeTaxPort.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/fakeSvc/FakeTaxPort.kt
@@ -1,4 +1,4 @@
-package co.com.japl.module.creditcard.views.bought.forms
+package co.com.japl.module.creditcard.views.fakeSvc
 
 import co.com.japl.finances.iports.dtos.TaxDTO
 import co.com.japl.finances.iports.enums.KindInterestRateEnum

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/fakeSvc/SMSCreditCardFake.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/fakeSvc/SMSCreditCardFake.kt
@@ -1,0 +1,62 @@
+package co.com.japl.module.creditcard.views.fakeSvc
+
+import co.com.japl.finances.iports.dtos.SMSCreditCard
+import co.com.japl.finances.iports.enums.KindInterestRateEnum
+import co.com.japl.finances.iports.inbounds.creditcard.ISMSCreditCardPort
+import java.time.LocalDateTime
+
+class SMSCreditCardFake : ISMSCreditCardPort{
+    override fun create(dto: SMSCreditCard): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun update(dto: SMSCreditCard): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun delete(codeSMSCreditCard: Int): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun getById(codeSMSCreditCard: Int): SMSCreditCard? {
+        TODO("Not yet implemented")
+    }
+
+    override fun validateMessagePattern(dto: SMSCreditCard): List<String> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getByCreditCardAndKindInterest(
+        codeCreditCard: Int,
+        kind: KindInterestRateEnum
+    ): List<SMSCreditCard> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getAllByCodeCreditCard(codeCreditCard: Int): List<SMSCreditCard> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getSmsMessages(
+        phoneNumber: String,
+        pattern: String,
+        numDaysRead: Int
+    ): List<Triple<String, Double, LocalDateTime>> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getSmsMessages(
+        pattern: String,
+        sms: String
+    ): Triple<String, Double, LocalDateTime>? {
+        TODO("Not yet implemented")
+    }
+
+    override fun enable(codeSMSCreditCard: Int): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun disable(codeSMSCreditCard: Int): Boolean {
+        TODO("Not yet implemented")
+    }
+}

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/paid/PaidList.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/paid/PaidList.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import co.com.japl.finances.iports.dtos.BoughtCreditCardPeriodDTO
 import co.com.japl.module.creditcard.R
@@ -30,7 +31,7 @@ import kotlinx.coroutines.withContext
 import java.time.LocalDateTime
 
 @Composable
-fun PaidList(viewModel: BoughtCreditCardViewModel){
+fun PaidList(viewModel: BoughtCreditCardViewModel,navController: NavController){
     val loaderState = remember {viewModel.progress}
     val loader = remember {viewModel.loader}
     val scope = rememberCoroutineScope()
@@ -45,26 +46,25 @@ fun PaidList(viewModel: BoughtCreditCardViewModel){
             progress = { loaderState.floatValue },
         )
     }else {
-        Yearly(viewModel = viewModel)
+        Yearly(viewModel = viewModel,navController)
     }
 
 }
 
 @Composable
-private fun Yearly(viewModel:BoughtCreditCardViewModel){
+private fun Yearly(viewModel:BoughtCreditCardViewModel,navController: NavController){
     LazyColumn(modifier = Modifier.fillMaxWidth()){
         items(viewModel.periodList.size){item->
             val key = viewModel.periodList.keys.toList()[item]
             val list = viewModel.periodList[key]!!
-            Yearly(key = key, list = list, viewModel = viewModel)
+            Yearly(key = key, list = list, viewModel = viewModel,navController)
         }
     }
 }
 
 @Composable
-private fun Yearly(key:Long,list:List<BoughtCreditCardPeriodDTO>,viewModel:BoughtCreditCardViewModel){
+private fun Yearly(key:Long,list:List<BoughtCreditCardPeriodDTO>,viewModel:BoughtCreditCardViewModel,navController: NavController){
     val drowdownState = remember { mutableStateOf(false) }
-    val navController = rememberNavController()
     Surface(
         border = BorderStroke(1.dp,color= MaterialTheme.colorScheme.onPrimaryContainer),
         shadowElevation = 10.dp,

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/paid/PaidList.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/paid/PaidList.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.unit.dp
+import androidx.navigation.compose.rememberNavController
 import co.com.japl.finances.iports.dtos.BoughtCreditCardPeriodDTO
 import co.com.japl.module.creditcard.R
 import co.com.japl.module.creditcard.controllers.paid.BoughtCreditCardViewModel
@@ -63,6 +64,7 @@ private fun Yearly(viewModel:BoughtCreditCardViewModel){
 @Composable
 private fun Yearly(key:Long,list:List<BoughtCreditCardPeriodDTO>,viewModel:BoughtCreditCardViewModel){
     val drowdownState = remember { mutableStateOf(false) }
+    val navController = rememberNavController()
     Surface(
         border = BorderStroke(1.dp,color= MaterialTheme.colorScheme.onPrimaryContainer),
         shadowElevation = 10.dp,
@@ -73,7 +75,7 @@ private fun Yearly(key:Long,list:List<BoughtCreditCardPeriodDTO>,viewModel:Bough
             YearlyHeader(year = key, list = list)
             if (drowdownState.value) {
                 Monthly(list = list, goto = { cutoffDay, cutoff ->
-                    viewModel.goToListDetail(cutoffDay, cutoff)
+                    viewModel.goToListDetail(cutoffDay, cutoff,navController)
                 })
             }
         }

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/setting/forms/CreditCardSetting.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/setting/forms/CreditCardSetting.kt
@@ -24,10 +24,14 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.compose.rememberNavController
 import co.com.japl.module.creditcard.R
 import co.com.japl.module.creditcard.controllers.setting.CreditCardSettingViewModel
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.com.japl.module.creditcard.enums.MoreOptionsItemsTypeSettings
+import co.com.japl.module.creditcard.views.fakeSvc.CreditCardFake
+import co.com.japl.module.creditcard.views.fakeSvc.CreditCardSettingFake
 import co.com.japl.ui.components.CheckBoxField
 import co.com.japl.ui.components.FieldSelect
 import co.com.japl.ui.components.FieldText
@@ -144,17 +148,18 @@ private fun Body(viewModel: CreditCardSettingViewModel, modifier:Modifier) {
 
 @Composable
 private fun Buttons(viewModel: CreditCardSettingViewModel) {
+    val navController = rememberNavController()
     val state = remember {viewModel.showButtons}
     val newOneState = remember {viewModel.newOne}
         if (!newOneState.value) {
             FloatButton(imageVector = Icons.Rounded.Update,
                 descriptionIcon = R.string.save) {
-                viewModel.update()
+                viewModel.update(navController)
             }
         } else {
             FloatButton(imageVector = Icons.Rounded.Create,
                 descriptionIcon =R.string.save) {
-                viewModel.create()
+                viewModel.create(navController)
             }
         }
 }
@@ -163,7 +168,7 @@ private fun Buttons(viewModel: CreditCardSettingViewModel) {
 @Composable
 @Preview(showBackground = true, showSystemUi = true)
 private fun CreditCardSettingPreview(){
-    val viewModel = CreditCardSettingViewModel(codeCreditCard = null,codeCreditCardSetting = null, creditCardSvc = null,creditCardSettingSvc = null, navController=null)
+    val viewModel = CreditCardSettingViewModel(savedStateHandle = SavedStateHandle(), creditCardSvc = CreditCardFake(),creditCardSettingSvc = CreditCardSettingFake())
     viewModel.showProgress.value = false
     MaterialThemeComposeUI {
         CreditCardSetting(viewModel = viewModel)

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/setting/lists/CreditCardSettingList.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/setting/lists/CreditCardSettingList.kt
@@ -1,5 +1,6 @@
 package co.com.japl.module.creditcard.views.setting.lists
 
+import android.annotation.SuppressLint
 import android.content.res.Configuration
 import android.os.Build
 import androidx.annotation.RequiresApi
@@ -32,6 +33,8 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.compose.rememberNavController
 import co.com.japl.finances.iports.dtos.CreditCardSettingDTO
 import co.com.japl.module.creditcard.R
 import co.com.japl.module.creditcard.controllers.setting.CreditCardSettingListViewModel
@@ -40,6 +43,7 @@ import co.com.japl.ui.theme.values.Dimensions
 import co.com.japl.ui.theme.values.ModifiersCustom.Weight1f
 import co.com.japl.ui.theme.values.ModifiersCustom.Weight1fAndAlightCenterVertical
 import co.com.japl.module.creditcard.enums.MoreOptionsItemsSettingsCreditCard
+import co.com.japl.module.creditcard.views.fakeSvc.CreditCardSettingFake
 import co.com.japl.ui.utils.WindowWidthSize
 import co.com.japl.ui.components.AlertDialogOkCancel
 import co.com.japl.ui.components.MoreOptionsDialog
@@ -69,10 +73,11 @@ import java.time.LocalDateTime
 
 @Composable
 private fun Body(viewModel: CreditCardSettingListViewModel){
+    val navController = rememberNavController()
     val listState = remember { viewModel.list }
     Scaffold( floatingActionButton = {
         FloatingActionButton(onClick = {
-            viewModel.onClick()
+            viewModel.onClick(navController)
         }, elevation = FloatingActionButtonDefaults.elevation(10.dp),
             backgroundColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f)) {
             Icon(
@@ -85,14 +90,15 @@ private fun Body(viewModel: CreditCardSettingListViewModel){
                 listState.forEach{item->
                     Item(
                         item = item,
-                        edit = { id -> viewModel.edit(id) },
-                        delete = { id -> viewModel.delete(id) })
+                        edit = { id -> viewModel.edit(id,navController) },
+                        delete = { id -> viewModel.delete(id,navController) })
                 }
         }
     }
 
 }
 
+@SuppressLint("UnusedBoxWithConstraintsScope")
 @Composable
 private fun Item(item:CreditCardSettingDTO,edit:(Int)->Unit,delete:(Int)->Unit){
     val stateShowOptions = remember { mutableStateOf(false) }
@@ -207,7 +213,7 @@ fun CreditCardSettingListPreviewDARK(){
 }
 
 fun getViewModel():CreditCardSettingListViewModel{
-    val viewModel = CreditCardSettingListViewModel(0, null,null)
+    val viewModel = CreditCardSettingListViewModel(SavedStateHandle(), CreditCardSettingFake())
     viewModel.showProgress.value = false
     viewModel.progress.floatValue = 0.7f
     viewModel.list.add(CreditCardSettingDTO(1,2,"test","test","", LocalDateTime.now(),Short.MIN_VALUE))

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/setting/lists/CreditCardSettingList.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/setting/lists/CreditCardSettingList.kt
@@ -29,11 +29,13 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import co.com.japl.finances.iports.dtos.CreditCardSettingDTO
 import co.com.japl.module.creditcard.R
@@ -53,7 +55,7 @@ import kotlinx.coroutines.launch
 import java.time.LocalDateTime
 
 @Composable
- fun CreditCardSettingList(viewModel: CreditCardSettingListViewModel){
+ fun CreditCardSettingList(viewModel: CreditCardSettingListViewModel,navController: NavController){
     val stateShow = remember {viewModel.showProgress}
     val stateProgress = remember {viewModel.progress}
 
@@ -67,13 +69,12 @@ import java.time.LocalDateTime
             modifier = Modifier.fillMaxWidth(),
         )
     }else {
-        Body(viewModel = viewModel)
+        Body(viewModel = viewModel,navController)
     }
 }
 
 @Composable
-private fun Body(viewModel: CreditCardSettingListViewModel){
-    val navController = rememberNavController()
+private fun Body(viewModel: CreditCardSettingListViewModel,navController: NavController){
     val listState = remember { viewModel.list }
     Scaffold( floatingActionButton = {
         FloatingActionButton(onClick = {
@@ -198,7 +199,7 @@ private fun ItemCompact(item:CreditCardSettingDTO,statusShowOptions:MutableState
 fun CreditCardSettingListPreview(){
     val viewModel = getViewModel()
     MaterialThemeComposeUI {
-        CreditCardSettingList(viewModel)
+        CreditCardSettingList(viewModel, NavController(LocalContext.current))
     }
 }
 
@@ -208,7 +209,7 @@ fun CreditCardSettingListPreview(){
 fun CreditCardSettingListPreviewDARK(){
     val viewModel = getViewModel()
     MaterialThemeComposeUI {
-        CreditCardSettingList(viewModel)
+        CreditCardSettingList(viewModel, NavController(LocalContext.current))
     }
 }
 

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/simulator/SimulatorList.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/simulator/SimulatorList.kt
@@ -26,10 +26,12 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.compose.rememberNavController
 import co.com.japl.finances.iports.dtos.SimulatorCreditDTO
 import co.com.japl.finances.iports.enums.KindOfTaxEnum
 import co.com.japl.module.creditcard.R
 import co.com.japl.module.creditcard.controllers.simulator.SimulatorListItemViewModel
+import co.com.japl.module.creditcard.views.fakeSvc.SimulatorCreditVariableFake
 import co.com.japl.ui.components.MoreOptionsDialogPair
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.com.japl.ui.theme.values.Dimensions
@@ -61,6 +63,7 @@ private fun MainBody(viewModel: SimulatorListItemViewModel,size:WindowWidthSize)
 
 @Composable
 private fun Header(viewModel: SimulatorListItemViewModel, size:WindowWidthSize){
+    val navController = rememberNavController()
     val state = remember { viewModel.showOptions }
     Row {
         Text(
@@ -157,7 +160,7 @@ private fun Header(viewModel: SimulatorListItemViewModel, size:WindowWidthSize){
         }
     }
     Options(state=state,actionAmortization={
-      viewModel.gotoAmortization(viewModel.item.get().code)
+      viewModel.gotoAmortization(viewModel.item.get().code,navController)
     })
 }
 
@@ -337,5 +340,8 @@ private fun getViewModel(): SimulatorListItemViewModel{
         quoteValue = 1038978.toBigDecimal(),
         capitalValue = 833333.toBigDecimal()
     )
-    return SimulatorListItemViewModel(itemValue = dto)
+    return SimulatorListItemViewModel(
+        itemValue = dto,
+        simulatorVariableSvc = SimulatorCreditVariableFake()
+    )
 }

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/sms/forms/SMS.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/sms/forms/SMS.kt
@@ -30,7 +30,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.compose.rememberNavController
 import co.com.japl.module.creditcard.R
+import co.com.japl.module.creditcard.views.fakeSvc.CreditCardFake
+import co.com.japl.module.creditcard.views.fakeSvc.SMSCreditCardFake
 import co.com.japl.ui.components.FieldSelect
 import co.com.japl.ui.components.FieldText
 import co.com.japl.ui.components.FloatButton
@@ -61,9 +65,10 @@ fun Sms(viewModel:SmsCreditCardViewModel){
 
 @Composable
 private fun Form(viewModel: SmsCreditCardViewModel){
+    val navController = rememberNavController()
     Scaffold (
         floatingActionButton = {
-            Buttons({viewModel.clean()}, {viewModel.save()})
+            Buttons({viewModel.clean()}, {viewModel.save(navController)})
         }
     ) {
         Body(viewModel = viewModel, modifier = Modifier
@@ -201,7 +206,7 @@ internal fun SmsPreviewLight(){
 }
 @Composable
 private fun getViewModel():SmsCreditCardViewModel{
-    val viewModel = SmsCreditCardViewModel(null,null,null,null)
+    val viewModel = SmsCreditCardViewModel(SavedStateHandle(), SMSCreditCardFake(), CreditCardFake())
     viewModel.load.value = false
     return viewModel
 }

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/sms/list/SMS.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/sms/list/SMS.kt
@@ -25,11 +25,14 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.navigation.compose.rememberNavController
 import co.com.japl.finances.iports.dtos.SMSCreditCard
 import co.com.japl.finances.iports.enums.KindInterestRateEnum
 import co.com.japl.module.creditcard.R
 import co.com.japl.module.creditcard.controllers.smscreditcard.list.SmsCreditCardViewModel
 import co.com.japl.module.creditcard.enums.MoreOptionsItemSmsCreditCard
+import co.com.japl.module.creditcard.views.fakeSvc.CreditCardFake
+import co.com.japl.module.creditcard.views.fakeSvc.SMSCreditCardFake
 import co.com.japl.ui.components.AlertDialogOkCancel
 import co.com.japl.ui.components.Carousel
 import co.com.japl.ui.components.FloatButton
@@ -65,10 +68,11 @@ fun SMS(viewModel:SmsCreditCardViewModel) {
 
 @Composable
 private fun Body(viewModel: SmsCreditCardViewModel){
+    val navController = rememberNavController()
     Scaffold (
         floatingActionButton = {
             Buttons{
-                viewModel.add()
+                viewModel.add(navController)
             }
         }
     ) {
@@ -79,6 +83,7 @@ private fun Body(viewModel: SmsCreditCardViewModel){
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun Content(viewModel: SmsCreditCardViewModel,modifier: Modifier){
+    val navController = rememberNavController()
     val list = remember { viewModel.list}
     Column {
         Row (horizontalArrangement = Arrangement.End, modifier=Modifier.fillMaxWidth()) {
@@ -93,13 +98,13 @@ private fun Content(viewModel: SmsCreditCardViewModel,modifier: Modifier){
                     list[it]?.values?.forEach {
                         for (i in it) {
                             Card(sms = i, modifier = Modifier, edit = {
-                                viewModel.edit(it)
+                                viewModel.edit(it,navController)
                             }, delete = {
-                                viewModel.delete(it)
+                                viewModel.delete(it,navController)
                             }, enable = {
-                                viewModel.enabled(it)
+                                viewModel.enabled(it,navController)
                             }, disable = {
-                                viewModel.disabled(it)
+                                viewModel.disabled(it,navController)
                             })
                         }
                     }
@@ -191,7 +196,7 @@ internal fun SMSPreview(){
 
 @Composable
 private fun getViewModel():SmsCreditCardViewModel {
-  val viewModel = SmsCreditCardViewModel(null,null, null)
+  val viewModel = SmsCreditCardViewModel(SMSCreditCardFake(), CreditCardFake())
     viewModel.load.value = false
     listOf(
         SMSCreditCard(

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/AmortizationTableFragment.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/AmortizationTableFragment.kt
@@ -9,6 +9,8 @@ import android.view.ViewGroup
 import androidx.annotation.RequiresApi
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.ViewModel
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.creditcard.IAmortizationTablePort
 import co.com.japl.module.creditcard.controllers.amortization.AmortizationViewModel
@@ -24,14 +26,25 @@ class AmortizationTableFragment : Fragment(){
 
     @Inject lateinit var amortizationSvc: IAmortizationTablePort
 
+    val viewModel: AmortizationViewModel by viewModels{
+        ViewModelFactory(
+            this,
+            viewModelClass= AmortizationViewModel::class.java,
+            build = {
+                AmortizationViewModel(
+                    it,
+                    amortizationSvc
+                )
+            }
+        )
+    }
+
     @RequiresApi(Build.VERSION_CODES.S)
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
         val view = FragmentAmortizationTableBinding.inflate(inflater)
-        val code = arguments?.let{ AmortizationTableParams.download(it)["CODE"] as Long }
-        val viewModel = AmortizationViewModel( code?.toInt()!!,amortizationSvc,findNavController())
         view.composeViewFat.apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/boughtcreditcard/ListQuotesPaid.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/boughtcreditcard/ListQuotesPaid.kt
@@ -57,7 +57,7 @@ class ListQuotesPaid : Fragment() {
                 setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
                 setContent {
                     MaterialThemeComposeUI {
-                        PaidList(viewModel = viewModel)
+                        PaidList(viewModel = viewModel,findNavController())
 
                 }
             }

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/boughtcreditcard/ListQuotesPaid.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/boughtcreditcard/ListQuotesPaid.kt
@@ -9,6 +9,7 @@ import android.view.ViewGroup
 import androidx.annotation.RequiresApi
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.creditcard.bought.lists.IBoughtListPort
 import co.com.japl.ui.theme.MaterialThemeComposeUI
@@ -18,6 +19,7 @@ import co.com.japl.module.creditcard.controllers.paid.BoughtCreditCardViewModel
 import co.com.japl.module.creditcard.views.paid.PaidList
 import co.com.japl.ui.Prefs
 import co.japl.android.myapplication.finanzas.ApplicationInitial
+import co.japl.android.myapplication.finanzas.controller.ViewModelFactory
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlin.properties.Delegates
@@ -30,6 +32,20 @@ class ListQuotesPaid : Fragment() {
     @Inject lateinit var prefs : Prefs
     private lateinit var _binding : FragmentListPeriodsBinding
 
+    val viewModel:BoughtCreditCardViewModel by viewModels{
+        ViewModelFactory(
+            owner = this,
+            viewModelClass = BoughtCreditCardViewModel::class.java,
+            build = {
+                BoughtCreditCardViewModel(
+                    savedStateHandle = it,
+                    service = port,
+                    prefs = prefs
+                )
+            }
+        )
+    }
+
     @RequiresApi(Build.VERSION_CODES.O)
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -37,15 +53,11 @@ class ListQuotesPaid : Fragment() {
     ): View? {
         _binding = FragmentListPeriodsBinding.inflate(inflater, container, false)
         val rootView = _binding.root
-        arguments?.let{
-            creditCardId = PeriodsParams.Companion.Historical.download(it)
-        }
-        Log.d(javaClass.name,"=== ListQuotesPaid start")
         _binding.composeViewLp.apply {
                 setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
                 setContent {
                     MaterialThemeComposeUI {
-                        PaidList(viewModel = BoughtCreditCardViewModel(port,creditCardId,findNavController(),prefs))
+                        PaidList(viewModel = viewModel)
 
                 }
             }

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/boughtcreditcard/SmsFragment.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/boughtcreditcard/SmsFragment.kt
@@ -8,6 +8,7 @@ import android.view.ViewGroup
 import androidx.annotation.RequiresApi
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.creditcard.ICreditCardPort
 import co.com.japl.finances.iports.inbounds.creditcard.ISMSCreditCardPort
@@ -15,6 +16,7 @@ import co.com.japl.module.creditcard.controllers.smscreditcard.form.SmsCreditCar
 import co.com.japl.module.creditcard.views.sms.forms.Sms
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.japl.android.myapplication.databinding.FragmentSmsCreditCardBinding
+import co.japl.android.myapplication.finanzas.controller.ViewModelFactory
 import co.japl.android.myapplication.putParams.SmsCreditCardParams
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -24,19 +26,26 @@ class SmsFragment: Fragment()  {
     @Inject lateinit var creditCardSvc:ICreditCardPort
     @Inject lateinit var smsCreditCardSvc:ISMSCreditCardPort
 
+    val viewModel:SmsCreditCardViewModel by viewModels{
+        ViewModelFactory(
+            owner = this,
+            viewModelClass = SmsCreditCardViewModel::class.java,
+            build={
+                SmsCreditCardViewModel(
+                    it,
+                    smsCreditCardSvc,
+                    creditCardSvc
+                )
+            }
+        )
+    }
+
     @RequiresApi(Build.VERSION_CODES.S)
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
         val view = FragmentSmsCreditCardBinding.inflate(inflater,container,false)
-        val code = arguments?.let{SmsCreditCardParams.download(it)}
-        val viewModel = SmsCreditCardViewModel(
-            codeSMSCC = code,
-            svc=smsCreditCardSvc,
-            creditCardSvc = creditCardSvc,
-            navController = findNavController()
-        )
         view.cvComposeLscc?.apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/boughtcreditcard/SmsListFragment.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/boughtcreditcard/SmsListFragment.kt
@@ -8,6 +8,7 @@ import android.view.ViewGroup
 import androidx.annotation.RequiresApi
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.creditcard.ICreditCardPort
 import co.com.japl.finances.iports.inbounds.creditcard.ISMSCreditCardPort
@@ -15,6 +16,7 @@ import co.com.japl.module.creditcard.controllers.smscreditcard.list.SmsCreditCar
 import co.com.japl.module.creditcard.views.sms.list.SMS
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.japl.android.myapplication.databinding.FragmentListSmsCreditCardBinding
+import co.japl.android.myapplication.finanzas.controller.ViewModelFactory
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -24,17 +26,25 @@ class SmsListFragment: Fragment()  {
     @Inject lateinit var creditCardSvc:ICreditCardPort
     @Inject lateinit var smsCreditCardSvc:ISMSCreditCardPort
 
+    val viewModel : SmsCreditCardViewModel by viewModels{
+        ViewModelFactory(
+            owner = this,
+            viewModelClass = SmsCreditCardViewModel::class.java,
+            build={
+                SmsCreditCardViewModel(
+                    svc = smsCreditCardSvc,
+                    creditCardSvc = creditCardSvc
+                )
+            }
+        )
+    }
+
     @RequiresApi(Build.VERSION_CODES.S)
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
         val view = FragmentListSmsCreditCardBinding.inflate(inflater,container,false)
-        val viewModel = SmsCreditCardViewModel(
-            svc = smsCreditCardSvc,
-            creditCardSvc = creditCardSvc,
-            navController = findNavController()
-        )
         view.cvComposeLscc?.apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditcard/CreateCreditCard.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditcard/CreateCreditCard.kt
@@ -52,7 +52,7 @@ class CreateCreditCard : Fragment() {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
                 MaterialThemeComposeUI {
-                    CreditCard(viewModel)
+                    CreditCard(viewModel,findNavController())
                 }
             }
         }

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditcard/CreateCreditCard.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditcard/CreateCreditCard.kt
@@ -8,12 +8,14 @@ import android.view.ViewGroup
 import androidx.annotation.RequiresApi
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.creditcard.ICreditCardPort
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.japl.android.myapplication.databinding.FragmentCreateCreditCardBinding
 import co.com.japl.module.creditcard.controllers.account.CreditCardViewModel
 import co.com.japl.module.creditcard.views.account.forms.CreditCard
+import co.japl.android.myapplication.finanzas.controller.ViewModelFactory
 import co.japl.android.myapplication.putParams.CreditCardParams
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -27,22 +29,30 @@ class CreateCreditCard : Fragment() {
     private var _binding:FragmentCreateCreditCardBinding? = null
     private val binding get() = _binding!!
 
+    val viewModel : CreditCardViewModel by viewModels{
+        ViewModelFactory(
+            owner = this,
+            viewModelClass = CreditCardViewModel::class.java,
+            build={
+                CreditCardViewModel(
+                    it,
+                    creditCardSvc
+                )
+            }
+        )
+    }
+
     @RequiresApi(Build.VERSION_CODES.S)
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        arguments?.let {
-            param1 = CreditCardParams.download(it).orElse("0")
-        }
-
-        val creditCardViewModel = CreditCardViewModel(param1?.toInt(),creditCardSvc,findNavController())
         _binding = FragmentCreateCreditCardBinding.inflate(inflater)
         binding.cvComposeCcc.apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
                 MaterialThemeComposeUI {
-                    CreditCard(creditCardViewModel)
+                    CreditCard(viewModel)
                 }
             }
         }

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditcard/CreditCardSettingFragment.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditcard/CreditCardSettingFragment.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.creditcard.ICreditCardPort
 import co.com.japl.finances.iports.inbounds.creditcard.ICreditCardSettingPort
@@ -15,6 +16,7 @@ import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.japl.android.myapplication.databinding.FragmentCreditCardSettingBinding
 import co.com.japl.module.creditcard.views.setting.forms.CreditCardSetting
 import co.com.japl.module.creditcard.controllers.setting.CreditCardSettingViewModel
+import co.japl.android.myapplication.finanzas.controller.ViewModelFactory
 import co.japl.android.myapplication.putParams.CreditCardSettingParams
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -28,22 +30,26 @@ class CreditCardSettingFragment : Fragment() {
     private var _binding:FragmentCreditCardSettingBinding? = null
     val binding get() = _binding
 
+    val viewModel : CreditCardSettingViewModel by viewModels{
+        ViewModelFactory(
+            owner = this,
+            viewModelClass = CreditCardSettingViewModel::class.java,
+            build = {
+                CreditCardSettingViewModel(
+                    savedStateHandle = it
+                    , creditCardSvc=creditCardSvc
+                    , creditCardSettingSvc=creditCardSettingSvc
+                )
+            }
+        )
+    }
+
     @RequiresApi(Build.VERSION_CODES.O)
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
         _binding = FragmentCreditCardSettingBinding.inflate(inflater)
-
-        val map = CreditCardSettingParams.download(arguments)
-        val codeCreditCard = map[CreditCardSettingParams.Params.ARG_CODE_CREDIT_CARD]
-        val codeCreditCardSetting = map[CreditCardSettingParams.Params.ARG_ID]
-
-        val viewModel = CreditCardSettingViewModel(codeCreditCard=codeCreditCard
-            , codeCreditCardSetting=codeCreditCardSetting
-            , creditCardSvc=creditCardSvc
-            , creditCardSettingSvc=creditCardSettingSvc
-            , navController = findNavController())
         binding?.cvComposeCcs?.apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditcard/ListCreditCard.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditcard/ListCreditCard.kt
@@ -8,12 +8,14 @@ import android.view.ViewGroup
 import androidx.annotation.RequiresApi
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.creditcard.ICreditCardPort
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.japl.android.myapplication.databinding.FragmentListCreditCardBinding
 import co.com.japl.module.creditcard.views.account.lists.CreditCardList
 import co.com.japl.module.creditcard.controllers.account.CreditCardListViewModel
+import co.japl.android.myapplication.finanzas.controller.ViewModelFactory
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -24,9 +26,14 @@ class ListCreditCard : Fragment()  {
     private lateinit var _binding : FragmentListCreditCardBinding
     private val binding get() = _binding
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
+    val viewModel : CreditCardListViewModel by viewModels {
+        ViewModelFactory(
+            owner = this,
+            viewModelClass = CreditCardListViewModel::class.java,
+            build = {
+                CreditCardListViewModel(creditCardSvc)
+            }
+        )
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
@@ -35,7 +42,6 @@ class ListCreditCard : Fragment()  {
         savedInstanceState: Bundle?
     ): View? {
         _binding = FragmentListCreditCardBinding.inflate(inflater)
-        val viewModel = CreditCardListViewModel(creditCardSvc,findNavController())
         binding?.listComposeLcc?.apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditcard/ListCreditCard.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditcard/ListCreditCard.kt
@@ -46,7 +46,7 @@ class ListCreditCard : Fragment()  {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
                 MaterialThemeComposeUI {
-                    CreditCardList(creditCardViewModel = viewModel)
+                    CreditCardList(creditCardViewModel = viewModel,findNavController())
                 }
             }
         }

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditcard/ListCreditCardSetting.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditcard/ListCreditCardSetting.kt
@@ -8,12 +8,14 @@ import android.view.ViewGroup
 import androidx.annotation.RequiresApi
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.creditcard.ICreditCardSettingPort
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.japl.android.myapplication.databinding.FragmentListCreditCardSettingBinding
 import co.com.japl.module.creditcard.views.setting.lists.CreditCardSettingList
 import co.com.japl.module.creditcard.controllers.setting.CreditCardSettingListViewModel
+import co.japl.android.myapplication.finanzas.controller.ViewModelFactory
 import co.japl.android.myapplication.putParams.ListCreditCardSettingParams
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -27,9 +29,14 @@ class ListCreditCardSetting : Fragment() {
      lateinit var _binding:FragmentListCreditCardSettingBinding
     private val binding get() = _binding
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
+    val viewModel : CreditCardSettingListViewModel by viewModels {
+        ViewModelFactory(
+            owner = this,
+            viewModelClass = CreditCardSettingListViewModel::class.java,
+            build = {
+                CreditCardSettingListViewModel(it,saveSvc)
+            }
+        )
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
@@ -38,11 +45,6 @@ class ListCreditCardSetting : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         _binding = FragmentListCreditCardSettingBinding.inflate(inflater)
-        val map = ListCreditCardSettingParams.download(arguments)
-        if(map.containsKey(ListCreditCardSettingParams.Params.ARG_CODE_CREDIT_CARD)) {
-            codeCreditCard = map[ListCreditCardSettingParams.Params.ARG_CODE_CREDIT_CARD]!!
-        }
-        val viewModel = CreditCardSettingListViewModel(codeCreditCard,saveSvc,findNavController())
         binding?.cvComposeLccs?.apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditcard/ListCreditCardSetting.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditcard/ListCreditCardSetting.kt
@@ -49,7 +49,7 @@ class ListCreditCardSetting : Fragment() {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
                 MaterialThemeComposeUI {
-                    CreditCardSettingList(viewModel = viewModel)
+                    CreditCardSettingList(viewModel = viewModel,findNavController())
                 }
             }
         }

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditfix/AdditionalCreditFragment.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditfix/AdditionalCreditFragment.kt
@@ -28,7 +28,6 @@ class AdditionalCreditFragment : Fragment(){
             viewModelClass = AdditionalFormViewModel::class.java,
             build = {
                 AdditionalFormViewModel(
-                    context = context?.applicationContext!!,
                     savedStateHandle = it,
                     additionalSvc = additionalSvc
                 )

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditfix/AdditionalListFragment.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditfix/AdditionalListFragment.kt
@@ -24,7 +24,7 @@ class AdditionalListFragment : Fragment() {
     @Inject lateinit var additionalSvc : IAdditional
     private val viewModel: AdditionalViewModel by viewModels {
         ViewModelFactory(this,AdditionalViewModel::class.java){
-            AdditionalViewModel(requireContext(),it,additionalSvc)
+            AdditionalViewModel(it,additionalSvc)
         }
     }
 

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditfix/CreditFixFragment.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditfix/CreditFixFragment.kt
@@ -30,7 +30,8 @@ class CreditFixFragment : Fragment(){
             build = {
                 CreditFormViewModel(
                     savedStateHandle = it,
-                    creditSvc = creditSvc
+                    creditSvc = creditSvc,
+                    context = context?.applicationContext!!
                 )
             }
         )

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditfix/CreditFixFragment.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/creditfix/CreditFixFragment.kt
@@ -30,8 +30,7 @@ class CreditFixFragment : Fragment(){
             build = {
                 CreditFormViewModel(
                     savedStateHandle = it,
-                    creditSvc = creditSvc,
-                    context = context?.applicationContext!!
+                    creditSvc = creditSvc
                 )
             }
         )

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/simulators/list/ListViewModel.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/simulators/list/ListViewModel.kt
@@ -20,11 +20,10 @@ class ListViewModel  @Inject constructor(private val simulatorVariableSvc: ISimu
         execute()
     }
 
-    fun createViewModelQuoteVariable(dto: SimulatorCreditDTO, navController: NavController): co.com.japl.module.creditcard.controllers.simulator.SimulatorListItemViewModel {
+    fun createViewModelQuoteVariable(dto: SimulatorCreditDTO): co.com.japl.module.creditcard.controllers.simulator.SimulatorListItemViewModel {
         return co.com.japl.module.creditcard.controllers.simulator.SimulatorListItemViewModel(
             dto,
-            simulatorVariableSvc,
-            navController
+            simulatorVariableSvc
         )
     }
 

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/taxes/ListTaxCreditCard.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/taxes/ListTaxCreditCard.kt
@@ -8,6 +8,7 @@ import android.view.ViewGroup
 import androidx.annotation.RequiresApi
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.creditcard.ICreditCardPort
 import co.com.japl.finances.iports.inbounds.creditcard.ITaxPort
@@ -15,6 +16,7 @@ import co.com.japl.module.creditcard.controllers.creditrate.lists.CreditRateList
 import co.com.japl.module.creditcard.views.creditrate.lists.CreditRateList
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.japl.android.myapplication.databinding.FragmentListTaxCreditCardBinding
+import co.japl.android.myapplication.finanzas.controller.ViewModelFactory
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -27,9 +29,16 @@ class ListTaxCreditCard : Fragment() {
     lateinit var _bind : FragmentListTaxCreditCardBinding
     val bind get() = _bind
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
+    val viewModel: CreditRateListViewModel by viewModels {
+        ViewModelFactory(
+            owner = this,
+            viewModelClass = CreditRateListViewModel::class.java,
+            build = {
+                CreditRateListViewModel(
+                    creditCardSvc2,
+                    creditRateSvc)
+            }
+        )
     }
 
     @RequiresApi(Build.VERSION_CODES.S)
@@ -38,7 +47,6 @@ class ListTaxCreditCard : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         _bind = FragmentListTaxCreditCardBinding.inflate(inflater)
-        val viewModel = CreditRateListViewModel(requireContext(),creditCardSvc2,creditRateSvc,findNavController())
         bind.cvComposableTcc.apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/taxes/ListTaxCreditCard.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/taxes/ListTaxCreditCard.kt
@@ -51,7 +51,7 @@ class ListTaxCreditCard : Fragment() {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
                 MaterialThemeComposeUI {
-                    CreditRateList(viewModel = viewModel)
+                    CreditRateList(viewModel = viewModel,findNavController())
                 }
             }
         }

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/taxes/Taxes.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/taxes/Taxes.kt
@@ -56,7 +56,7 @@ class Taxes : Fragment() {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
                 MaterialThemeComposeUI {
-                    CreditRate(viewModel = viewModel)
+                    CreditRate(viewModel = viewModel,findNavController())
                 }
             }
         }

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/taxes/Taxes.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/taxes/Taxes.kt
@@ -8,6 +8,7 @@ import android.view.ViewGroup
 import androidx.annotation.RequiresApi
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.creditcard.ICreditCardPort
 import co.com.japl.finances.iports.inbounds.creditcard.ITaxPort
@@ -17,6 +18,7 @@ import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.japl.android.myapplication.databinding.FragmentTaxesBinding
 import co.japl.android.myapplication.putParams.TaxesParams
 import co.com.japl.utils.NumbersUtil
+import co.japl.android.myapplication.finanzas.controller.ViewModelFactory
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -30,6 +32,19 @@ class Taxes : Fragment() {
     private var codeCreditCard:Int? = null
     private var codeCreditRate:Int? = null
 
+    val viewModel : CreateRateViewModel by viewModels{
+        ViewModelFactory(
+            owner = this,
+            viewModelClass = CreateRateViewModel::class.java,
+            build = {
+                CreateRateViewModel(it,
+                    service,
+                    creditCardSvc)
+            }
+
+        )
+    }
+
 
     @RequiresApi(Build.VERSION_CODES.S)
     override fun onCreateView(
@@ -37,8 +52,6 @@ class Taxes : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         _binding = FragmentTaxesBinding.inflate(inflater)
-        getParameters()
-        val viewModel = CreateRateViewModel(codeCreditCard,codeCreditRate,service,creditCardSvc,findNavController())
         _binding.cvComponentFts.apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
@@ -49,19 +62,4 @@ class Taxes : Fragment() {
         }
         return _binding.root.rootView
     }
-
-    private fun getParameters(){
-        arguments?.let {
-            val params = TaxesParams.download(it)
-            codeCreditCard = if(NumbersUtil.isNumber(params.first))
-                params.first.toInt()
-            else
-                null
-            codeCreditRate = if(NumbersUtil.isNumber(params.second))
-                params.second.toInt()
-            else
-                null
-        }
-    }
-
 }

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/view/simulators/Lists.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/view/simulators/Lists.kt
@@ -72,7 +72,7 @@ private fun Body(dto: SimulatorCreditDTO, viewModel: ListViewModel, navControlle
         val viewModel = viewModel.createViewModelQuoteFix(dto, navController)
         SimulatorListCredit(viewModel)
     } else {
-        val viewModel = viewModel.createViewModelQuoteVariable(dto, navController)
+        val viewModel = viewModel.createViewModelQuoteVariable(dto)
         SimulatorList(viewModel)
     }
 }

--- a/credit/src/main/java/co/com/japl/module/credit/controllers/forms/AdditionalFormViewModel.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/controllers/forms/AdditionalFormViewModel.kt
@@ -24,7 +24,6 @@ import java.time.LocalDate
 import javax.inject.Inject
 
 class AdditionalFormViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
     private val savedStateHandle: SavedStateHandle,
     private val additionalSvc: IAdditionalFormPort
 ) : ViewModel(){
@@ -90,8 +89,8 @@ class AdditionalFormViewModel @Inject constructor(
                         if (it.create(_dto.value)) {
                             viewModelScope.launch {
                                 hostState.showSnackbar(
-                                    message = context.getString(R.string.create_record_success),
-                                    actionLabel = context.getString(R.string.close),
+                                    message = navController.context.getString(R.string.create_record_success),
+                                    actionLabel = navController.context.getString(R.string.close),
                                     duration = SnackbarDuration.Short
                                 ).also {
                                     navController.popBackStack()
@@ -100,8 +99,8 @@ class AdditionalFormViewModel @Inject constructor(
                         } else {
                             viewModelScope.launch {
                                 hostState.showSnackbar(
-                                    message = context.getString(R.string.error_record_success),
-                                    actionLabel = context.getString(R.string.close),
+                                    message = navController.context.getString(R.string.error_record_success),
+                                    actionLabel = navController.context.getString(R.string.close),
                                     duration = SnackbarDuration.Short
                                 )
                             }
@@ -110,8 +109,8 @@ class AdditionalFormViewModel @Inject constructor(
                         if (it.update(_dto.value)) {
                             viewModelScope.launch {
                                 hostState.showSnackbar(
-                                    message = context.getString(R.string.update_record_success),
-                                    actionLabel = context.getString(R.string.close),
+                                    message = navController.context.getString(R.string.update_record_success),
+                                    actionLabel = navController.context.getString(R.string.close),
                                     duration = SnackbarDuration.Short
                                 ).also {
                                     navController.popBackStack()
@@ -120,8 +119,8 @@ class AdditionalFormViewModel @Inject constructor(
                         } else {
                             viewModelScope.launch {
                                 hostState.showSnackbar(
-                                    message = context.getString(R.string.error_upd_record_success),
-                                    actionLabel = context.getString(R.string.close),
+                                    message = navController.context.getString(R.string.error_upd_record_success),
+                                    actionLabel = navController.context.getString(R.string.close),
                                     duration = SnackbarDuration.Short
                                 )
                             }
@@ -131,7 +130,7 @@ class AdditionalFormViewModel @Inject constructor(
                     viewModelScope.launch {
                         hostState.showSnackbar(
                             message = "Error: ${e.message}",
-                            actionLabel = context.getString(R.string.close),
+                            actionLabel = navController.context.getString(R.string.close),
                             duration = SnackbarDuration.Short
                         )
                     }

--- a/credit/src/main/java/co/com/japl/module/credit/controllers/forms/CreditFormViewModel.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/controllers/forms/CreditFormViewModel.kt
@@ -159,13 +159,13 @@ class CreditFormViewModel @Inject constructor(
         }
     }
 
-    fun onSubmitFormClicked(){
+    fun onSubmitFormClicked(navController: NavController){
         if(validate()){
-            executeSave()
+            executeSave(navController)
         }else{
             viewModelScope.launch {
                 snackbarHostState.showSnackbar(
-                    message = context.resources.getString(R.string.invalid_form),
+                    message = navController.context.resources.getString(R.string.invalid_form),
                     withDismissAction = true
                 )
             }
@@ -185,12 +185,12 @@ class CreditFormViewModel @Inject constructor(
         return valid.also { it.takeIf { it }?.let { executeCalculateQuote() } }
     }
 
-    fun executeSave() = CoroutineScope(Dispatchers.IO).launch {
+    fun executeSave(navController: NavController) = CoroutineScope(Dispatchers.IO).launch {
         showProgress.value = true
-        saveRunning()
+        saveRunning(navController)
     }
 
-    suspend fun saveRunning(){
+    suspend fun saveRunning(navController: NavController){
         creditSvc.save(creditDTO.value).takeIf{it > 0}?.let { code ->
             _creditDto.update {
                 it.copy(id = code)
@@ -199,7 +199,7 @@ class CreditFormViewModel @Inject constructor(
         }?.also {
             showProgress.value = false
             snackbarHostState.showSnackbar(
-                message = context.resources.getString(R.string.save_success)
+                message = navController.context.resources.getString(R.string.save_success)
             )
         }
     }
@@ -256,7 +256,7 @@ class CreditFormViewModel @Inject constructor(
         if(_creditDto.value.id <= 0) {
             viewModelScope.launch {
                 snackbarHostState.showSnackbar(
-                    message = context.resources.getString(R.string.invalid_option_amortization),
+                    message = navController.context.resources.getString(R.string.invalid_option_amortization),
                     withDismissAction = true
                 )
             }

--- a/credit/src/main/java/co/com/japl/module/credit/controllers/list/AdditionalViewModel.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/controllers/list/AdditionalViewModel.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
 @ViewModelScoped
-class AdditionalViewModel constructor(private val context: Context,private val savedStateHandle: SavedStateHandle, private val additionalSvc: IAdditional?): ViewModel(){
+class AdditionalViewModel constructor(private val savedStateHandle: SavedStateHandle, private val additionalSvc: IAdditional?): ViewModel(){
 
     val list = mutableStateListOf<AdditionalCreditDTO>()
     private val _loading = MutableStateFlow<Boolean>(false)
@@ -38,14 +38,14 @@ class AdditionalViewModel constructor(private val context: Context,private val s
         AdditionalList.navigateForm(code,navController)
     }
 
-    fun deleteAdditional(idCode:Int){
+    fun deleteAdditional(idCode:Int, navController: NavController){
         additionalSvc?.let{
             it.delete(idCode).also{ resp ->
                 viewModelScope.launch {
                     when(resp) {
                        true -> hostState.showSnackbar(
-                            message = context.getString(R.string.delete_record),
-                            actionLabel = context.getString(R.string.close),
+                            message = navController.context.getString(R.string.delete_record),
+                            actionLabel = navController.context.getString(R.string.close),
                             duration = SnackbarDuration.Short
                         ).also {
                             viewModelScope.launch {
@@ -53,8 +53,8 @@ class AdditionalViewModel constructor(private val context: Context,private val s
                             }
                        }
                         false -> hostState.showSnackbar(
-                            message = context.getString(R.string.error_delete_record),
-                            actionLabel = context.getString(R.string.close),
+                            message = navController.context.getString(R.string.error_delete_record),
+                            actionLabel = navController.context.getString(R.string.close),
                             duration = SnackbarDuration.Short
                         )
                     }

--- a/credit/src/main/java/co/com/japl/module/credit/views/creditamortization/CreditAmortizationScreen.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/views/creditamortization/CreditAmortizationScreen.kt
@@ -44,10 +44,10 @@ import co.com.japl.finances.iports.dtos.GracePeriodDTO
 import co.com.japl.finances.iports.enums.KindAmortization
 import co.com.japl.finances.iports.enums.KindOfTaxEnum
 import co.com.japl.finances.iports.enums.KindPaymentsEnums
-import co.com.japl.finances.iports.inbounds.credit.IAdditional
-import co.com.japl.finances.iports.inbounds.credit.IAmortizationTablePort
-import co.com.japl.finances.iports.inbounds.credit.ICreditPort
-import co.com.japl.finances.iports.inbounds.credit.IPeriodGracePort
+import co.com.japl.module.credit.views.fakes.FakeAdditional
+import co.com.japl.module.credit.views.fakes.FakeAmortizationTablePort
+import co.com.japl.module.credit.views.fakes.FakeCreditPort
+import co.com.japl.module.credit.views.fakes.FakePeriodGracePort
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.com.japl.ui.utils.WindowWidthSize
 import co.com.japl.utils.NumbersUtil

--- a/credit/src/main/java/co/com/japl/module/credit/views/extravalue/ExtraValueListScreen.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/views/extravalue/ExtraValueListScreen.kt
@@ -26,7 +26,7 @@ import androidx.lifecycle.SavedStateHandle
 import co.com.japl.finances.iports.dtos.ExtraValueAmortizationDTO
 import co.com.japl.module.credit.R
 import co.com.japl.module.credit.controllers.extravalue.ExtraValueListViewModel
-import co.com.japl.module.credit.views.fakesSvc.ExtraValueAmortizationCreditFake
+import co.com.japl.module.credit.views.fakes.ExtraValueAmortizationCreditFake
 import co.com.japl.ui.components.DataTable
 import co.com.japl.ui.components.FloatButton
 import co.com.japl.ui.model.datatable.Header

--- a/credit/src/main/java/co/com/japl/module/credit/views/fakes/ExtraValueAmortizationCreditFake.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/views/fakes/ExtraValueAmortizationCreditFake.kt
@@ -1,4 +1,4 @@
-package co.com.japl.module.credit.views.fakesSvc
+package co.com.japl.module.credit.views.fakes
 
 import co.com.japl.finances.iports.dtos.ExtraValueAmortizationDTO
 import co.com.japl.finances.iports.inbounds.credit.IExtraValueAmortizationCreditPort

--- a/credit/src/main/java/co/com/japl/module/credit/views/fakes/FakeAdditional.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/views/fakes/FakeAdditional.kt
@@ -1,4 +1,4 @@
-package co.com.japl.module.credit.views.creditamortization
+package co.com.japl.module.credit.views.fakes
 
 import co.com.japl.finances.iports.dtos.AdditionalCreditDTO
 import co.com.japl.finances.iports.inbounds.credit.IAdditional

--- a/credit/src/main/java/co/com/japl/module/credit/views/fakes/FakeAdditionalFormSvc.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/views/fakes/FakeAdditionalFormSvc.kt
@@ -1,4 +1,4 @@
-package co.com.japl.module.credit.views.forms
+package co.com.japl.module.credit.views.fakes
 
 import co.com.japl.finances.iports.dtos.AdditionalCreditDTO
 import co.com.japl.finances.iports.inbounds.credit.IAdditionalFormPort

--- a/credit/src/main/java/co/com/japl/module/credit/views/fakes/FakeAmortizationTablePort.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/views/fakes/FakeAmortizationTablePort.kt
@@ -1,4 +1,4 @@
-package co.com.japl.module.credit.views.creditamortization
+package co.com.japl.module.credit.views.fakes
 
 import co.com.japl.finances.iports.dtos.AmortizationRowDTO
 import co.com.japl.finances.iports.enums.KindAmortization

--- a/credit/src/main/java/co/com/japl/module/credit/views/fakes/FakeCreditFormSvc.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/views/fakes/FakeCreditFormSvc.kt
@@ -1,4 +1,4 @@
-package co.com.japl.module.credit.views.forms
+package co.com.japl.module.credit.views.fakes
 
 import co.com.japl.finances.iports.dtos.CreditDTO
 import co.com.japl.finances.iports.enums.KindOfTaxEnum

--- a/credit/src/main/java/co/com/japl/module/credit/views/fakes/FakeCreditPort.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/views/fakes/FakeCreditPort.kt
@@ -1,4 +1,4 @@
-package co.com.japl.module.credit.views.creditamortization
+package co.com.japl.module.credit.views.fakes
 
 import co.com.japl.finances.iports.dtos.CreditDTO
 import co.com.japl.finances.iports.dtos.RecapCreditDTO

--- a/credit/src/main/java/co/com/japl/module/credit/views/fakes/FakePeriodGracePort.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/views/fakes/FakePeriodGracePort.kt
@@ -1,4 +1,4 @@
-package co.com.japl.module.credit.views.creditamortization
+package co.com.japl.module.credit.views.fakes
 
 import co.com.japl.finances.iports.dtos.GracePeriodDTO
 import co.com.japl.finances.iports.inbounds.credit.IPeriodGracePort

--- a/credit/src/main/java/co/com/japl/module/credit/views/fakes/SimulatorCreditFixFake.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/views/fakes/SimulatorCreditFixFake.kt
@@ -1,4 +1,4 @@
-package co.com.japl.module.credit.views.fakesSvc
+package co.com.japl.module.credit.views.fakes
 
 import co.com.japl.finances.iports.dtos.SimulatorCreditDTO
 import co.com.japl.finances.iports.inbounds.credit.ISimulatorCreditFixPort

--- a/credit/src/main/java/co/com/japl/module/credit/views/forms/AdditionalForm.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/views/forms/AdditionalForm.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import co.com.japl.module.credit.views.fakes.FakeAdditionalFormSvc
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.com.japl.ui.theme.values.Dimensions
 import co.com.japl.ui.utils.DateUtils
@@ -132,11 +133,9 @@ private fun AdditionalFormPreview(){
 
 @Composable
 private fun getViewModel(): AdditionalFormViewModel{
-    val context = LocalContext.current
-    val navController = NavController(context)
     val savedStateHandle = SavedStateHandle()
     val additionalSvc = FakeAdditionalFormSvc()
-    val viewModel = AdditionalFormViewModel(context, savedStateHandle, additionalSvc)
+    val viewModel = AdditionalFormViewModel(savedStateHandle, additionalSvc)
     viewModel.loading.value = false
     return viewModel
 }

--- a/credit/src/main/java/co/com/japl/module/credit/views/forms/CreditForm.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/views/forms/CreditForm.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.SavedStateHandle
 import co.com.japl.finances.iports.dtos.CreditDTO
 import co.com.japl.finances.iports.inbounds.credit.ICreditFormPort
+import co.com.japl.module.credit.views.fakes.FakeCreditFormSvc
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.com.japl.ui.theme.values.Dimensions
 import co.com.japl.ui.utils.DateUtils

--- a/credit/src/main/java/co/com/japl/module/credit/views/forms/CreditForm.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/views/forms/CreditForm.kt
@@ -73,7 +73,7 @@ private fun Body(viewModel: CreditFormViewModel, navController: NavController) {
                 backView = {viewModel.backView(navController)},
                 clean = {viewModel.clean()},
                 amortization = {viewModel.amortization(navController)},
-                save = {viewModel.onSubmitFormClicked()}
+                save = {viewModel.onSubmitFormClicked(navController)}
             )
         }, snackbarHost = {
             SnackbarHost(hostState = snackbarHostState)

--- a/credit/src/main/java/co/com/japl/module/credit/views/lists/Additional.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/views/lists/Additional.kt
@@ -149,7 +149,7 @@ private  fun RowScope.RowListBody(index:Int,viewModel: AdditionalViewModel,navCo
             confirmNameButton = R.string.delete,
             onDismiss = { deleteStatus.value = false }
         ) {
-            viewModel.deleteAdditional(value.id)
+            viewModel.deleteAdditional(value.id,navController)
             deleteStatus.value = false
         }
 
@@ -213,7 +213,7 @@ private fun AdditionalPreviewNight(){
 
 @Composable
 private fun getViewModel(): AdditionalViewModel{
-    val vm = AdditionalViewModel(LocalContext.current, SavedStateHandle(),null)
+    val vm = AdditionalViewModel(SavedStateHandle(),null)
     vm.list.add(AdditionalCreditDTO(
         id = 1,
         name = "Test",

--- a/credit/src/main/java/co/com/japl/module/credit/views/simulator/Simulator.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/views/simulator/Simulator.kt
@@ -36,7 +36,7 @@ import co.com.japl.finances.iports.enums.KindOfTaxEnum
 import co.com.japl.finances.iports.inbounds.credit.ISimulatorCreditFixPort
 import co.com.japl.module.credit.R
 import co.com.japl.module.credit.controllers.simulator.SimulatorFixViewModel
-import co.com.japl.module.credit.views.fakesSvc.SimulatorCreditFixFake
+import co.com.japl.module.credit.views.fakes.SimulatorCreditFixFake
 import co.com.japl.ui.components.FieldSelect
 import co.com.japl.ui.components.FieldText
 import co.com.japl.ui.components.FieldView


### PR DESCRIPTION
This commit refactors the creation and usage of ViewModels in the credit module to follow modern Android development best practices.

- ViewModels are now created in Fragments using the `by viewModels` delegate with a custom `ViewModelProvider.Factory`.
- `NavController` is no longer injected into ViewModel constructors. Instead, it is passed as a parameter to the methods that require it for navigation or for showing `Snackbar` messages.
- `Context` dependencies in ViewModels have been removed from constructors. Methods that show `Snackbar` messages now use `navController.context`.
- All fake/mock service implementations for Composable previews have been consolidated into a single `credit/src/main/java/co/com/japl/module/credit/views/fakes` directory to improve project structure and maintain preview functionality.