### PR TITLE
Implement settings popup in paid module monthly view

### DIFF
--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/monthly/list/MonthlyViewModel.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/monthly/list/MonthlyViewModel.kt
@@ -1,12 +1,15 @@
 package co.com.japl.module.paid.controllers.monthly.list
 
+import android.content.Context
 import android.util.Log
+import android.widget.Toast
 import androidx.compose.runtime.mutableDoubleStateOf
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import androidx.navigation.NavController
 import co.com.japl.finances.iports.dtos.AccountDTO
 import co.com.japl.finances.iports.enums.KindInterestRateEnum
@@ -19,10 +22,15 @@ import co.com.japl.finances.iports.inbounds.paid.ISmsPort
 import co.com.japl.module.paid.navigations.Paid
 import co.com.japl.module.paid.navigations.Paids
 import co.com.japl.module.paid.navigations.Period
+import co.com.japl.module.paid.R
 import co.com.japl.ui.Prefs
 import co.com.japl.ui.utils.DateUtils
+import co.japl.android.myapplication.utils.NumbersUtil
+import kotlinx.coroutines.Dispatchers
 
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.time.YearMonth
 import java.time.format.TextStyle
 import java.util.Locale
@@ -41,6 +49,10 @@ class MonthlyViewModel constructor(private val period:YearMonth,private val paid
     val incomesTotalState = mutableDoubleStateOf(0.0)
     val listGraph = mutableStateListOf<Pair<String,Double>>()
     val paidEmailDaysRead = mutableStateOf("${prefs?.paidEmailDaysRead ?: 7}")
+    val paidSMSDaysRead = mutableStateOf("${prefs?.paidSMSDaysRead ?: 7}")
+    val errorPaidEmailDaysRead = mutableStateOf(false)
+    val errorPaidSMSDaysRead = mutableStateOf(false)
+    val settingState = mutableStateOf(false)
 
     fun goToListDetail(){
         try {
@@ -155,9 +167,8 @@ class MonthlyViewModel constructor(private val period:YearMonth,private val paid
     }
 
     suspend fun readEmail(){
+        val numDaysRead = paidEmailDaysRead.value.toIntOrNull() ?: prefs?.paidEmailDaysRead ?: 7
         try {
-            val numDaysRead = paidEmailDaysRead.value.toIntOrNull() ?: prefs?.paidEmailDaysRead ?: 7
-
             emailSvc?.getAll()?.filter { it.active }?.forEach { emailConfig ->
 
                 emailSvc.validateMessagePattern(emailConfig, numDaysRead).filter { it.matched }.forEach { validation ->
@@ -182,10 +193,37 @@ class MonthlyViewModel constructor(private val period:YearMonth,private val paid
         }
     }
 
-    fun saveSettings() {
-        paidEmailDaysRead.value.toIntOrNull()?.let {
-            prefs?.paidEmailDaysRead = it
+    fun readEmail(context: Context){
+        settingState.value = false
+        viewModelScope.launch(Dispatchers.IO) {
+            readEmail()
+            withContext(Dispatchers.Main) {
+                Toast.makeText(context, R.string.email_read_process_completed, Toast.LENGTH_SHORT).show()
+            }
         }
+    }
+
+    fun saveSettings(context: Context) {
+        if(!errorPaidEmailDaysRead.value && !errorPaidSMSDaysRead.value) {
+            paidEmailDaysRead.value.toIntOrNull()?.let {
+                prefs?.paidEmailDaysRead = it
+            }
+            paidSMSDaysRead.value.toIntOrNull()?.let {
+                prefs?.paidSMSDaysRead = it
+            }
+            settingState.value = false
+            Toast.makeText(context, R.string.toast_saves_successful, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    fun validation(){
+        paidEmailDaysRead.value.takeIf { it.isNotEmpty() && NumbersUtil.isNumber(it) }?.let{
+            errorPaidEmailDaysRead.value = false
+        }?: errorPaidEmailDaysRead.let{it.value = true}
+
+        paidSMSDaysRead.value.takeIf { it.isNotEmpty() && NumbersUtil.isNumber(it) }?.let{
+            errorPaidSMSDaysRead.value = false
+        }?: errorPaidSMSDaysRead.let{it.value = true}
     }
 
 }

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/monthly/list/Monthly.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/monthly/list/Monthly.kt
@@ -11,12 +11,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.rounded.DirectionsRun
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.CalendarMonth
 import androidx.compose.material.icons.rounded.RemoveRedEye
-import androidx.compose.material.icons.rounded.SaveAs
-import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
@@ -111,6 +109,10 @@ viewModel.accountList
                         } ?: accountState?.let { it.value = null }
                     })
 
+                IconButton(onClick = { viewModel.settingState.value = true }) {
+                    Icon(imageVector = Icons.Rounded.Settings, contentDescription = stringResource(id = R.string.setting))
+                }
+
                 HelpWikiButton(wikiUrl = R.string.wiki_paid_url, descriptionContent = R.string.wiki_paid_description)
             }
 
@@ -118,39 +120,12 @@ viewModel.accountList
                 Accounts(viewModel = viewModel)
 
                 PiecePieGraph(list = listGraph)
-
-                Settings(viewModel = viewModel)
             }
 
         }
     }
-}
-
-@Composable
-private fun Settings(viewModel: MonthlyViewModel) {
-    val paidEmailDaysRead = viewModel.paidEmailDaysRead
-    Column(modifier = Modifier.padding(top = Dimensions.PADDING_SHORT)) {
-        HorizontalDivider()
-        Text(text = stringResource(R.string.setting), style = MaterialTheme.typography.titleMedium, modifier = Modifier.padding(vertical = Dimensions.PADDING_SHORT))
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            FieldText(
-                title = stringResource(R.string.msm_read_num),
-                value = paidEmailDaysRead.value,
-                modifier = Modifier.weight(1f)
-            ) { paidEmailDaysRead.value = it }
-
-            IconButton(onClick = { viewModel.saveSettings() }) {
-                Icon(imageVector = Icons.Rounded.SaveAs, contentDescription = stringResource(R.string.save))
-            }
-
-            IconButton(onClick = {
-                CoroutineScope(Dispatchers.IO).launch {
-                    viewModel.readEmail()
-                }
-            }) {
-                Icon(imageVector = Icons.AutoMirrored.Rounded.DirectionsRun, contentDescription = stringResource(R.string.email_read))
-            }
-        }
+    if(viewModel.settingState.value){
+        PopupSetting(viewModel = viewModel, state = viewModel.settingState)
     }
 }
 

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/monthly/list/PopUpView.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/monthly/list/PopUpView.kt
@@ -1,0 +1,74 @@
+package co.com.japl.module.paid.views.monthly.list
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ForwardToInbox
+import androidx.compose.material.icons.rounded.Cancel
+import androidx.compose.material.icons.rounded.Save
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import co.com.japl.module.paid.R
+import co.com.japl.module.paid.controllers.monthly.list.MonthlyViewModel
+import co.com.japl.ui.components.FieldText
+import co.com.japl.ui.components.FloatButton
+import co.com.japl.ui.components.Popup
+import co.com.japl.ui.theme.values.Dimensions
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PopupSetting(viewModel: MonthlyViewModel, state: MutableState<Boolean>) {
+    val paidEmailDaysRead = remember { viewModel.paidEmailDaysRead }
+    val errorPaidEmailDaysRead = remember { viewModel.errorPaidEmailDaysRead }
+    val paidSMSDaysRead = remember { viewModel.paidSMSDaysRead }
+    val errorPaidSMSDaysRead = remember { viewModel.errorPaidSMSDaysRead }
+    val context = LocalContext.current
+
+    Popup(title = R.string.setting, state = state) {
+        Scaffold(
+            floatingActionButton = {
+                Row {
+                    FloatButton(imageVector = Icons.AutoMirrored.Rounded.ForwardToInbox, descriptionIcon = R.string.email_read) {
+                        viewModel.readEmail(context)
+                    }
+                    FloatButton(imageVector = Icons.Rounded.Save, descriptionIcon = R.string.save) {
+                        viewModel.saveSettings(context)
+                    }
+                }
+            },
+            modifier = Modifier.padding(Dimensions.PADDING_SHORT)
+        ) {
+            Column(modifier = Modifier.padding(it)) {
+                FieldText(title = stringResource(id = R.string.msm_read_num),
+                    value = paidSMSDaysRead.value,
+                    hasErrorState = errorPaidSMSDaysRead,
+                    keyboardType = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    icon = Icons.Rounded.Cancel,
+                    validation = { viewModel.validation() },
+                    callback = {
+                        paidSMSDaysRead.value = it
+                    }, modifier = Modifier.padding(top = Dimensions.PADDING_SHORT).fillMaxWidth())
+
+                FieldText(title = stringResource(id = R.string.email_read_num),
+                    value = paidEmailDaysRead.value,
+                    hasErrorState = errorPaidEmailDaysRead,
+                    keyboardType = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    icon = Icons.Rounded.Cancel,
+                    validation = { viewModel.validation() },
+                    callback = {
+                        paidEmailDaysRead.value = it
+                    }, modifier = Modifier.padding(top = Dimensions.PADDING_SHORT).fillMaxWidth())
+            }
+        }
+    }
+}

--- a/japl-android-finances-paid-module/src/main/res/values/values.xml
+++ b/japl-android-finances-paid-module/src/main/res/values/values.xml
@@ -22,6 +22,7 @@
     <string name="end">Finalizar</string>
     <string name="setting">Configuración</string>
     <string name="msm_read_num">Número dias lectura SMS</string>
+    <string name="email_read_num">Número dias lectura Email</string>
 
     <string name="year">Año</string>
     <string name="month">Mes</string>


### PR DESCRIPTION
This change implements a settings popup in the paid module's monthly list view, mirroring the functionality found in the credit card module. Users can now configure the number of days for reading SMS and emails via a popup instead of an inline form. The popup also allows triggering the email data loading process with immediate UI feedback via Toasts. Logic for saving settings includes validation to ensure only numeric inputs are accepted.

---
*PR created automatically by Jules for task [12683738855831024135](https://jules.google.com/task/12683738855831024135) started by @nano871022*