### PR TITLE
Implement SMS Pattern Validation Popup

### DIFF
--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/smscreditcard/form/SmsCreditCardViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/smscreditcard/form/SmsCreditCardViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.NavController
 import co.com.japl.finances.iports.dtos.CreditCardDTO
+import co.com.japl.finances.iports.dtos.EmailValidationDTO
 import co.com.japl.finances.iports.dtos.SMSCreditCard
 import co.com.japl.finances.iports.enums.KindInterestRateEnum
 import co.com.japl.finances.iports.inbounds.common.ILLMService
@@ -21,6 +22,7 @@ import com.google.android.material.snackbar.BaseTransientBottomBar
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import kotlin.time.Duration
 
 class SmsCreditCardViewModel constructor(private val codeSMSCC:Int?,private val svc:ISMSCreditCardPort?,private val creditCardSvc:ICreditCardPort?,private val navController: NavController?, private val llmService: ILLMService? = null, private val prefs: Prefs?=null): ViewModel() {
@@ -44,6 +46,9 @@ class SmsCreditCardViewModel constructor(private val codeSMSCC:Int?,private val 
     val pattern = mutableStateOf("")
     val errorPattern = mutableStateOf(false)
     val validationResult = mutableStateOf("")
+    val showPopup = mutableStateOf(false)
+    val validating = mutableStateOf(false)
+    val validationResults = mutableStateListOf<EmailValidationDTO>()
 
     val validate = mutableStateOf("")
 
@@ -132,16 +137,30 @@ class SmsCreditCardViewModel constructor(private val codeSMSCC:Int?,private val 
     fun validatePatternWithMessages() {
         validate()
         smsCreditCard?.let { dto ->
-            svc?.let {
-                validationResult.value = ""
+            viewModelScope.launch(Dispatchers.IO) {
+                withContext(Dispatchers.Main) {
+                    validating.value = true
+                    showPopup.value = true
+                    validationResults.clear()
+                    validationResult.value = ""
+                }
                 runCatching {
-                    it.validateMessagePattern(dto)
-                }.onFailure {
-                    validationResult.value = "Error: ${it.message}"
-                }.onSuccess {
-                    it?.takeIf { it.isNotEmpty() }?.forEach {
-                        validationResult.value += it + "\n\n"
-                    } ?: validationResult.let { it.value = "Not found sms" }
+                    svc?.validateMessagePattern(dto) ?: emptyList()
+                }.onFailure { e ->
+                    withContext(Dispatchers.Main) {
+                        validating.value = false
+                        validationResult.value = "Error: ${e.message}"
+                    }
+                }.onSuccess { list ->
+                    withContext(Dispatchers.Main) {
+                        validating.value = false
+                        validationResults.addAll(list)
+                        if (list.isNotEmpty()) {
+                            validationResult.value = "Success"
+                        } else {
+                            validationResult.value = "Not found sms"
+                        }
+                    }
                 }
             }
         }
@@ -186,10 +205,16 @@ class SmsCreditCardViewModel constructor(private val codeSMSCC:Int?,private val 
         }
     }
 
-    fun main() = runBlocking {
-        progress.floatValue = 0.1f
-        execute()
-        progress.floatValue = 1.0f
+    fun main() {
+        viewModelScope.launch(Dispatchers.IO) {
+            withContext(Dispatchers.Main) {
+                progress.floatValue = 0.1f
+            }
+            execute()
+            withContext(Dispatchers.Main) {
+                progress.floatValue = 1.0f
+            }
+        }
     }
 
     suspend fun execute(){

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/sms/forms/SMS.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/sms/forms/SMS.kt
@@ -3,9 +3,14 @@ package co.com.japl.module.creditcard.views.sms.forms
 import android.content.res.Configuration
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Icon
@@ -22,8 +27,12 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.Button
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.tooling.preview.Preview
 import co.com.japl.module.creditcard.controllers.smscreditcard.form.SmsCreditCardViewModel
 import co.com.japl.ui.theme.MaterialThemeComposeUI
@@ -35,22 +44,21 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import co.com.japl.module.creditcard.R
 import co.com.japl.ui.components.AlertDialogOkCancel
+import co.com.japl.ui.components.Carousel
 import co.com.japl.ui.components.FieldSelect
 import co.com.japl.ui.components.FieldText
 import co.com.japl.ui.components.FloatButton
+import co.com.japl.ui.components.Popup
 import co.com.japl.ui.components.CheckBoxField
 import co.com.japl.ui.theme.values.Dimensions
 import co.com.japl.ui.theme.values.ModifiersCustom.Weight1f
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 
 @Composable
 fun Sms(viewModel:SmsCreditCardViewModel){
     val load by remember {viewModel.load}
     var progress  by remember {viewModel.progress}
 
-    CoroutineScope(Dispatchers.IO).launch {
+    LaunchedEffect(Unit) {
         viewModel.main()
     }
     if(load){
@@ -168,21 +176,128 @@ private fun Body(viewModel: SmsCreditCardViewModel,modifier:Modifier){
               , textAlign = TextAlign.Center
               ,modifier=Weight1f())
       }
-
-    FieldText(title = stringResource(id = R.string.validate)
-          , value = validationResult.value,
-          lines = 6,
-            icon = Icons.Rounded.Cancel,
-        callback = {
-            validationResult.value = it
-        },
-          readOnly = true,
-          modifier = modifier)
-
-
   }
+    ValidationPopup(viewModel)
     DialogAIExpReg(viewModel)
 
+}
+
+@Composable
+private fun ValidationPopup(viewModel: SmsCreditCardViewModel) {
+    val showPopup = remember { viewModel.showPopup }
+    val validating = remember { viewModel.validating }
+    val validationResults = remember { viewModel.validationResults }
+
+    Popup(title = R.string.validation_results_title, state = showPopup) {
+        Column(
+            modifier = Modifier
+                .padding(Dimensions.PADDING_SHORT)
+                .fillMaxWidth()
+        ) {
+            if (validating.value) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(50.dp),
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                }
+            } else {
+                if (validationResults.isEmpty() && viewModel.validationResult.value.isNotEmpty()) {
+                    Text(
+                        text = viewModel.validationResult.value,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.padding(Dimensions.PADDING_SHORT)
+                    )
+                } else {
+                    Carousel(
+                        size = validationResults.size,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(200.dp)
+                    ) { index ->
+                        val result = validationResults[index]
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(Dimensions.PADDING_SHORT)
+                        ) {
+                            if (result.matched) {
+                                Text(
+                                    text = stringResource(
+                                        id = R.string.extracted_name,
+                                        result.name ?: ""
+                                    ),
+                                    color = MaterialTheme.colorScheme.onSurface
+                                )
+                                Text(
+                                    text = stringResource(
+                                        id = R.string.extracted_value,
+                                        result.value ?: ""
+                                    ),
+                                    color = MaterialTheme.colorScheme.onSurface
+                                )
+                                Text(
+                                    text = stringResource(
+                                        id = R.string.extracted_date,
+                                        result.date ?: ""
+                                    ),
+                                    color = MaterialTheme.colorScheme.onSurface
+                                )
+                                Text(
+                                    text = result.bodySnippet,
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                    style = MaterialTheme.typography.bodySmall
+                                )
+                            } else {
+                                Text(
+                                    text = stringResource(id = R.string.not_extracted),
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                    style = MaterialTheme.typography.titleMedium
+                                )
+                                Spacer(modifier = Modifier.height(Dimensions.PADDING_SHORT))
+                                Text(
+                                    text = result.bodySnippet,
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                    style = MaterialTheme.typography.bodySmall
+                                )
+                            }
+                        }
+                    }
+
+                    HorizontalDivider(modifier = Modifier.padding(vertical = Dimensions.PADDING_SHORT))
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = stringResource(id = R.string.sms_found, validationResults.size),
+                            color = MaterialTheme.colorScheme.onSurface,
+                            modifier = Modifier.weight(1f)
+                        )
+                        Text(
+                            text = stringResource(
+                                id = R.string.sms_matched,
+                                validationResults.count { it.matched }),
+                            color = MaterialTheme.colorScheme.onSurface,
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(Dimensions.PADDING_SHORT))
+
+                OutlinedButton(onClick = { showPopup.value = false }, modifier = Modifier.align(Alignment.End)) {
+                    Text(text = stringResource(id = R.string.validation_close), color = MaterialTheme.colorScheme.onSurface)
+                }
+            }
+        }
+    }
 }
 
 @Composable

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/sms/forms/SMS.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/sms/forms/SMS.kt
@@ -63,7 +63,6 @@ fun Sms(viewModel:SmsCreditCardViewModel){
     }
     if(load){
         LinearProgressIndicator(
-            progress = { progress },
             modifier = Modifier.fillMaxWidth(),
         )
     }else{

--- a/CreditCardModule/src/main/res/values/strings.xml
+++ b/CreditCardModule/src/main/res/values/strings.xml
@@ -111,6 +111,8 @@ Messages:
     <string name="validation_results_title">Resultados de Validación</string>
     <string name="emails_found">Correos encontrados: %1$d</string>
     <string name="emails_matched">Coincidencias: %1$d</string>
+    <string name="sms_found">SMS encontrados: %1$d</string>
+    <string name="sms_matched">Coincidencias: %1$d</string>
     <string name="extracted_name">Nombre: %1$s</string>
     <string name="extracted_value">Valor: %1$s</string>
     <string name="extracted_date">Fecha: %1$s</string>

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/modules/AbstractModule.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/modules/AbstractModule.kt
@@ -117,7 +117,7 @@ import co.japl.finances.core.usercases.interfaces.creditcard.bought.lists.IBough
 import co.japl.finances.core.usercases.interfaces.creditcard.paid.lists.IPaidList
 import co.japl.finances.core.usercases.interfaces.paid.IProjection
 import co.japl.finances.core.usercases.interfaces.paid.ISMSOld
-import co.japl.finances.core.usercases.interfaces.paid.ISms
+import co.japl.finances.core.usercases.interfaces.paid.ISms2
 import co.japl.finances.core.usercases.interfaces.recap.IRecap
 import co.japl.finances.core.adapters.inbound.implement.creditcard.EmailCreditCard
 import co.japl.finances.core.usercases.implement.creditcard.EmailCreditCardImpl
@@ -384,7 +384,7 @@ abstract class AbstractModule {
     abstract fun bindInboundSmsPaidPort(svc:SMSImpl):ISmsPort
 
     @Binds
-    abstract fun bindUserCaseSmsPaid(svc:co.japl.finances.core.usercases.implement.paid.PaidImpl):ISms
+    abstract fun bindUserCaseSmsPaid(svc:co.japl.finances.core.usercases.implement.paid.PaidImpl):ISms2
 
     @Binds
     abstract fun bindInboundPaidCheckPaymentPort(svc:co.japl.finances.core.adapters.inbound.implement.paid.CheckPaymentImpl):ICheckPaymentPort

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/adapters/inbound/implement/creditcard/SMSCreditCardImpl.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/adapters/inbound/implement/creditcard/SMSCreditCardImpl.kt
@@ -28,7 +28,7 @@ class SMSCreditCardImpl @Inject constructor(private val svc:ISMSCreditCard) : IS
         return svc.getById(codeSMSCreditCard)
     }
 
-    override fun validateMessagePattern(dto: SMSCreditCard): List<String> {
+    override fun validateMessagePattern(dto: SMSCreditCard): List<co.com.japl.finances.iports.dtos.EmailValidationDTO> {
         return svc.validateMessagePattern(dto)
     }
 

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/adapters/inbound/implement/paid/SMSImpl.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/adapters/inbound/implement/paid/SMSImpl.kt
@@ -31,7 +31,7 @@ class SMSImpl @Inject constructor(private val svc:ISMSOld, private val smsSvc:IS
         return svc.getById(codeSMSPaidDTO)
     }
 
-    override fun validateMessagePattern(dto: SMSPaidDTO): List<String> {
+    override fun validateMessagePattern(dto: SMSPaidDTO): List<co.com.japl.finances.iports.dtos.EmailValidationDTO> {
         return svc.validateMessagePattern(dto)
     }
 

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/adapters/inbound/implement/paid/SMSImpl.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/adapters/inbound/implement/paid/SMSImpl.kt
@@ -6,11 +6,11 @@ import co.com.japl.finances.iports.enums.KindInterestRateEnum
 import co.com.japl.finances.iports.inbounds.paid.ISMSPaidPort
 import co.com.japl.finances.iports.inbounds.paid.ISmsPort
 import co.japl.finances.core.usercases.interfaces.paid.ISMSOld
-import co.japl.finances.core.usercases.interfaces.paid.ISms
+import co.japl.finances.core.usercases.interfaces.paid.ISms2
 import java.time.LocalDateTime
 import javax.inject.Inject
 
-class SMSImpl @Inject constructor(private val svc:ISMSOld, private val smsSvc:ISms) : ISMSPaidPort , ISmsPort{
+class SMSImpl @Inject constructor(private val svc:ISMSOld, private val smsSvc: ISms2) : ISMSPaidPort , ISmsPort{
     override fun create(dto: SMSPaidDTO): Int {
         require(dto.id == 0){"Id must be zero"}
         return svc.create(dto)

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/implement/creditcard/SMSCreditCardImpl.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/implement/creditcard/SMSCreditCardImpl.kt
@@ -1,5 +1,6 @@
 package co.japl.finances.core.usercases.implement.creditcard
 
+import co.com.japl.finances.iports.dtos.EmailValidationDTO
 import co.com.japl.finances.iports.dtos.SMSCreditCard
 import co.com.japl.finances.iports.enums.KindInterestRateEnum
 import co.com.japl.finances.iports.inbounds.common.ISMSRead
@@ -28,19 +29,20 @@ class SMSCreditCardImpl @Inject constructor(private val svc:ISMSCreditCardPort, 
         return svc.getById(codeSMSCreditCard)
     }
 
-    override fun validateMessagePattern(dto: SMSCreditCard): List<String> {
-        val list = mutableListOf<String>()
+    override fun validateMessagePattern(dto: SMSCreditCard): List<EmailValidationDTO> {
+        val list = mutableListOf<EmailValidationDTO>()
         smsSvc.load(dto.phoneNumber,360).takeIf{it.isNotEmpty()}?.forEach{sms->
             if(dto.pattern.isNotEmpty() && dto.pattern.toRegex().containsMatchIn(sms)){
                 dto.pattern.toRegex().find(sms)?.let{
-                    if(it.groupValues.size > 3){
-                        list.add("OK ${it.groupValues}")
+                    val values = SmsUtil.getValues(it.groupValues)
+                    if(values != null){
+                        list.add(EmailValidationDTO(name = values.first, value = values.second.toString(), date = values.third.toString(), matched = true, bodySnippet = sms.take(100).replace("\n", " ")))
                     }else{
-                        list.add("Not enough values get Name Bought, Price and Date $sms")
+                        list.add(EmailValidationDTO(matched = false, bodySnippet = sms.take(100).replace("\n", " ")))
                     }
-                }?:list.add("Not matched $sms")
+                }?:list.add(EmailValidationDTO(matched = false, bodySnippet = sms.take(100).replace("\n", " ")))
             }else{
-                list.add("Not matched $sms")
+                list.add(EmailValidationDTO(matched = false, bodySnippet = sms.take(100).replace("\n", " ")))
             }
         }
         return list

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/implement/paid/PaidImpl.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/implement/paid/PaidImpl.kt
@@ -5,12 +5,13 @@ import co.com.japl.finances.iports.dtos.PaidRecapDTO
 import co.com.japl.finances.iports.outbounds.IPaidPort
 import co.com.japl.finances.iports.outbounds.IPaidRecapPort
 import co.japl.finances.core.usercases.interfaces.paid.IPaid
-import co.japl.finances.core.usercases.interfaces.paid.ISms
+
+import co.japl.finances.core.usercases.interfaces.paid.ISms2
 import java.time.LocalDateTime
 import java.time.YearMonth
 import javax.inject.Inject
 
-class PaidImpl @Inject constructor(private val recapSvc: IPaidRecapPort,private val paidSvc:IPaidPort)   : IPaid , ISms{
+class PaidImpl @Inject constructor(private val recapSvc: IPaidRecapPort,private val paidSvc:IPaidPort)   : IPaid , ISms2{
     override fun get(codeAccount: Int, period: YearMonth): List<PaidDTO> {
 
         return paidSvc.getActivePaid(codeAccount, period)

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/implement/paid/SMSImpl.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/implement/paid/SMSImpl.kt
@@ -1,5 +1,6 @@
 package co.japl.finances.core.usercases.implement.paid
 
+import co.com.japl.finances.iports.dtos.EmailValidationDTO
 import co.com.japl.finances.iports.dtos.SMSPaidDTO
 import co.com.japl.finances.iports.inbounds.common.ISMSRead
 import co.com.japl.finances.iports.outbounds.ISMSPaidPort
@@ -27,19 +28,20 @@ class SMSImpl @Inject constructor(private val svc:ISMSPaidPort, private val smsS
         return svc.getById(codeSMSPaidDTO)
     }
 
-    override fun validateMessagePattern(dto: SMSPaidDTO): List<String> {
-        val list = mutableListOf<String>()
+    override fun validateMessagePattern(dto: SMSPaidDTO): List<EmailValidationDTO> {
+        val list = mutableListOf<EmailValidationDTO>()
         smsSvc.load(dto.phoneNumber,360).takeIf{it.isNotEmpty()}?.forEach{sms->
             if(dto.pattern.isNotEmpty() && dto.pattern.toRegex().containsMatchIn(sms)){
                 dto.pattern.toRegex().find(sms)?.let{
-                    if(it.groupValues.size > 3){
-                        list.add("OK ${it.groupValues}")
+                    val values = SmsUtil.getValues(it.groupValues)
+                    if(values != null){
+                        list.add(EmailValidationDTO(name = values.first, value = values.second.toString(), date = values.third.toString(), matched = true, bodySnippet = sms.take(100).replace("\n", " ")))
                     }else{
-                        list.add("Not enough values get Name Bought, Price and Date $sms")
+                        list.add(EmailValidationDTO(matched = false, bodySnippet = sms.take(100).replace("\n", " ")))
                     }
-                }?:list.add("Not matched $sms")
+                }?:list.add(EmailValidationDTO(matched = false, bodySnippet = sms.take(100).replace("\n", " ")))
             }else{
-                list.add("Not matched $sms")
+                list.add(EmailValidationDTO(matched = false, bodySnippet = sms.take(100).replace("\n", " ")))
             }
         }
         return list

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/interfaces/creditcard/ISMSCreditCard.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/interfaces/creditcard/ISMSCreditCard.kt
@@ -1,5 +1,6 @@
 package co.japl.finances.core.usercases.interfaces.creditcard
 
+import co.com.japl.finances.iports.dtos.EmailValidationDTO
 import co.com.japl.finances.iports.dtos.SMSCreditCard
 import co.com.japl.finances.iports.enums.KindInterestRateEnum
 import java.time.LocalDateTime
@@ -14,7 +15,7 @@ interface ISMSCreditCard {
 
     fun getById(codeSMSCreditCard: Int): SMSCreditCard?
 
-    fun validateMessagePattern(dto: SMSCreditCard): List<String>
+    fun validateMessagePattern(dto: SMSCreditCard): List<EmailValidationDTO>
 
     fun getAllByCodeCreditCard(codeCreditCard: Int): List<SMSCreditCard>
 

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/interfaces/paid/ISMS.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/interfaces/paid/ISMS.kt
@@ -1,5 +1,6 @@
 package co.japl.finances.core.usercases.interfaces.paid
 
+import co.com.japl.finances.iports.dtos.EmailValidationDTO
 import co.com.japl.finances.iports.dtos.SMSPaidDTO
 import co.com.japl.finances.iports.enums.KindInterestRateEnum
 import java.time.LocalDateTime
@@ -14,7 +15,7 @@ interface ISMS {
 
     fun getById(codeSMSPaidDTO: Int): SMSPaidDTO?
 
-    fun validateMessagePattern(dto: SMSPaidDTO): List<String>
+    fun validateMessagePattern(dto: SMSPaidDTO): List<EmailValidationDTO>
 
     fun getAllByCodeAccount(codeAccount: Int): List<SMSPaidDTO>
 

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/interfaces/paid/ISMSOld.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/interfaces/paid/ISMSOld.kt
@@ -1,5 +1,6 @@
 package co.japl.finances.core.usercases.interfaces.paid
 
+import co.com.japl.finances.iports.dtos.EmailValidationDTO
 import co.com.japl.finances.iports.dtos.SMSPaidDTO
 import co.com.japl.finances.iports.enums.KindInterestRateEnum
 import java.time.LocalDateTime
@@ -14,7 +15,7 @@ interface ISMSOld {
 
     fun getById(codeSMSPaidDTO: Int): SMSPaidDTO?
 
-    fun validateMessagePattern(dto: SMSPaidDTO): List<String>
+    fun validateMessagePattern(dto: SMSPaidDTO): List<EmailValidationDTO>
 
     fun getAllByCodeAccount(codeAccount: Int): List<SMSPaidDTO>
 

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/interfaces/paid/ISms.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/interfaces/paid/ISms.kt
@@ -1,10 +1,29 @@
 package co.japl.finances.core.usercases.interfaces.paid
 
-import co.com.japl.finances.iports.dtos.PaidDTO
 import co.com.japl.finances.iports.dtos.SMSPaidDTO
+import co.com.japl.finances.iports.enums.KindInterestRateEnum
 import java.time.LocalDateTime
 
-interface ISms {
-    fun createBySms(dto: PaidDTO): Boolean
+interface ISMS {
 
+    fun create(dto: SMSPaidDTO): Int
+
+    fun update(dto: SMSPaidDTO): Boolean
+
+    fun delete(codeSMSPaidDTO: Int): Boolean
+
+    fun getById(codeSMSPaidDTO: Int): SMSPaidDTO?
+
+    fun validateMessagePattern(dto: SMSPaidDTO): List<String>
+
+    fun getAllByCodeAccount(codeAccount: Int): List<SMSPaidDTO>
+
+    fun getSmsMessages(
+        phoneNumber: String,
+        pattern: String,numDaysRead:Int
+    ): List<Triple<String, Double, LocalDateTime>>
+
+    fun enable(codeSMSPaidDTO: Int): Boolean
+
+    fun disable(codeSMSPaidDTO: Int): Boolean
 }

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/interfaces/paid/ISms2.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/interfaces/paid/ISms2.kt
@@ -1,0 +1,10 @@
+package co.japl.finances.core.usercases.interfaces.paid
+
+import co.com.japl.finances.iports.dtos.PaidDTO
+import co.com.japl.finances.iports.dtos.SMSPaidDTO
+import java.time.LocalDateTime
+
+interface ISms2 {
+    fun createBySms(dto: PaidDTO): Boolean
+
+}

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/sms/form/SmsViewModel.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/sms/form/SmsViewModel.kt
@@ -19,6 +19,7 @@ import co.com.japl.ui.Prefs
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 
 class SmsViewModel constructor(private val codeSMS:Int?, private val svc:ISMSPaidPort?, private val accountSvc:IAccountPort?, private val navController: NavController?, private val llmService: ILLMService? = null, val prefs: Prefs?=null): ViewModel() {
 

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/sms/form/SmsViewModel.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/sms/form/SmsViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.NavController
 import co.com.japl.finances.iports.dtos.AccountDTO
+import co.com.japl.finances.iports.dtos.EmailValidationDTO
 import co.com.japl.finances.iports.dtos.SMSPaidDTO
 import co.com.japl.finances.iports.enums.KindInterestRateEnum
 import co.com.japl.finances.iports.inbounds.common.ILLMService
@@ -15,7 +16,6 @@ import co.com.japl.finances.iports.inbounds.inputs.IAccountPort
 import co.com.japl.finances.iports.inbounds.paid.ISMSPaidPort
 import co.com.japl.module.paid.R
 import co.com.japl.ui.Prefs
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -38,6 +38,9 @@ class SmsViewModel constructor(private val codeSMS:Int?, private val svc:ISMSPai
     val pattern = mutableStateOf("")
     val errorPattern = mutableStateOf(false)
     val validationResult = mutableStateOf("")
+    val showPopup = mutableStateOf(false)
+    val validating = mutableStateOf(false)
+    val validationResults = mutableStateListOf<EmailValidationDTO>()
 
     val validate = mutableStateOf("")
 
@@ -123,11 +126,31 @@ class SmsViewModel constructor(private val codeSMS:Int?, private val svc:ISMSPai
     fun validatePatternWithMessages(){
         validate()
         smsPaid?.let {dto->
-            svc?.let{
-                validationResult.value = ""
-                it.validateMessagePattern(dto)?.takeIf { it.isNotEmpty() }?.forEach{
-                    validationResult.value += it+"\n\n"
-                }?:validationResult.let{it.value = "Not found sms"}
+            viewModelScope.launch(Dispatchers.IO) {
+                withContext(Dispatchers.Main) {
+                    validating.value = true
+                    showPopup.value = true
+                    validationResults.clear()
+                    validationResult.value = ""
+                }
+                runCatching {
+                    svc?.validateMessagePattern(dto) ?: emptyList()
+                }.onFailure { e ->
+                    withContext(Dispatchers.Main) {
+                        validating.value = false
+                        validationResult.value = "Error: ${e.message}"
+                    }
+                }.onSuccess { list ->
+                    withContext(Dispatchers.Main) {
+                        validating.value = false
+                        validationResults.addAll(list)
+                        if (list.isNotEmpty()) {
+                            validationResult.value = "Success"
+                        } else {
+                            validationResult.value = "Not found sms"
+                        }
+                    }
+                }
             }
         }
     }
@@ -164,10 +187,16 @@ class SmsViewModel constructor(private val codeSMS:Int?, private val svc:ISMSPai
         }
     }
 
-    fun main() = runBlocking {
-        progress.floatValue = 0.1f
-        execute()
-        progress.floatValue = 1.0f
+    fun main() {
+        viewModelScope.launch(Dispatchers.IO) {
+            withContext(Dispatchers.Main) {
+                progress.floatValue = 0.1f
+            }
+            execute()
+            withContext(Dispatchers.Main) {
+                progress.floatValue = 1.0f
+            }
+        }
     }
 
     suspend fun execute(){

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/sms/form/SMS.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/sms/form/SMS.kt
@@ -63,7 +63,6 @@ fun Sms(viewModel:SmsViewModel){
     }
     if(load){
         LinearProgressIndicator(
-            progress = { progress },
             modifier = Modifier.fillMaxWidth(),
         )
     }else{

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/sms/form/SMS.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/sms/form/SMS.kt
@@ -3,9 +3,14 @@ package co.com.japl.module.paid.views.sms.form
 import android.content.res.Configuration
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Icon
@@ -18,12 +23,16 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.Button
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material.icons.automirrored.rounded.DirectionsRun
 import androidx.compose.material.icons.rounded.Cancel
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.tooling.preview.Preview
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import  androidx.compose.runtime.getValue
@@ -35,22 +44,21 @@ import androidx.compose.ui.text.style.TextAlign
 import co.com.japl.module.paid.R
 import co.com.japl.module.paid.controllers.sms.form.SmsViewModel
 import co.com.japl.ui.components.AlertDialogOkCancel
+import co.com.japl.ui.components.Carousel
 import co.com.japl.ui.components.FieldSelect
 import co.com.japl.ui.components.FieldText
 import co.com.japl.ui.components.FloatButton
+import co.com.japl.ui.components.Popup
 import co.com.japl.ui.components.CheckBoxField
 import co.com.japl.ui.theme.values.Dimensions
 import co.com.japl.ui.theme.values.ModifiersCustom.Weight1f
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 
 @Composable
 fun Sms(viewModel:SmsViewModel){
     val load by remember {viewModel.load}
     var progress  by remember {viewModel.progress}
 
-    CoroutineScope(Dispatchers.IO).launch {
+    LaunchedEffect(Unit) {
         viewModel.main()
     }
     if(load){
@@ -160,19 +168,127 @@ private fun Body(viewModel: SmsViewModel,modifier:Modifier) {
                 modifier = Weight1f()
             )
         }
-
-        FieldText(
-            title = stringResource(id = R.string.validate), value = validationResult.value,
-            lines = 6,
-            icon = Icons.Rounded.Cancel,
-            callback = {
-                validationResult.value = it
-            },
-            readOnly = true,
-            modifier = modifier
-        )
     }
+    ValidationPopup(viewModel)
     AIDialog(viewModel)
+}
+
+@Composable
+private fun ValidationPopup(viewModel: SmsViewModel) {
+    val showPopup = remember { viewModel.showPopup }
+    val validating = remember { viewModel.validating }
+    val validationResults = remember { viewModel.validationResults }
+
+    Popup(title = R.string.validation_results_title, state = showPopup) {
+        Column(
+            modifier = Modifier
+                .padding(Dimensions.PADDING_SHORT)
+                .fillMaxWidth()
+        ) {
+            if (validating.value) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(50.dp),
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                }
+            } else {
+                if (validationResults.isEmpty() && viewModel.validationResult.value.isNotEmpty()) {
+                    Text(
+                        text = viewModel.validationResult.value,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.padding(Dimensions.PADDING_SHORT)
+                    )
+                } else {
+                    Carousel(
+                        size = validationResults.size,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(200.dp)
+                    ) { index ->
+                        val result = validationResults[index]
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(Dimensions.PADDING_SHORT)
+                        ) {
+                            if (result.matched) {
+                                Text(
+                                    text = stringResource(
+                                        id = R.string.extracted_name,
+                                        result.name ?: ""
+                                    ),
+                                    color = MaterialTheme.colorScheme.onSurface
+                                )
+                                Text(
+                                    text = stringResource(
+                                        id = R.string.extracted_value,
+                                        result.value ?: ""
+                                    ),
+                                    color = MaterialTheme.colorScheme.onSurface
+                                )
+                                Text(
+                                    text = stringResource(
+                                        id = R.string.extracted_date,
+                                        result.date ?: ""
+                                    ),
+                                    color = MaterialTheme.colorScheme.onSurface
+                                )
+                                Text(
+                                    text = result.bodySnippet,
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                    style = MaterialTheme.typography.bodySmall
+                                )
+                            } else {
+                                Text(
+                                    text = stringResource(id = R.string.not_extracted),
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                    style = MaterialTheme.typography.titleMedium
+                                )
+                                Spacer(modifier = Modifier.height(Dimensions.PADDING_SHORT))
+                                Text(
+                                    text = result.bodySnippet,
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                    style = MaterialTheme.typography.bodySmall
+                                )
+                            }
+                        }
+                    }
+
+                    HorizontalDivider(modifier = Modifier.padding(vertical = Dimensions.PADDING_SHORT))
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = stringResource(id = R.string.sms_found, validationResults.size),
+                            color = MaterialTheme.colorScheme.onSurface,
+                            modifier = Modifier.weight(1f)
+                        )
+                        Text(
+                            text = stringResource(
+                                id = R.string.sms_matched,
+                                validationResults.count { it.matched }),
+                            color = MaterialTheme.colorScheme.onSurface,
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(Dimensions.PADDING_SHORT))
+
+                OutlinedButton(onClick = { showPopup.value = false }, modifier = Modifier.align(Alignment.End)) {
+                    Text(text = stringResource(id = R.string.validation_close), color = MaterialTheme.colorScheme.onSurface)
+                }
+            }
+        }
+    }
 }
 
 @Composable

--- a/japl-android-finances-paid-module/src/main/res/values/strings.xml
+++ b/japl-android-finances-paid-module/src/main/res/values/strings.xml
@@ -72,4 +72,12 @@ Message:
 %s
     </string>
     <string name="download_sms">Descargar SMS</string>
+    <string name="validation_results_title">Resultados de Validación</string>
+    <string name="sms_found">SMS encontrados: %1$d</string>
+    <string name="sms_matched">Coincidencias: %1$d</string>
+    <string name="extracted_name">Nombre: %1$s</string>
+    <string name="extracted_value">Valor: %1$s</string>
+    <string name="extracted_date">Fecha: %1$s</string>
+    <string name="not_extracted">No se logró extraer datos</string>
+    <string name="validation_close">Cerrar</string>
 </resources>

--- a/japl-finances-iports/src/main/java/co/com/japl/finances/iports/inbounds/creditcard/ISMSCreditCardPort.kt
+++ b/japl-finances-iports/src/main/java/co/com/japl/finances/iports/inbounds/creditcard/ISMSCreditCardPort.kt
@@ -1,5 +1,6 @@
 package co.com.japl.finances.iports.inbounds.creditcard
 
+import co.com.japl.finances.iports.dtos.EmailValidationDTO
 import co.com.japl.finances.iports.dtos.SMSCreditCard
 import co.com.japl.finances.iports.enums.KindInterestRateEnum
 import java.time.LocalDateTime
@@ -14,7 +15,7 @@ interface ISMSCreditCardPort{
 
     fun getById(codeSMSCreditCard: Int):SMSCreditCard?
 
-    fun validateMessagePattern(dto:SMSCreditCard):List<String>
+    fun validateMessagePattern(dto:SMSCreditCard):List<EmailValidationDTO>
 
     fun getByCreditCardAndKindInterest(codeCreditCard:Int,kind: KindInterestRateEnum):List<SMSCreditCard>
 

--- a/japl-finances-iports/src/main/java/co/com/japl/finances/iports/inbounds/paid/ISMSPaidPort.kt
+++ b/japl-finances-iports/src/main/java/co/com/japl/finances/iports/inbounds/paid/ISMSPaidPort.kt
@@ -1,5 +1,6 @@
 package co.com.japl.finances.iports.inbounds.paid
 
+import co.com.japl.finances.iports.dtos.EmailValidationDTO
 import co.com.japl.finances.iports.dtos.SMSPaidDTO
 import co.com.japl.finances.iports.enums.KindInterestRateEnum
 import java.time.LocalDateTime
@@ -14,7 +15,7 @@ interface ISMSPaidPort{
 
     fun getById(codeSMSPaid: Int):SMSPaidDTO?
 
-    fun validateMessagePattern(dto:SMSPaidDTO):List<String>
+    fun validateMessagePattern(dto:SMSPaidDTO):List<EmailValidationDTO>
 
     fun getAllByCodeAccount(codeAccount: Int):List<SMSPaidDTO>
 


### PR DESCRIPTION
This change migrates the SMS pattern validation feedback from a read-only text field to a more interactive and structured popup, consistent with the Email validation flow. It involves changes across the `iports`, `core`, `CreditCardModule`, and `paid` modules to support the flow from data extraction to UI display.

---
*PR created automatically by Jules for task [2790692770535710542](https://jules.google.com/task/2790692770535710542) started by @nano871022*