### PR TITLE
Implement AI Model Selection in Extraction Forms

### DIFF
--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/emailcreditcard/form/EmailCreditCardViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/emailcreditcard/form/EmailCreditCardViewModel.kt
@@ -59,6 +59,8 @@ class EmailCreditCardViewModel constructor(
     val aiFailed = mutableStateOf(false)
     val emailSamples = mutableStateListOf<Pair<String, Boolean>>()
     val showEmailDialog = mutableStateOf(false)
+    val llmModels = mutableStateListOf<Pair<Int, String>>()
+    val selectedLLMModel = mutableStateOf<Pair<Int, String>?>(null)
 
     fun loadEmailSamples() {
         if (sender.value.isNotEmpty()) {
@@ -86,7 +88,7 @@ class EmailCreditCardViewModel constructor(
                 withContext(Dispatchers.Main) {
                     progress.floatValue = 0.3f
                 }
-                llmService?.getAiResponse(prompt)?.onSuccess { response ->
+                llmService?.getAiResponse(prompt, selectedLLMModel.value?.second)?.onSuccess { response ->
                     withContext(Dispatchers.Main) {
                         progress.floatValue = 0.6f
                         val lines = response.trim().lines()
@@ -279,6 +281,15 @@ class EmailCreditCardViewModel constructor(
         withContext(Dispatchers.Main) {
             kindInterestRateList.clear()
             KindInterestRateEnum.entries.map { Pair(it.getCode().toInt(), it.name) }.forEach { kindInterestRateList.add(it) }
+
+            llmService?.getModels()?.onSuccess { models ->
+                llmModels.clear()
+                models.forEachIndexed { index, name ->
+                    llmModels.add(Pair(index, name))
+                }
+                val model = prefs?.llmModel ?: ""
+                selectedLLMModel.value = llmModels.firstOrNull { it.second == model } ?: llmModels.firstOrNull()
+            }
         }
         progress.floatValue = 0.8f
     }

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/smscreditcard/form/SmsCreditCardViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/smscreditcard/form/SmsCreditCardViewModel.kt
@@ -54,6 +54,8 @@ class SmsCreditCardViewModel constructor(private val codeSMSCC:Int?,private val 
 
     val smsSamples = mutableStateListOf<Pair<String, Boolean>>()
     val showSmsDialog = mutableStateOf(false)
+    val llmModels = mutableStateListOf<Pair<Int, String>>()
+    val selectedLLMModel = mutableStateOf<Pair<Int, String>?>(null)
 
     fun loadSmsSamples() {
         if (phoneNumber.value.isNotEmpty()) {
@@ -73,7 +75,7 @@ class SmsCreditCardViewModel constructor(private val codeSMSCC:Int?,private val 
                 progress.floatValue = 0.1f
                 val prompt = navController?.context?.getString(R.string.promt_sms_expreg, selectedSms.joinToString("\n"))?:""
                 progress.floatValue = 0.3f
-                llmService?.getAiResponse(prompt)?.onSuccess { response ->
+                llmService?.getAiResponse(prompt, selectedLLMModel.value?.second)?.onSuccess { response ->
                     progress.floatValue = 0.6f
                     pattern.value = response.trim().removeSurrounding("`").removePrefix("regex").trim()
                     progress.floatValue = 1.0f
@@ -247,6 +249,15 @@ class SmsCreditCardViewModel constructor(private val codeSMSCC:Int?,private val 
         kindInterestRateList.clear()
         KindInterestRateEnum.values().map { Pair(it.getCode().toInt(), it.name)}.forEach(kindInterestRateList::add)
             .also { progress.floatValue = 0.8f }
+
+        llmService?.getModels()?.onSuccess { models ->
+            llmModels.clear()
+            models.forEachIndexed { index, name ->
+                llmModels.add(Pair(index, name))
+            }
+            val model = prefs?.llmModel ?: ""
+            selectedLLMModel.value = llmModels.firstOrNull { it.second == model } ?: llmModels.firstOrNull()
+        }
 
         load.value = false
     }

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/email/form/EmailBought.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/email/form/EmailBought.kt
@@ -215,16 +215,6 @@ private fun DialogAIEmail(viewModel: EmailCreditCardViewModel) {
             title = { Text(text = stringResource(R.string.select_example_email), color = MaterialTheme.colorScheme.onSurface) },
             text = {
                 Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
-                    examples.forEachIndexed { index, pair ->
-                        CheckBoxField(
-                            title = pair.first,
-                            value = pair.second,
-                            callback = { viewModel.emailSamples[index] = pair.copy(second = it) }
-                        )
-                    }
-
-                    HorizontalDivider(modifier = Modifier.padding(vertical = Dimensions.PADDING_SHORT))
-
                     Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.clickable { showModelSelection.value = !showModelSelection.value }) {
                         Text(text = stringResource(R.string.ai_model), modifier = Modifier.weight(1f), color = MaterialTheme.colorScheme.onSurface)
                         Icon(imageVector = Icons.Rounded.ArrowDownward, contentDescription = null, tint = MaterialTheme.colorScheme.onSurface)
@@ -240,6 +230,18 @@ private fun DialogAIEmail(viewModel: EmailCreditCardViewModel) {
                             viewModel.selectedLLMModel.value = it
                         }
                     }
+
+                    HorizontalDivider(modifier = Modifier.padding(vertical = Dimensions.PADDING_SHORT))
+
+                    examples.forEachIndexed { index, pair ->
+                        CheckBoxField(
+                            title = pair.first,
+                            value = pair.second,
+                            callback = { viewModel.emailSamples[index] = pair.copy(second = it) }
+                        )
+                    }
+
+
                 }
             },
             confirmButton = {

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/email/form/EmailBought.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/email/form/EmailBought.kt
@@ -5,10 +5,12 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.DirectionsRun
 import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material.icons.rounded.ArrowDownward
 import androidx.compose.material.icons.rounded.Cancel
 import androidx.compose.material.icons.rounded.CleaningServices
 import androidx.compose.foundation.layout.Box
@@ -205,6 +207,7 @@ private fun DialogAIEmail(viewModel: EmailCreditCardViewModel) {
     val showDialog = viewModel.showEmailDialog
     val examples = viewModel.emailSamples
     val aiFailed = viewModel.aiFailed
+    val showModelSelection = remember { mutableStateOf(false) }
 
     if (showDialog.value && examples.isNotEmpty()) {
         AlertDialog(
@@ -218,6 +221,24 @@ private fun DialogAIEmail(viewModel: EmailCreditCardViewModel) {
                             value = pair.second,
                             callback = { viewModel.emailSamples[index] = pair.copy(second = it) }
                         )
+                    }
+
+                    HorizontalDivider(modifier = Modifier.padding(vertical = Dimensions.PADDING_SHORT))
+
+                    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.clickable { showModelSelection.value = !showModelSelection.value }) {
+                        Text(text = stringResource(R.string.ai_model), modifier = Modifier.weight(1f), color = MaterialTheme.colorScheme.onSurface)
+                        Icon(imageVector = Icons.Rounded.ArrowDownward, contentDescription = null, tint = MaterialTheme.colorScheme.onSurface)
+                    }
+
+                    if (showModelSelection.value) {
+                        FieldSelect(
+                            title = stringResource(R.string.select_ai_model),
+                            value = viewModel.selectedLLMModel.value?.second ?: "",
+                            list = viewModel.llmModels,
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            viewModel.selectedLLMModel.value = it
+                        }
                     }
                 }
             },

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/sms/forms/SMS.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/sms/forms/SMS.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import co.com.japl.module.creditcard.controllers.smscreditcard.form.SmsCreditCardViewModel
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import  androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -314,15 +315,7 @@ private fun DialogAIExpReg( viewModel: SmsCreditCardViewModel){
             title = { Text(text = stringResource(R.string.select_exaple_sms), color = MaterialTheme.colorScheme.onSurface) },
             text = {
                 Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
-                    examples.forEachIndexed { index, pair ->
-                        CheckBoxField(
-                            title = pair.first,
-                            value = pair.second,
-                            callback = { viewModel.smsSamples[index] = pair.copy(second = it) }
-                        )
-                    }
 
-                    HorizontalDivider(modifier = Modifier.padding(vertical = Dimensions.PADDING_SHORT))
 
                     Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.clickable { showModelSelection.value = !showModelSelection.value }) {
                         Text(text = stringResource(R.string.ai_model), modifier = Modifier.weight(1f), color = MaterialTheme.colorScheme.onSurface)
@@ -339,6 +332,18 @@ private fun DialogAIExpReg( viewModel: SmsCreditCardViewModel){
                             viewModel.selectedLLMModel.value = it
                         }
                     }
+
+                    HorizontalDivider(modifier = Modifier.padding(vertical = Dimensions.PADDING_SHORT))
+
+                    examples.forEachIndexed { index, pair ->
+                        CheckBoxField(
+                            title = pair.first,
+                            value = pair.second,
+                            callback = { viewModel.smsSamples[index] = pair.copy(second = it) }
+                        )
+                    }
+
+
                 }
             },
             confirmButton = {

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/sms/forms/SMS.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/sms/forms/SMS.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -16,6 +17,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Icon
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.CleaningServices
+import androidx.compose.material.icons.rounded.ArrowDownward
 import androidx.compose.material.icons.rounded.Save
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Scaffold
@@ -304,6 +306,7 @@ private fun DialogAIExpReg( viewModel: SmsCreditCardViewModel){
     val showDialog = remember {viewModel.showSmsDialog}
     val examples = remember {viewModel.smsSamples}
     val aiFaile = remember {  viewModel.aiFaile }
+    val showModelSelection = remember { mutableStateOf(false) }
 
     if (showDialog.value && examples.isNotEmpty()) {
         AlertDialog(
@@ -317,6 +320,24 @@ private fun DialogAIExpReg( viewModel: SmsCreditCardViewModel){
                             value = pair.second,
                             callback = { viewModel.smsSamples[index] = pair.copy(second = it) }
                         )
+                    }
+
+                    HorizontalDivider(modifier = Modifier.padding(vertical = Dimensions.PADDING_SHORT))
+
+                    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.clickable { showModelSelection.value = !showModelSelection.value }) {
+                        Text(text = stringResource(R.string.ai_model), modifier = Modifier.weight(1f), color = MaterialTheme.colorScheme.onSurface)
+                        androidx.compose.material3.Icon(imageVector = Icons.Rounded.ArrowDownward, contentDescription = null, tint = MaterialTheme.colorScheme.onSurface)
+                    }
+
+                    if (showModelSelection.value) {
+                        FieldSelect(
+                            title = stringResource(R.string.select_ai_model),
+                            value = viewModel.selectedLLMModel.value?.second ?: "",
+                            list = viewModel.llmModels,
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            viewModel.selectedLLMModel.value = it
+                        }
                     }
                 }
             },

--- a/CreditCardModule/src/main/res/values/strings.xml
+++ b/CreditCardModule/src/main/res/values/strings.xml
@@ -119,4 +119,6 @@ Messages:
     <string name="not_extracted">No se logró extraer datos</string>
     <string name="validation_close">Cerrar</string>
     <string name="loading_data">Cargando Data</string>
+    <string name="ai_model">Modelo IA</string>
+    <string name="select_ai_model">Seleccionar Modelo IA</string>
 </resources>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,10 @@
     <uses-permission android:name="com.google.android.gms.permission.AD_ID"
         xmlns:tools="http://schemas.android.com/tools" tools:node="remove"/>
 
+    <queries>
+        <package android:name="com.google.android.gms" />
+    </queries>
+
     <application
          android:requestLegacyExternalStorage="true"
          android:usesCleartextTraffic="true"

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/view/setting/LLMConnectionForm.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/view/setting/LLMConnectionForm.kt
@@ -165,12 +165,17 @@ fun getLLMConnectFViewModel(): LLMConnectionViewModel {
     var context = LocalContext.current
     val prefs = Prefs(context)
     var llmsSvc = object : ILLMService {
-        override suspend fun getAiResponse(prompt: String): Result<String> {
-            return Result.success("Respuesta de IA")
+        override suspend fun getAiResponse(
+            prompt: String,
+            model: String?
+        ): Result<String> {
+            TODO("Not yet implemented")
         }
+
         override suspend fun getModels(): Result<List<String>> {
-            return Result.success(listOf("Modelo 1", "Modelo 2"))
+            TODO("Not yet implemented")
         }
+
     }
 
     return LLMConnectionViewModel(

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/adapters/inbound/implement/common/LLMServiceImpl.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/adapters/inbound/implement/common/LLMServiceImpl.kt
@@ -14,15 +14,15 @@ class LLMServiceImpl @Inject constructor(
     private val deepSeekService: DeepSeekService
 ) : ILLMService {
 
-    override suspend fun getAiResponse(prompt: String): Result<String> {
+    override suspend fun getAiResponse(prompt: String, model: String?): Result<String> {
         Log.d(this::javaClass.name, "getAiResponse: $prompt")
         if (!prefs.llmEnabled) {
             return Result.failure(Exception("LLM is disabled"))
         }
         val type = try { LLMType.valueOf(prefs.llmType) } catch (e: Exception) { LLMType.GEMINI }
         return when (type) {
-            LLMType.GEMINI -> geminiService.getAiResponse(prompt)
-            LLMType.DEEPSEEK -> deepSeekService.getAiResponse(prompt)
+            LLMType.GEMINI -> geminiService.getAiResponse(prompt, model)
+            LLMType.DEEPSEEK -> deepSeekService.getAiResponse(prompt, model)
         }
     }
 

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/implement/common/DeepSeekService.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/implement/common/DeepSeekService.kt
@@ -12,11 +12,11 @@ class DeepSeekService @Inject constructor(
     private val llmOutboundPort: ILLMOutboundPort
 ) : ILLMService {
 
-    override suspend fun getAiResponse(prompt: String): Result<String> {
+    override suspend fun getAiResponse(prompt: String, model: String?): Result<String> {
         val config = LLMConfigDTO(
             type = LLMType.DEEPSEEK,
             apiKey = prefs.llmApiKey,
-            model = prefs.llmModel.ifEmpty { "deepseek-chat" },
+            model = model ?: prefs.llmModel.ifEmpty { "deepseek-chat" },
             url = prefs.llmDeepSeekUrl
         )
         return llmOutboundPort.getAiResponse(config, prompt)

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/implement/common/GeminiService.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/implement/common/GeminiService.kt
@@ -12,11 +12,11 @@ class GeminiService @Inject constructor(
     private val llmOutboundPort: ILLMOutboundPort
 ) : ILLMService {
 
-    override suspend fun getAiResponse(prompt: String): Result<String> {
+    override suspend fun getAiResponse(prompt: String, model: String?): Result<String> {
         val config = LLMConfigDTO(
             type = LLMType.GEMINI,
             apiKey = prefs.llmApiKey,
-            model = prefs.llmModel.ifEmpty { "gemini-1.5-flash" },
+            model = model ?: prefs.llmModel.ifEmpty { "gemini-1.5-flash" },
             url = prefs.llmGeminiUrl
         )
         return llmOutboundPort.getAiResponse(config, prompt)

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/emailpaid/form/EmailPaidViewModel.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/emailpaid/form/EmailPaidViewModel.kt
@@ -51,6 +51,8 @@ class EmailPaidViewModel(
     val aiFailed = mutableStateOf(false)
     val emailSamples = mutableStateListOf<Pair<String, Boolean>>()
     val showEmailDialog = mutableStateOf(false)
+    val llmModels = mutableStateListOf<Pair<Int, String>>()
+    val selectedLLMModel = mutableStateOf<Pair<Int, String>?>(null)
 
     fun loadEmailSamples() {
         if (sender.value.isNotEmpty()) {
@@ -75,7 +77,7 @@ class EmailPaidViewModel(
                     progress.floatValue = 0.1f
                 }
                 val prompt = context?.getString(R.string.promt_email_expreg, selectedEmails.joinToString("\n")) ?: ""
-                llmService?.getAiResponse(prompt)?.onSuccess { response ->
+                llmService?.getAiResponse(prompt, selectedLLMModel.value?.second)?.onSuccess { response ->
                     withContext(Dispatchers.Main) {
                         val lines = response.trim().lines()
                         lines.forEach { line ->
@@ -205,6 +207,15 @@ class EmailPaidViewModel(
                 }
             }
             withContext(Dispatchers.Main) {
+                llmService?.getModels()?.onSuccess { models ->
+                    llmModels.clear()
+                    models.forEachIndexed { index, name ->
+                        llmModels.add(Pair(index, name))
+                    }
+                    val model = prefs?.llmModel ?: ""
+                    selectedLLMModel.value = llmModels.firstOrNull { it.second == model } ?: llmModels.firstOrNull()
+                }
+
                 load.value = false
             }
         }

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/sms/form/SmsViewModel.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/sms/form/SmsViewModel.kt
@@ -48,6 +48,8 @@ class SmsViewModel constructor(private val codeSMS:Int?, private val svc:ISMSPai
     val smsSamples = mutableStateListOf<Pair<String, Boolean>>()
     val showSmsDialog = mutableStateOf(false)
     val aiFaile = mutableStateOf<Boolean>(false)
+    val llmModels = mutableStateListOf<Pair<Int, String>>()
+    val selectedLLMModel = mutableStateOf<Pair<Int, String>?>(null)
 
     fun loadSmsSamples() {
         if (phoneNumber.value.isNotEmpty()) {
@@ -69,7 +71,7 @@ class SmsViewModel constructor(private val codeSMS:Int?, private val svc:ISMSPai
                 load.value = true
                 progress.floatValue = 0.1f
                 val prompt = navController?.context?.getString(R.string.promt_sms_expreg,selectedSms.joinToString("\n"))?:""
-                llmService?.getAiResponse(prompt)?.onSuccess { response ->
+                llmService?.getAiResponse(prompt, selectedLLMModel.value?.second)?.onSuccess { response ->
                     progress.floatValue = 0.5f
                     pattern.value = response.trim().removeSurrounding("`").removePrefix("regex").trim()
                     progress.floatValue = 0.8f
@@ -227,6 +229,15 @@ class SmsViewModel constructor(private val codeSMS:Int?, private val svc:ISMSPai
         kindInterestRateList.clear()
         KindInterestRateEnum.values().map { Pair(it.getCode().toInt(), it.name)}.forEach(kindInterestRateList::add)
             .also { progress.floatValue = 0.8f }
+
+        llmService?.getModels()?.onSuccess { models ->
+            llmModels.clear()
+            models.forEachIndexed { index, name ->
+                llmModels.add(Pair(index, name))
+            }
+            val model = prefs?.llmModel ?: ""
+            selectedLLMModel.value = llmModels.firstOrNull { it.second == model } ?: llmModels.firstOrNull()
+        }
 
         load.value = false
     }

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/email/form/EmailPaid.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/email/form/EmailPaid.kt
@@ -130,11 +130,6 @@ private fun DialogAIEmail(viewModel: EmailPaidViewModel) {
             title = { Text(text = stringResource(R.string.select_example_email), color = MaterialTheme.colorScheme.onSurface) },
             text = {
                 Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
-                    examples.forEachIndexed { index, pair ->
-                        CheckBoxField(title = pair.first, value = pair.second, callback = { viewModel.emailSamples[index] = pair.copy(second = it) })
-                    }
-
-                    HorizontalDivider(modifier = Modifier.padding(vertical = Dimensions.PADDING_SHORT))
 
                     Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.clickable { showModelSelection.value = !showModelSelection.value }) {
                         Text(text = stringResource(R.string.ai_model), modifier = Modifier.weight(1f), color = MaterialTheme.colorScheme.onSurface)
@@ -151,6 +146,14 @@ private fun DialogAIEmail(viewModel: EmailPaidViewModel) {
                             viewModel.selectedLLMModel.value = it
                         }
                     }
+
+                    HorizontalDivider(modifier = Modifier.padding(vertical = Dimensions.PADDING_SHORT))
+
+                    examples.forEachIndexed { index, pair ->
+                        CheckBoxField(title = pair.first, value = pair.second, callback = { viewModel.emailSamples[index] = pair.copy(second = it) })
+                    }
+
+
                 }
             },
             confirmButton = {

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/email/form/EmailPaid.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/email/form/EmailPaid.kt
@@ -1,11 +1,13 @@
 package co.com.japl.module.paid.views.email.form
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.DirectionsRun
 import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material.icons.rounded.ArrowDownward
 import androidx.compose.material.icons.rounded.CleaningServices
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -120,6 +122,7 @@ private fun DialogAIEmail(viewModel: EmailPaidViewModel) {
     val showDialog = viewModel.showEmailDialog
     val examples = viewModel.emailSamples
     val aiFailed = viewModel.aiFailed
+    val showModelSelection = remember { mutableStateOf(false) }
 
     if (showDialog.value && examples.isNotEmpty()) {
         AlertDialog(
@@ -129,6 +132,24 @@ private fun DialogAIEmail(viewModel: EmailPaidViewModel) {
                 Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
                     examples.forEachIndexed { index, pair ->
                         CheckBoxField(title = pair.first, value = pair.second, callback = { viewModel.emailSamples[index] = pair.copy(second = it) })
+                    }
+
+                    HorizontalDivider(modifier = Modifier.padding(vertical = Dimensions.PADDING_SHORT))
+
+                    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.clickable { showModelSelection.value = !showModelSelection.value }) {
+                        Text(text = stringResource(R.string.ai_model), modifier = Modifier.weight(1f), color = MaterialTheme.colorScheme.onSurface)
+                        Icon(imageVector = androidx.compose.material.icons.Icons.Rounded.ArrowDownward, contentDescription = null, tint = MaterialTheme.colorScheme.onSurface)
+                    }
+
+                    if (showModelSelection.value) {
+                        FieldSelect(
+                            title = stringResource(R.string.select_ai_model),
+                            value = viewModel.selectedLLMModel.value?.second ?: "",
+                            list = viewModel.llmModels,
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            viewModel.selectedLLMModel.value = it
+                        }
                     }
                 }
             },

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/sms/form/SMS.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/sms/form/SMS.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.tooling.preview.Preview
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import  androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -305,15 +306,6 @@ private fun AIDialog(viewModel: SmsViewModel){
           title = { Text(text = stringResource(R.string.select_example_sms), color = MaterialTheme.colorScheme.onSurface) },
           text = {
               Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
-                  examples.forEachIndexed { index, pair ->
-                      CheckBoxField(
-                          title = pair.first,
-                          value = pair.second,
-                          callback = { viewModel.smsSamples[index] = pair.copy(second = it) }
-                      )
-                  }
-
-                  HorizontalDivider(modifier = Modifier.padding(vertical = Dimensions.PADDING_SHORT))
 
                   Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.clickable { showModelSelection.value = !showModelSelection.value }) {
                       Text(text = stringResource(R.string.ai_model), modifier = Modifier.weight(1f), color = MaterialTheme.colorScheme.onSurface)
@@ -330,6 +322,18 @@ private fun AIDialog(viewModel: SmsViewModel){
                           viewModel.selectedLLMModel.value = it
                       }
                   }
+
+                  HorizontalDivider(modifier = Modifier.padding(vertical = Dimensions.PADDING_SHORT))
+
+                  examples.forEachIndexed { index, pair ->
+                      CheckBoxField(
+                          title = pair.first,
+                          value = pair.second,
+                          callback = { viewModel.smsSamples[index] = pair.copy(second = it) }
+                      )
+                  }
+
+
               }
           },
           confirmButton = {

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/sms/form/SMS.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/sms/form/SMS.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -16,6 +17,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Icon
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.CleaningServices
+import androidx.compose.material.icons.rounded.ArrowDownward
 import androidx.compose.material.icons.rounded.Save
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Scaffold
@@ -295,6 +297,7 @@ private fun AIDialog(viewModel: SmsViewModel){
     val showSms by viewModel.showSmsDialog
     val aiFaile by   viewModel.aiFaile
     val examples = remember { viewModel.smsSamples}
+    val showModelSelection = remember { mutableStateOf(false) }
 
   if (showSms && examples.isNotEmpty()) {
       AlertDialog(
@@ -308,6 +311,24 @@ private fun AIDialog(viewModel: SmsViewModel){
                           value = pair.second,
                           callback = { viewModel.smsSamples[index] = pair.copy(second = it) }
                       )
+                  }
+
+                  HorizontalDivider(modifier = Modifier.padding(vertical = Dimensions.PADDING_SHORT))
+
+                  Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.clickable { showModelSelection.value = !showModelSelection.value }) {
+                      Text(text = stringResource(R.string.ai_model), modifier = Modifier.weight(1f), color = MaterialTheme.colorScheme.onSurface)
+                      androidx.compose.material3.Icon(imageVector = Icons.Rounded.ArrowDownward, contentDescription = null, tint = MaterialTheme.colorScheme.onSurface)
+                  }
+
+                  if (showModelSelection.value) {
+                      FieldSelect(
+                          title = stringResource(R.string.select_ai_model),
+                          value = viewModel.selectedLLMModel.value?.second ?: "",
+                          list = viewModel.llmModels,
+                          modifier = Modifier.fillMaxWidth()
+                      ) {
+                          viewModel.selectedLLMModel.value = it
+                      }
                   }
               }
           },

--- a/japl-android-finances-paid-module/src/main/res/values/strings.xml
+++ b/japl-android-finances-paid-module/src/main/res/values/strings.xml
@@ -128,4 +128,6 @@ Email Samples:
     <string name="email_address">Email</string>
     <string name="clone">Duplicar</string>
     <string name="do_you_wnat_to_delete_email_record">Desea eliminar el registro</string>
+    <string name="ai_model">Modelo IA</string>
+    <string name="select_ai_model">Seleccionar Modelo IA</string>
 </resources>

--- a/japl-finances-iports/src/main/java/co/com/japl/finances/iports/inbounds/common/ILLMService.kt
+++ b/japl-finances-iports/src/main/java/co/com/japl/finances/iports/inbounds/common/ILLMService.kt
@@ -1,6 +1,6 @@
 package co.com.japl.finances.iports.inbounds.common
 
 interface ILLMService {
-    suspend fun getAiResponse(prompt: String): Result<String>
+    suspend fun getAiResponse(prompt: String, model: String? = null): Result<String>
     suspend fun getModels(): Result<List<String>>
 }


### PR DESCRIPTION
This change allows users to manually select which AI model to use during pattern extraction from SMS or Emails, providing more flexibility when the default model doesn't perform as expected. The UI includes a divider and a toggleable selection field in the AI generation dialogs.

---
*PR created automatically by Jules for task [9856940092540060084](https://jules.google.com/task/9856940092540060084) started by @nano871022*