### PR TITLE
Implement email sync for credit card purchases

### DIFF
--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/emailcreditcard/form/EmailCreditCardViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/emailcreditcard/form/EmailCreditCardViewModel.kt
@@ -63,7 +63,7 @@ class EmailCreditCardViewModel constructor(
     fun loadEmailSamples() {
         if (sender.value.isNotEmpty()) {
             viewModelScope.launch(Dispatchers.IO) {
-                svc?.getEmailList(sender.value, subjectPattern.value)?.let { list ->
+                svc?.getEmailList(sender.value, subjectPattern.value, 30)?.let { list ->
                     withContext(Dispatchers.Main) {
                         emailSamples.clear()
                         list.map { Pair(it, false) }.forEach(emailSamples::add)
@@ -188,7 +188,7 @@ class EmailCreditCardViewModel constructor(
                     validationResults.clear()
                 }
                 runCatching {
-                    svc?.validateMessagePattern(dto) ?: emptyList()
+                    svc?.validateMessagePattern(dto, 30) ?: emptyList()
                 }.onFailure { e ->
                     withContext(Dispatchers.Main) {
                         validating.value = false

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/modules/EntryPoint.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/modules/EntryPoint.kt
@@ -4,9 +4,11 @@ import android.app.Activity
 import android.app.Application
 import co.com.japl.finances.iports.inbounds.common.IDifferQuotesPort
 import co.com.japl.finances.iports.inbounds.creditcard.ICreditCardPort
+import co.com.japl.finances.iports.inbounds.creditcard.IEmailCreditCardPort
 import co.com.japl.finances.iports.inbounds.creditcard.ISimulatorCreditVariablePort
 import co.com.japl.finances.iports.inbounds.creditcard.ITaxPort
 import co.com.japl.finances.iports.inbounds.creditcard.bought.IBoughtPort
+import co.com.japl.finances.iports.inbounds.creditcard.bought.IBoughtSmsPort
 import co.com.japl.finances.iports.inbounds.creditcard.bought.lists.IBoughtListPort
 import co.com.japl.finances.iports.inbounds.recap.IRecapPort
 import co.com.japl.module.creditcard.impl.SMSObserver
@@ -34,4 +36,8 @@ interface EntryPoint {
     fun getDifferInstallmentSvc():IDifferQuotesPort
 
    fun getSimulatorVariablePort(): ISimulatorCreditVariablePort
+
+   fun getEmailCreditCardPort(): IEmailCreditCardPort
+
+   fun getInboundBoughtSmsPort(): IBoughtSmsPort
 }

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/view/creditcard/bought/PopUpView.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/view/creditcard/bought/PopUpView.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.Switch
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Cancel
+import androidx.compose.material.icons.rounded.ForwardToInbox
 import androidx.compose.material.icons.rounded.Save
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -206,13 +207,20 @@ fun PopupSetting(viewModel: SettingsViewModel,state: MutableState<Boolean>) {
     val simulatorState = remember { viewModel.simulatorState }
     val daysSmsRead = remember { viewModel.daysSmsRead }
     val errorDaysSmsRead = remember { viewModel.errorDaysSmsRead }
+    val daysEmailRead = remember { viewModel.daysEmailRead }
+    val errorDaysEmailRead = remember { viewModel.errorDaysEmailRead }
     val context = LocalContext.current
     co.com.japl.ui.components.Popup(title = R.string.settings_credit_card_boughts, state = state) {
         Scaffold(
             floatingActionButton = {
-                FloatButton(imageVector = Icons.Rounded.Save, descriptionIcon = R.string.save) {
-                    viewModel.save(context)
-                    state.value = false
+                Row {
+                    FloatButton(imageVector = Icons.Rounded.ForwardToInbox, descriptionIcon = R.string.read_email) {
+                        viewModel.readEmail(context)
+                    }
+                    FloatButton(imageVector = Icons.Rounded.Save, descriptionIcon = R.string.save) {
+                        viewModel.save(context)
+                        state.value = false
+                    }
                 }
             },
             modifier=Modifier.padding(Dimensions.PADDING_SHORT)
@@ -243,6 +251,16 @@ fun PopupSetting(viewModel: SettingsViewModel,state: MutableState<Boolean>) {
                    validation = {viewModel.validation()},
                    callback = {
                        daysSmsRead.value = it
+                   },modifier= Modifier.padding(top=Dimensions.PADDING_SHORT).fillMaxWidth())
+
+               FieldText(title = stringResource(id = R.string.days_email_read),
+                   value = "${daysEmailRead.value}",
+                   hasErrorState = errorDaysEmailRead,
+                   keyboardType = KeyboardOptions(keyboardType = KeyboardType.Number),
+                   icon = Icons.Rounded.Cancel,
+                   validation = {viewModel.validation()},
+                   callback = {
+                       daysEmailRead.value = it
                    },modifier= Modifier.padding(top=Dimensions.PADDING_SHORT).fillMaxWidth())
             }
         }

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/view/creditcard/bought/PopUpView.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/view/creditcard/bought/PopUpView.kt
@@ -216,6 +216,7 @@ fun PopupSetting(viewModel: SettingsViewModel,state: MutableState<Boolean>) {
                 Row {
                     FloatButton(imageVector = Icons.Rounded.ForwardToInbox, descriptionIcon = R.string.read_email) {
                         viewModel.readEmail(context)
+                        state.value = false
                     }
                     FloatButton(imageVector = Icons.Rounded.Save, descriptionIcon = R.string.save) {
                         viewModel.save(context)

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/view/creditcard/bought/SettingsViewModel.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/view/creditcard/bought/SettingsViewModel.kt
@@ -7,9 +7,20 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import co.com.japl.finances.iports.inbounds.creditcard.IEmailCreditCardPort
+import co.com.japl.finances.iports.inbounds.creditcard.bought.IBoughtSmsPort
 import co.com.japl.ui.Prefs
 import co.japl.android.myapplication.R
+import co.japl.android.myapplication.finanzas.modules.EntryPoint
+import co.japl.finances.core.utils.DateUtils
 import co.japl.finances.core.utils.NumbersUtil
+import dagger.hilt.EntryPoints
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.time.LocalDate
+import java.time.LocalDateTime
 
 class SettingsViewModel constructor(private val prefs: Prefs): ViewModel() {
 
@@ -17,12 +28,15 @@ class SettingsViewModel constructor(private val prefs: Prefs): ViewModel() {
 
     val daysSmsRead = mutableStateOf("${prefs.creditCardSMSDaysRead}")
     val errorDaysSmsRead = mutableStateOf(false)
+    val daysEmailRead = mutableStateOf("${prefs.creditCardEmailDaysRead}")
+    val errorDaysEmailRead = mutableStateOf(false)
     val simulatorState = mutableStateOf(prefs.simulator)
 
     fun save(context:Context){
-        if(!errorDaysSmsRead.value) {
+        if(!errorDaysSmsRead.value && !errorDaysEmailRead.value) {
             prefs.simulator = simulatorState.value
             prefs.creditCardSMSDaysRead = daysSmsRead.value.toInt()
+            prefs.creditCardEmailDaysRead = daysEmailRead.value.toInt()
             state.value = false
             Toast.makeText(context, R.string.saved, Toast.LENGTH_SHORT).show()
         }
@@ -32,6 +46,38 @@ class SettingsViewModel constructor(private val prefs: Prefs): ViewModel() {
         daysSmsRead.value.takeIf { it != null && it.isNotEmpty() && NumbersUtil.isNumber(it) }?.let{
             errorDaysSmsRead.value = false
         }?: errorDaysSmsRead.let{it.value = true}
+
+        daysEmailRead.value.takeIf { it != null && it.isNotEmpty() && NumbersUtil.isNumber(it) }?.let{
+            errorDaysEmailRead.value = false
+        }?: errorDaysEmailRead.let{it.value = true}
+    }
+
+    fun readEmail(context: Context) {
+        val emailCCSvc: IEmailCreditCardPort = EntryPoints.get(context.applicationContext, EntryPoint::class.java).getEmailCreditCardPort()
+        val boughtSmsSvc: IBoughtSmsPort = EntryPoints.get(context.applicationContext, EntryPoint::class.java).getInboundBoughtSmsPort()
+        val numDaysRead = daysEmailRead.value.toIntOrNull() ?: prefs.creditCardEmailDaysRead
+        val startDate = LocalDate.now().minusDays(numDaysRead.toLong())
+
+        viewModelScope.launch(Dispatchers.IO) {
+            emailCCSvc.getAll().filter { it.active }.forEach { emailConfig ->
+                emailCCSvc.validateMessagePattern(emailConfig, numDaysRead).filter { it.matched }.forEach { validation ->
+                    val date = validation.date?.let { DateUtils.toLocalDateRegex(it) }
+                    val value = validation.value?.toDoubleOrNull()
+                    if (date != null && value != null && (date.isAfter(startDate) || date.isEqual(startDate))) {
+                        boughtSmsSvc.createBySms(
+                            name = validation.name ?: "",
+                            value = value,
+                            date = date.atStartOfDay(),
+                            codeCreditRate = emailConfig.codeCreditCard,
+                            kind = emailConfig.kindInterestRateEnum
+                        )
+                    }
+                }
+            }
+            withContext(Dispatchers.Main) {
+                Toast.makeText(context, R.string.email_read_process_completed, Toast.LENGTH_SHORT).show()
+            }
+        }
     }
 
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -480,6 +480,9 @@
     <string name="title_account_doesnt_create_yet">No hay una Cuenta bancaria creada</string>
     <string name="message_account_doesnt_create_yet">Para utilizar este modulo es necesario crear una cuenta bancaria de referencia, desea crear una?</string>
     <string name="days_sms_read">Dias de lectura SMS</string>
+    <string name="days_email_read">Dias de lectura Email</string>
+    <string name="read_email">Leer Email</string>
+    <string name="email_read_process_completed">Proceso de lectura de email completado</string>
     <string name="go">Ir</string>
     <string name="default_web_client_id">332922408573-hdcfmvvogd9thf0ujtqbl1rghn5voud2.apps.googleusercontent.com</string>
     <string name="default_web_client_id2">332922408573-sq5fj56cbl35mptmvo0mvp3ig39mf58p.apps.googleusercontent.com</string>

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/adapters/inbound/implement/creditcard/EmailCreditCard.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/adapters/inbound/implement/creditcard/EmailCreditCard.kt
@@ -8,11 +8,11 @@ import javax.inject.Inject
 
 class EmailCreditCard @Inject constructor(val svc: IEmailCreditCard) : IEmailCreditCardPort {
 
-    override fun validateMessagePattern(dto: EmailCreditCardDTO): List<EmailValidationDTO> {
+    override fun validateMessagePattern(dto: EmailCreditCardDTO, numDaysRead: Int): List<EmailValidationDTO> {
         require(dto.bodyPattern.isNotEmpty()){"Need pattern for find in message"}
         require(dto.subjectPattern.isNotEmpty()){"Need pattern for find in email"}
         require(dto.sender.isNotEmpty()){"Need sender of email"}
-        return svc.validateMessagePattern(dto)
+        return svc.validateMessagePattern(dto, numDaysRead)
     }
 
     override fun create(dto: EmailCreditCardDTO): Int {
@@ -57,7 +57,7 @@ class EmailCreditCard @Inject constructor(val svc: IEmailCreditCard) : IEmailCre
         return svc.clone(id)
     }
 
-    override fun getEmailList(sender: String, subject: String): List<String> {
-        return svc.getEmailList(sender, subject)
+    override fun getEmailList(sender: String, subject: String, numDaysRead: Int): List<String> {
+        return svc.getEmailList(sender, subject, numDaysRead)
     }
 }

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/implement/creditcard/EmailCreditCardImpl.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/implement/creditcard/EmailCreditCardImpl.kt
@@ -22,7 +22,7 @@ class EmailCreditCardImpl @Inject constructor(val svc: IEmailCreditCardPort, val
 
     override fun clone(id: Int): Boolean =getById(id)?.let{create(it.copy(id=0))!=0}?:false
 
-    override fun validateMessagePattern(dto: EmailCreditCardDTO): List<EmailValidationDTO> = messageSvc.validateMessagePattern(dto)
+    override fun validateMessagePattern(dto: EmailCreditCardDTO, numDaysRead: Int): List<EmailValidationDTO> = messageSvc.validateMessagePattern(dto, numDaysRead)
 
-    override fun getEmailList(sender: String, subject: String): List<String> = messageSvc.getEmailList(sender, subject)
+    override fun getEmailList(sender: String, subject: String, numDaysRead: Int): List<String> = messageSvc.getEmailList(sender, subject, numDaysRead)
 }

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/interfaces/creditcard/IEmailCreditCard.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/interfaces/creditcard/IEmailCreditCard.kt
@@ -5,6 +5,10 @@ import co.com.japl.finances.iports.dtos.EmailValidationDTO
 
 interface IEmailCreditCard {
 
+    fun validateMessagePattern(dto: EmailCreditCardDTO, numDaysRead: Int): List<EmailValidationDTO>
+
+    fun getEmailList(sender: String, subject: String, numDaysRead: Int): List<String>
+
     fun create(dto: EmailCreditCardDTO): Int
 
     fun update(dto: EmailCreditCardDTO): Boolean
@@ -18,8 +22,4 @@ interface IEmailCreditCard {
     fun delete(id: Int): Boolean
 
     fun clone(id: Int): Boolean
-
-    fun validateMessagePattern(dto: EmailCreditCardDTO): List<EmailValidationDTO>
-
-    fun getEmailList(sender: String, subject: String): List<String>
 }

--- a/japl-android-finances-services/src/main/java/co/japl/android/finances/services/implement/EmailCreditCardPatternImpl.kt
+++ b/japl-android-finances-services/src/main/java/co/japl/android/finances/services/implement/EmailCreditCardPatternImpl.kt
@@ -9,8 +9,8 @@ import javax.inject.Inject
 
 class EmailCreditCardPatternImpl @Inject constructor(private val emailRead: IEmailRead) : IEmailCreditCardPattern {
 
-    override fun validateMessagePattern(dto: EmailCreditCardDTO): List<EmailValidationDTO> {
-        val emails = emailRead.getEmails(dto.sender, dto.subjectPattern)
+    override fun validateMessagePattern(dto: EmailCreditCardDTO, numDaysRead: Int): List<EmailValidationDTO> {
+        val emails = emailRead.getEmails(dto.sender, dto.subjectPattern, numDaysRead)
         val pattern = Pattern.compile(dto.bodyPattern, Pattern.CASE_INSENSITIVE or Pattern.MULTILINE or Pattern.DOTALL)
         
         return emails.map { body ->
@@ -33,7 +33,7 @@ class EmailCreditCardPatternImpl @Inject constructor(private val emailRead: IEma
         }
     }
 
-    override fun getEmailList(sender: String, subject: String): List<String> {
-        return emailRead.getEmails(sender, subject)
+    override fun getEmailList(sender: String, subject: String, numDaysRead: Int): List<String> {
+        return emailRead.getEmails(sender, subject, numDaysRead)
     }
 }

--- a/japl-android-finances-services/src/main/java/co/japl/android/finances/services/implement/GmailReadImpl.kt
+++ b/japl-android-finances-services/src/main/java/co/japl/android/finances/services/implement/GmailReadImpl.kt
@@ -22,7 +22,7 @@ class GmailReadImpl @Inject constructor(
     private val jsonFactory = GsonFactory.getDefaultInstance()
     private val httpTransport = NetHttpTransport()
 
-    override fun getEmails(sender: String, subject: String): List<String> {
+    override fun getEmails(sender: String, subject: String, numDaysRead: Int): List<String> {
         val account = GoogleSignIn.getLastSignedInAccount(context) ?: return emptyList()
         val credential =
             GoogleAccountCredential.usingOAuth2(context, listOf(GmailScopes.GMAIL_READONLY))
@@ -32,7 +32,7 @@ class GmailReadImpl @Inject constructor(
             .setApplicationName("Finanzas")
             .build()
 
-        val query = "from:$sender"
+        val query = "from:$sender newer_than:${numDaysRead}d"
 
         return try {
             val response = service.users().messages().list("me").setQ(query).execute()

--- a/japl-finances-iports/src/main/java/co/com/japl/finances/iports/inbounds/common/IEmailRead.kt
+++ b/japl-finances-iports/src/main/java/co/com/japl/finances/iports/inbounds/common/IEmailRead.kt
@@ -1,5 +1,5 @@
 package co.com.japl.finances.iports.inbounds.common
 
 interface IEmailRead {
-    fun getEmails(sender: String, subject: String): List<String>
+    fun getEmails(sender: String, subject: String, numDaysRead: Int): List<String>
 }

--- a/japl-finances-iports/src/main/java/co/com/japl/finances/iports/inbounds/creditcard/IEmailCreditCardPort.kt
+++ b/japl-finances-iports/src/main/java/co/com/japl/finances/iports/inbounds/creditcard/IEmailCreditCardPort.kt
@@ -5,7 +5,7 @@ import co.com.japl.finances.iports.dtos.EmailValidationDTO
 
 interface IEmailCreditCardPort{
 
-    fun validateMessagePattern(dto: EmailCreditCardDTO):List<EmailValidationDTO>
+    fun validateMessagePattern(dto: EmailCreditCardDTO, numDaysRead: Int):List<EmailValidationDTO>
 
     fun create(dto: EmailCreditCardDTO): Int
 
@@ -21,5 +21,5 @@ interface IEmailCreditCardPort{
 
     fun clone(id:Int):Boolean
 
-    fun getEmailList(sender: String, subject: String): List<String>
+    fun getEmailList(sender: String, subject: String, numDaysRead: Int): List<String>
 }

--- a/japl-finances-iports/src/main/java/co/com/japl/finances/iports/outbounds/IEmailCreditCardPattern.kt
+++ b/japl-finances-iports/src/main/java/co/com/japl/finances/iports/outbounds/IEmailCreditCardPattern.kt
@@ -5,7 +5,7 @@ import co.com.japl.finances.iports.dtos.EmailValidationDTO
 
 interface IEmailCreditCardPattern {
 
-    fun validateMessagePattern(dto: EmailCreditCardDTO): List<EmailValidationDTO>
+    fun validateMessagePattern(dto: EmailCreditCardDTO, numDaysRead: Int): List<EmailValidationDTO>
 
-    fun getEmailList(sender: String, subject: String): List<String>
+    fun getEmailList(sender: String, subject: String, numDaysRead: Int): List<String>
 }

--- a/ui/src/main/java/co/com/japl/ui/Prefs.kt
+++ b/ui/src/main/java/co/com/japl/ui/Prefs.kt
@@ -7,6 +7,7 @@ class Prefs constructor(private val context:Context){
     val PREFS_NAME = "co.japl.android.myapplication.finanzas"
     val SHARED_NAME_SIMULATOR = "shared_qcc_simulator"
     val SHARED_NAME_CREDIT_CARD_SMS_DAYS_READ = "credit_card_sms_days_read"
+    val SHARED_NAME_CREDIT_CARD_EMAIL_DAYS_READ = "credit_card_email_days_read"
     val SHARED_NAME_PAID_SMS_DAYS_READ = "paid_sms_days_read"
     val SHARED_NAME_MSG_INITIAL = "msg_initial"
     val SHARED_NAME_LLM_TYPE = "llm_type"
@@ -48,6 +49,10 @@ class Prefs constructor(private val context:Context){
     var creditCardSMSDaysRead: Int
         get() = prefs.getString(SHARED_NAME_CREDIT_CARD_SMS_DAYS_READ,"7")?.toInt()?:7
         set(value) = prefs.edit().putString(SHARED_NAME_CREDIT_CARD_SMS_DAYS_READ,value.toString()).apply()
+
+    var creditCardEmailDaysRead: Int
+        get() = prefs.getString(SHARED_NAME_CREDIT_CARD_EMAIL_DAYS_READ,"7")?.toInt()?:7
+        set(value) = prefs.edit().putString(SHARED_NAME_CREDIT_CARD_EMAIL_DAYS_READ,value.toString()).apply()
 
     var paidSMSDaysRead: Int
         get() = prefs.getString(SHARED_NAME_PAID_SMS_DAYS_READ,"7")?.toInt()?:7


### PR DESCRIPTION
This PR implements a new feature to sync credit card purchases from Gmail.

### Changes:
- **Core Interfaces**: Updated `IEmailRead`, `IEmailCreditCardPort`, and related use cases to accept a `numDaysRead` parameter for filtering.
- **Gmail Implementation**: Updated `GmailReadImpl` to use the `newer_than:Xd` operator in the Gmail search query for efficiency.
- **UI & Settings**: 
    - Added a `days_email_read` field to the Credit Card settings popup.
    - Added an "Execute Email Process" button to the left of the Save button.
- **Sync Logic**: Implemented `readEmail()` in `SettingsViewModel` which fetches emails, applies patterns, and validates the extracted purchase date against the lookback period before creating records.
- **Injection**: Updated `EntryPoint` to allow obtaining necessary ports in the `app` module.

This addresses the user's request to have a sync process similar to SMS but for emails, with configurable lookback days and specific date validation.

---
*PR created automatically by Jules for task [409545587697488873](https://jules.google.com/task/409545587697488873) started by @nano871022*