### PR TITLE
Implement AI-assisted Email Pattern Generation

### DIFF
--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/emailcreditcard/form/EmailCreditCardViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/emailcreditcard/form/EmailCreditCardViewModel.kt
@@ -9,11 +9,15 @@ import androidx.lifecycle.viewModelScope
 import androidx.navigation.NavController
 import co.com.japl.finances.iports.dtos.CreditCardDTO
 import co.com.japl.finances.iports.dtos.EmailCreditCardDTO
+import android.util.Log
+import android.content.Context
 import co.com.japl.finances.iports.dtos.EmailValidationDTO
 import co.com.japl.finances.iports.enums.KindInterestRateEnum
+import co.com.japl.finances.iports.inbounds.common.ILLMService
 import co.com.japl.finances.iports.inbounds.creditcard.ICreditCardPort
 import co.com.japl.finances.iports.inbounds.creditcard.IEmailCreditCardPort
 import co.com.japl.module.creditcard.R
+import co.com.japl.ui.Prefs
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -22,7 +26,10 @@ class EmailCreditCardViewModel constructor(
     private val codeEmailCC: Int?,
     private val svc: IEmailCreditCardPort?,
     private val creditCardSvc: ICreditCardPort?,
-    private val navController: NavController?
+    private val navController: NavController?,
+    private val llmService: ILLMService? = null,
+    private val prefs: Prefs? = null,
+    private val context: Context? = null
 ) : ViewModel() {
 
     val load = mutableStateOf(true)
@@ -49,6 +56,72 @@ class EmailCreditCardViewModel constructor(
     val validating = mutableStateOf(false)
     val validationResults = mutableStateListOf<EmailValidationDTO>()
 
+    val aiFailed = mutableStateOf(false)
+    val emailSamples = mutableStateListOf<Pair<String, Boolean>>()
+    val showEmailDialog = mutableStateOf(false)
+
+    fun loadEmailSamples() {
+        if (sender.value.isNotEmpty()) {
+            viewModelScope.launch(Dispatchers.IO) {
+                svc?.getEmailList(sender.value, subjectPattern.value)?.let { list ->
+                    withContext(Dispatchers.Main) {
+                        emailSamples.clear()
+                        list.map { Pair(it, false) }.forEach(emailSamples::add)
+                        showEmailDialog.value = true
+                    }
+                }
+            }
+        }
+    }
+
+    fun generateRegexWithAI() {
+        val selectedEmails = emailSamples.filter { it.second }.map { it.first }
+        if (selectedEmails.isNotEmpty()) {
+            viewModelScope.launch(Dispatchers.IO) {
+                withContext(Dispatchers.Main) {
+                    load.value = true
+                    progress.floatValue = 0.1f
+                }
+                val prompt = context?.getString(R.string.promt_email_expreg, selectedEmails.joinToString("\n")) ?: ""
+                withContext(Dispatchers.Main) {
+                    progress.floatValue = 0.3f
+                }
+                llmService?.getAiResponse(prompt)?.onSuccess { response ->
+                    withContext(Dispatchers.Main) {
+                        progress.floatValue = 0.6f
+                        val lines = response.trim().lines()
+                        lines.forEach { line ->
+                            if (line.startsWith("SUBJECT:", ignoreCase = true)) {
+                                subjectPattern.value = line.substringAfter("SUBJECT:").trim()
+                            } else if (line.startsWith("BODY:", ignoreCase = true)) {
+                                bodyPattern.value = line.substringAfter("BODY:").trim().removeSurrounding("`").removePrefix("regex").trim()
+                            }
+                        }
+                        if (lines.size == 1 && !response.contains("SUBJECT:", ignoreCase = true)) {
+                             bodyPattern.value = response.trim().removeSurrounding("`").removePrefix("regex").trim()
+                        }
+                        progress.floatValue = 1.0f
+                        load.value = false
+                        showEmailDialog.value = false
+                        context?.let { Toast.makeText(it, R.string.ai_response, Toast.LENGTH_SHORT).show() }
+                    }
+                }?.onFailure {
+                    Log.e("EmailCCViewModel", "Error: ${it.message}")
+                    withContext(Dispatchers.Main) {
+                        aiFailed.value = true
+                        load.value = false
+                        showEmailDialog.value = false
+                        progress.floatValue = 1.0f
+                    }
+                }
+            }
+        }
+    }
+
+    fun isAIValid(): Boolean {
+        return prefs?.llmEnabled ?: false
+    }
+
     fun save() {
         validate()
         emailCreditCard?.let { dto ->
@@ -59,24 +132,24 @@ class EmailCreditCardViewModel constructor(
                         if (id > 0) {
                             emailCreditCard = dto.copy(id = id)
                             withContext(Dispatchers.Main) {
-                                Toast.makeText(navController?.context, R.string.toast_successful_insert, Toast.LENGTH_SHORT).show()
+                                context?.let { Toast.makeText(it, R.string.toast_successful_insert, Toast.LENGTH_SHORT).show() }
                                 navController?.popBackStack()
                             }
                         } else {
                             withContext(Dispatchers.Main) {
-                                Toast.makeText(navController?.context, R.string.toast_unsuccessful_insert, Toast.LENGTH_SHORT).show()
+                                context?.let { Toast.makeText(it, R.string.toast_unsuccessful_insert, Toast.LENGTH_SHORT).show() }
                             }
                         }
                     } else {
                         val result = svc?.update(dto) ?: false
                         if (result) {
                             withContext(Dispatchers.Main) {
-                                Toast.makeText(navController?.context, R.string.toast_successful_update, Toast.LENGTH_SHORT).show()
+                                context?.let { Toast.makeText(it, R.string.toast_successful_update, Toast.LENGTH_SHORT).show() }
                                 navController?.popBackStack()
                             }
                         } else {
                             withContext(Dispatchers.Main) {
-                                Toast.makeText(navController?.context, R.string.toast_dont_successful_update, Toast.LENGTH_SHORT).show()
+                                context?.let { Toast.makeText(it, R.string.toast_dont_successful_update, Toast.LENGTH_SHORT).show() }
                             }
                         }
                     }

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/email/form/EmailBought.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/email/form/EmailBought.kt
@@ -57,13 +57,17 @@ fun EmailBought(viewModel: EmailCreditCardViewModel){
     LaunchedEffect(Unit) {
         viewModel.main()
     }
+    Column (modifier =  Modifier.fillMaxWidth()){
+        if (load) {
+            LinearProgressIndicator(
+                modifier = Modifier.fillMaxWidth()
+            )
 
-    if (load) {
-        LinearProgressIndicator(
-            modifier = Modifier.fillMaxWidth()
-        )
-    } else {
-        Body(viewModel)
+            Text(text = stringResource(id = R.string.loading_data),
+                color = MaterialTheme.colorScheme.onPrimary)
+        } else {
+            Body(viewModel)
+        }
     }
 }
 

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/email/form/EmailBought.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/email/form/EmailBought.kt
@@ -24,6 +24,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -37,7 +40,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import co.com.japl.module.creditcard.R
 import co.com.japl.module.creditcard.controllers.emailcreditcard.form.EmailCreditCardViewModel
+import co.com.japl.ui.components.AlertDialogOkCancel
 import co.com.japl.ui.components.Carousel
+import co.com.japl.ui.components.CheckBoxField
 import co.com.japl.ui.components.FieldSelect
 import co.com.japl.ui.components.FieldText
 import co.com.japl.ui.components.FloatButton
@@ -82,6 +87,7 @@ private fun Body(viewModel: EmailCreditCardViewModel) {
     val isErrorBodyPattern = viewModel.errorBodyPattern
     
     val validationResult = viewModel.validationResult
+    val aiEnabled = viewModel.isAIValid()
 
     Scaffold(
         floatingActionButton = { Buttons(addClick = { viewModel.save() }, clear = { viewModel.clean() }) },
@@ -152,6 +158,18 @@ private fun Body(viewModel: EmailCreditCardViewModel) {
                 bodyPattern.value = it
             }
 
+            if (aiEnabled) {
+                Button(
+                    onClick = { viewModel.loadEmailSamples() },
+                    modifier = Modifier.align(Alignment.End).padding(top = Dimensions.PADDING_TOP)
+                ) {
+                    Text(
+                        text = stringResource(R.string.generate_by_ai),
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                }
+            }
+
             OutlinedButton(
                 onClick = { viewModel.validatePatternWithMessages() },
                 modifier = Modifier
@@ -175,6 +193,59 @@ private fun Body(viewModel: EmailCreditCardViewModel) {
     }
 
     ValidationPopup(viewModel)
+    DialogAIEmail(viewModel)
+}
+
+@Composable
+private fun DialogAIEmail(viewModel: EmailCreditCardViewModel) {
+    val showDialog = viewModel.showEmailDialog
+    val examples = viewModel.emailSamples
+    val aiFailed = viewModel.aiFailed
+
+    if (showDialog.value && examples.isNotEmpty()) {
+        AlertDialog(
+            onDismissRequest = { viewModel.showEmailDialog.value = false },
+            title = { Text(text = stringResource(R.string.select_example_email), color = MaterialTheme.colorScheme.onSurface) },
+            text = {
+                Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                    examples.forEachIndexed { index, pair ->
+                        CheckBoxField(
+                            title = pair.first,
+                            value = pair.second,
+                            callback = { viewModel.emailSamples[index] = pair.copy(second = it) }
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.showEmailDialog.value = false
+                    viewModel.generateRegexWithAI()
+                }) {
+                    Text(stringResource(R.string.generate), color = MaterialTheme.colorScheme.onSurface)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { viewModel.showEmailDialog.value = false }) {
+                    Text(stringResource(R.string.cancel), color = MaterialTheme.colorScheme.onSurface)
+                }
+            }
+        )
+    }
+    if ((showDialog.value && examples.isEmpty()) || aiFailed.value) {
+        AlertDialogOkCancel(
+            title = R.string.no_data,
+            confirmNameButton = R.string.ok,
+            onDismiss = {
+                viewModel.showEmailDialog.value = false
+                viewModel.aiFailed.value = false
+            },
+            onClick = {
+                viewModel.showEmailDialog.value = false
+                viewModel.aiFailed.value = false
+            }
+        )
+    }
 }
 
 @Composable

--- a/CreditCardModule/src/main/res/values/strings.xml
+++ b/CreditCardModule/src/main/res/values/strings.xml
@@ -116,4 +116,5 @@ Messages:
     <string name="extracted_date">Fecha: %1$s</string>
     <string name="not_extracted">No se logró extraer datos</string>
     <string name="validation_close">Cerrar</string>
+    <string name="loading_data">Cargando Data</string>
 </resources>

--- a/CreditCardModule/src/main/res/values/strings.xml
+++ b/CreditCardModule/src/main/res/values/strings.xml
@@ -70,8 +70,34 @@ If the result does not include the escape characters "" before "$" and "/", the 
 Message:
 %s
     </string>
+    <string name="promt_email_expreg">
+Act as a Java Regex compiler and Email Subject analyzer.
+
+Analyze the Email messages provided and generate:
+1. A search string for the email subject (Title Pattern) that is common to all these emails.
+2. A single, linear regular expression for the email body (Message Pattern) that captures: merchant/product name, value, and date.
+
+Technical Escaping Instructions for Body Regex (CRITICAL):
+Every dollar sign "$" must be written as "\$".
+Every forward slash "/" must be written as "\/".
+Every dot "." that must be treated as a literal must be written as "\.".
+Every comma "," that must be treated as a literal must be written as "\,".
+Every asterisk "*" that must be treated as a literal must be written as "\*".
+
+Use capture groups (?&lt;name&gt;...), (?&lt;value&gt;...), (?&lt;date&gt;...) for the Body Regex.
+
+Response Format (MANDATORY):
+SUBJECT: [title pattern]
+BODY: [body regex]
+
+Do not provide explanations or introductions.
+
+Messages:
+%s
+    </string>
     <string name="generate_by_ai">Generar con IA</string>
     <string name="select_exaple_sms">Seleccionar Ejemplo de SMS</string>
+    <string name="select_example_email">Seleccionar Ejemplo de Correo</string>
     <string name="generate">Generar</string>
     <string name="ai_response">Respuesta IA</string>
     <string name="ok">OK</string>

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/boughtcreditcard/EmailFragment.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/boughtcreditcard/EmailFragment.kt
@@ -9,11 +9,13 @@ import androidx.annotation.RequiresApi
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import co.com.japl.finances.iports.inbounds.common.ILLMService
 import co.com.japl.finances.iports.inbounds.creditcard.ICreditCardPort
 import co.com.japl.finances.iports.inbounds.creditcard.IEmailCreditCardPort
 import co.com.japl.module.creditcard.controllers.bought.forms.AdvanceViewModel
 import co.com.japl.module.creditcard.controllers.emailcreditcard.form.EmailCreditCardViewModel
 import co.com.japl.module.creditcard.views.email.form.EmailBought
+import co.com.japl.ui.Prefs
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.japl.android.myapplication.databinding.FragmentEmailCreditCardBinding
 import co.japl.android.myapplication.finanzas.controller.ViewModelFactory
@@ -27,6 +29,7 @@ class EmailFragment: Fragment(){
 
     @Inject lateinit var emailCCSvc : IEmailCreditCardPort
     @Inject lateinit var ccSvc : ICreditCardPort
+    @Inject lateinit var llmSvc : ILLMService
 
     val viewModel : EmailCreditCardViewModel by viewModels{
         ViewModelFactory(
@@ -39,6 +42,9 @@ class EmailFragment: Fragment(){
                     svc = emailCCSvc,
                     creditCardSvc = ccSvc,
                     navController = findNavController(),
+                    llmService = llmSvc,
+                    prefs = Prefs(requireContext()),
+                    context = requireContext()
                 )
             }
         )

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/adapters/inbound/implement/creditcard/EmailCreditCard.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/adapters/inbound/implement/creditcard/EmailCreditCard.kt
@@ -56,4 +56,8 @@ class EmailCreditCard @Inject constructor(val svc: IEmailCreditCard) : IEmailCre
         require(id != 0){"Id is 0"}
         return svc.clone(id)
     }
+
+    override fun getEmailList(sender: String, subject: String): List<String> {
+        return svc.getEmailList(sender, subject)
+    }
 }

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/implement/creditcard/EmailCreditCardImpl.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/implement/creditcard/EmailCreditCardImpl.kt
@@ -23,4 +23,6 @@ class EmailCreditCardImpl @Inject constructor(val svc: IEmailCreditCardPort, val
     override fun clone(id: Int): Boolean =getById(id)?.let{create(it.copy(id=0))!=0}?:false
 
     override fun validateMessagePattern(dto: EmailCreditCardDTO): List<EmailValidationDTO> = messageSvc.validateMessagePattern(dto)
+
+    override fun getEmailList(sender: String, subject: String): List<String> = messageSvc.getEmailList(sender, subject)
 }

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/interfaces/creditcard/IEmailCreditCard.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/interfaces/creditcard/IEmailCreditCard.kt
@@ -20,4 +20,6 @@ interface IEmailCreditCard {
     fun clone(id: Int): Boolean
 
     fun validateMessagePattern(dto: EmailCreditCardDTO): List<EmailValidationDTO>
+
+    fun getEmailList(sender: String, subject: String): List<String>
 }

--- a/japl-android-finances-services/src/main/java/co/japl/android/finances/services/implement/EmailCreditCardPatternImpl.kt
+++ b/japl-android-finances-services/src/main/java/co/japl/android/finances/services/implement/EmailCreditCardPatternImpl.kt
@@ -32,4 +32,8 @@ class EmailCreditCardPatternImpl @Inject constructor(private val emailRead: IEma
             }
         }
     }
+
+    override fun getEmailList(sender: String, subject: String): List<String> {
+        return emailRead.getEmails(sender, subject)
+    }
 }

--- a/japl-finances-iports/src/main/java/co/com/japl/finances/iports/inbounds/creditcard/IEmailCreditCardPort.kt
+++ b/japl-finances-iports/src/main/java/co/com/japl/finances/iports/inbounds/creditcard/IEmailCreditCardPort.kt
@@ -21,4 +21,5 @@ interface IEmailCreditCardPort{
 
     fun clone(id:Int):Boolean
 
+    fun getEmailList(sender: String, subject: String): List<String>
 }

--- a/japl-finances-iports/src/main/java/co/com/japl/finances/iports/outbounds/IEmailCreditCardPattern.kt
+++ b/japl-finances-iports/src/main/java/co/com/japl/finances/iports/outbounds/IEmailCreditCardPattern.kt
@@ -6,4 +6,6 @@ import co.com.japl.finances.iports.dtos.EmailValidationDTO
 interface IEmailCreditCardPattern {
 
     fun validateMessagePattern(dto: EmailCreditCardDTO): List<EmailValidationDTO>
+
+    fun getEmailList(sender: String, subject: String): List<String>
 }


### PR DESCRIPTION
This change implements AI-assisted pattern generation for Email Credit Card purchases. It allows users to fetch sample emails from Gmail, select relevant ones, and use an LLM to generate both the Subject and Body regex patterns. The implementation follows the hexagonal architecture pattern, updating ports, use cases, and adapters. It also enhances the UI with a new selection dialog and "Generate with AI" button.

---
*PR created automatically by Jules for task [15719888190861729611](https://jules.google.com/task/15719888190861729611) started by @nano871022*