### PR TITLE
Implement settings popup in paid module monthly view

### DIFF
--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/paids/PaidListFragment.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/paids/PaidListFragment.kt
@@ -9,7 +9,9 @@ import android.view.ViewGroup
 import androidx.annotation.RequiresApi
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.navigation.fragment.findNavController
+import co.com.japl.finances.iports.inbounds.paid.IEmailPaidPort
 import co.com.japl.finances.iports.inbounds.paid.IPaidPort
+import co.com.japl.finances.iports.inbounds.paid.ISmsPort
 import co.com.japl.module.paid.controllers.paid.list.PaidViewModel
 import co.com.japl.module.paid.views.paid.list.Paid
 import co.com.japl.ui.theme.MaterialThemeComposeUI
@@ -24,6 +26,8 @@ import javax.inject.Inject
 class PaidListFragment : Fragment()  {
 
     @Inject lateinit var paidSvc: IPaidPort
+    @Inject lateinit var emailSvc:IEmailPaidPort
+    @Inject lateinit var paidSmsSvc: ISmsPort
 
 
 
@@ -41,7 +45,9 @@ class PaidListFragment : Fragment()  {
             period= if(date != null) YearMonth.of(date.year,date.monthValue) else YearMonth.now(),
             paidSvc = paidSvc,
             prefs = ApplicationInitial.prefs,
-            navController = findNavController()
+            navController = findNavController(),
+            emailSvc = emailSvc,
+            paidSmsSvc = paidSmsSvc
         )
         root.cvPaidFpl.apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/paids/PaidsFragment.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/paids/PaidsFragment.kt
@@ -36,7 +36,7 @@ class PaidsFragment : Fragment() {
     lateinit var incomesSvc: IInputPort
     @Inject lateinit var paidSmsSvc:ISmsPort
     @Inject lateinit var smsSvc:ISMSPaidPort
-    @Inject lateinit var emailSvc:IEmailPaidPort
+
 
 
     @RequiresApi(Build.VERSION_CODES.S)
@@ -54,8 +54,7 @@ class PaidsFragment : Fragment() {
             paidSmsSvc = paidSmsSvc,
             prefs = ApplicationInitial.prefs,
             smsSvc = smsSvc,
-            navController = findNavController(),
-            emailSvc = emailSvc
+            navController = findNavController()
         )
         root.cvPaidsFp.apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/monthly/list/MonthlyViewModel.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/monthly/list/MonthlyViewModel.kt
@@ -35,7 +35,7 @@ import java.time.YearMonth
 import java.time.format.TextStyle
 import java.util.Locale
 
-class MonthlyViewModel constructor(private val period:YearMonth,private val paidSvc: IPaidPort?, private val incomesSvc:IInputPort?,private val accountSvc:IAccountPort?, private val smsSvc:ISMSPaidPort?,private val paidSmsSvc:ISmsPort?,private val prefs:Prefs?,private val navController: NavController?,private val emailSvc:IEmailPaidPort? = null): ViewModel() {
+class MonthlyViewModel constructor(private val period:YearMonth,private val paidSvc: IPaidPort?, private val incomesSvc:IInputPort?,private val accountSvc:IAccountPort?, private val smsSvc:ISMSPaidPort?,private val paidSmsSvc:ISmsPort?,private val prefs:Prefs?,private val navController: NavController?): ViewModel() {
     private var _accounts : List<AccountDTO>? = null
     val listAccount get() = _accounts
 
@@ -48,11 +48,6 @@ class MonthlyViewModel constructor(private val period:YearMonth,private val paid
     val paidTotalState = mutableDoubleStateOf(0.0)
     val incomesTotalState = mutableDoubleStateOf(0.0)
     val listGraph = mutableStateListOf<Pair<String,Double>>()
-    val paidEmailDaysRead = mutableStateOf("${prefs?.paidEmailDaysRead ?: 7}")
-    val paidSMSDaysRead = mutableStateOf("${prefs?.paidSMSDaysRead ?: 7}")
-    val errorPaidEmailDaysRead = mutableStateOf(false)
-    val errorPaidSMSDaysRead = mutableStateOf(false)
-    val settingState = mutableStateOf(false)
 
     fun goToListDetail(){
         try {
@@ -98,7 +93,7 @@ class MonthlyViewModel constructor(private val period:YearMonth,private val paid
         progressStatus.value = 0.6f
         readSms()
         progressStatus.value = 0.8f
-        readEmail()
+
         progressStatus.value = 1.0f
     }
 
@@ -165,65 +160,4 @@ class MonthlyViewModel constructor(private val period:YearMonth,private val paid
             Log.e(javaClass.name,e.message,e)
         }
     }
-
-    suspend fun readEmail(){
-        val numDaysRead = paidEmailDaysRead.value.toIntOrNull() ?: prefs?.paidEmailDaysRead ?: 7
-        try {
-            emailSvc?.getAll()?.filter { it.active }?.forEach { emailConfig ->
-
-                emailSvc.validateMessagePattern(emailConfig, numDaysRead).filter { it.matched }.forEach { validation ->
-
-                    val date = validation.date?.let {
-                        DateUtils.toLocalDate(it)
-                    }?.atStartOfDay()
-
-                    val value = validation.value?.toDoubleOrNull()
-                    if (date != null && value != null) {
-                        paidSmsSvc?.createBySms(
-                            name = validation.name ?: "",
-                            value = value,
-                            date = date,
-                            codeAccount = emailConfig.codeAccount
-                        )
-                    }
-                }
-            }
-        } catch (e: Exception) {
-            Log.e(javaClass.name, e.message, e)
-        }
-    }
-
-    fun readEmail(context: Context){
-        settingState.value = false
-        viewModelScope.launch(Dispatchers.IO) {
-            readEmail()
-            withContext(Dispatchers.Main) {
-                Toast.makeText(context, R.string.email_read_process_completed, Toast.LENGTH_SHORT).show()
-            }
-        }
-    }
-
-    fun saveSettings(context: Context) {
-        if(!errorPaidEmailDaysRead.value && !errorPaidSMSDaysRead.value) {
-            paidEmailDaysRead.value.toIntOrNull()?.let {
-                prefs?.paidEmailDaysRead = it
-            }
-            paidSMSDaysRead.value.toIntOrNull()?.let {
-                prefs?.paidSMSDaysRead = it
-            }
-            settingState.value = false
-            Toast.makeText(context, R.string.toast_saves_successful, Toast.LENGTH_SHORT).show()
-        }
-    }
-
-    fun validation(){
-        paidEmailDaysRead.value.takeIf { it.isNotEmpty() && NumbersUtil.isNumber(it) }?.let{
-            errorPaidEmailDaysRead.value = false
-        }?: errorPaidEmailDaysRead.let{it.value = true}
-
-        paidSMSDaysRead.value.takeIf { it.isNotEmpty() && NumbersUtil.isNumber(it) }?.let{
-            errorPaidSMSDaysRead.value = false
-        }?: errorPaidSMSDaysRead.let{it.value = true}
-    }
-
 }

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/monthly/list/MonthlyViewModel.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/monthly/list/MonthlyViewModel.kt
@@ -1,12 +1,15 @@
 package co.com.japl.module.paid.controllers.monthly.list
 
+import android.content.Context
 import android.util.Log
+import android.widget.Toast
 import androidx.compose.runtime.mutableDoubleStateOf
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import androidx.navigation.NavController
 import co.com.japl.finances.iports.dtos.AccountDTO
 import co.com.japl.finances.iports.enums.KindInterestRateEnum
@@ -19,10 +22,15 @@ import co.com.japl.finances.iports.inbounds.paid.ISmsPort
 import co.com.japl.module.paid.navigations.Paid
 import co.com.japl.module.paid.navigations.Paids
 import co.com.japl.module.paid.navigations.Period
+import co.com.japl.module.paid.R
 import co.com.japl.ui.Prefs
 import co.com.japl.ui.utils.DateUtils
+import co.japl.android.myapplication.utils.NumbersUtil
+import kotlinx.coroutines.Dispatchers
 
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.time.YearMonth
 import java.time.format.TextStyle
 import java.util.Locale
@@ -41,6 +49,10 @@ class MonthlyViewModel constructor(private val period:YearMonth,private val paid
     val incomesTotalState = mutableDoubleStateOf(0.0)
     val listGraph = mutableStateListOf<Pair<String,Double>>()
     val paidEmailDaysRead = mutableStateOf("${prefs?.paidEmailDaysRead ?: 7}")
+    val paidSMSDaysRead = mutableStateOf("${prefs?.paidSMSDaysRead ?: 7}")
+    val errorPaidEmailDaysRead = mutableStateOf(false)
+    val errorPaidSMSDaysRead = mutableStateOf(false)
+    val settingState = mutableStateOf(false)
 
     fun goToListDetail(){
         try {
@@ -155,9 +167,8 @@ class MonthlyViewModel constructor(private val period:YearMonth,private val paid
     }
 
     suspend fun readEmail(){
+        val numDaysRead = paidEmailDaysRead.value.toIntOrNull() ?: prefs?.paidEmailDaysRead ?: 7
         try {
-            val numDaysRead = paidEmailDaysRead.value.toIntOrNull() ?: prefs?.paidEmailDaysRead ?: 7
-
             emailSvc?.getAll()?.filter { it.active }?.forEach { emailConfig ->
 
                 emailSvc.validateMessagePattern(emailConfig, numDaysRead).filter { it.matched }.forEach { validation ->
@@ -182,10 +193,37 @@ class MonthlyViewModel constructor(private val period:YearMonth,private val paid
         }
     }
 
-    fun saveSettings() {
-        paidEmailDaysRead.value.toIntOrNull()?.let {
-            prefs?.paidEmailDaysRead = it
+    fun readEmail(context: Context){
+        settingState.value = false
+        viewModelScope.launch(Dispatchers.IO) {
+            readEmail()
+            withContext(Dispatchers.Main) {
+                Toast.makeText(context, R.string.email_read_process_completed, Toast.LENGTH_SHORT).show()
+            }
         }
+    }
+
+    fun saveSettings(context: Context) {
+        if(!errorPaidEmailDaysRead.value && !errorPaidSMSDaysRead.value) {
+            paidEmailDaysRead.value.toIntOrNull()?.let {
+                prefs?.paidEmailDaysRead = it
+            }
+            paidSMSDaysRead.value.toIntOrNull()?.let {
+                prefs?.paidSMSDaysRead = it
+            }
+            settingState.value = false
+            Toast.makeText(context, R.string.toast_saves_successful, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    fun validation(){
+        paidEmailDaysRead.value.takeIf { it.isNotEmpty() && NumbersUtil.isNumber(it) }?.let{
+            errorPaidEmailDaysRead.value = false
+        }?: errorPaidEmailDaysRead.let{it.value = true}
+
+        paidSMSDaysRead.value.takeIf { it.isNotEmpty() && NumbersUtil.isNumber(it) }?.let{
+            errorPaidSMSDaysRead.value = false
+        }?: errorPaidSMSDaysRead.let{it.value = true}
     }
 
 }

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/paid/list/PaidViewModel.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/paid/list/PaidViewModel.kt
@@ -1,24 +1,34 @@
 package co.com.japl.module.paid.controllers.paid.list
 
+import android.content.Context
+import android.util.Log
 import android.widget.Toast
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import androidx.navigation.NavController
 import co.com.japl.finances.iports.dtos.PaidDTO
+import co.com.japl.finances.iports.inbounds.paid.IEmailPaidPort
 import co.com.japl.finances.iports.inbounds.paid.IPaidPort
+import co.com.japl.finances.iports.inbounds.paid.ISmsPort
 import co.com.japl.module.paid.R
 import co.com.japl.module.paid.enums.PaidListOptions
 import co.com.japl.module.paid.navigations.Paid
 import co.com.japl.ui.Prefs
+import co.com.japl.ui.utils.DateUtils
+import co.japl.android.myapplication.utils.NumbersUtil
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import java.time.LocalDateTime
 import java.time.YearMonth
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 
-class PaidViewModel constructor(private val accountCode:Int, private val period:YearMonth,private val paidSvc:IPaidPort?=null,public val prefs:Prefs?,private val navController: NavController? = null): ViewModel(){
+class PaidViewModel constructor(private val accountCode:Int, private val period:YearMonth,private val paidSvc:IPaidPort?=null,public val prefs:Prefs?,private val navController: NavController? = null,private val emailSvc:IEmailPaidPort? = null,private val paidSmsSvc:ISmsPort?): ViewModel(){
 
     val progressStatus = mutableFloatStateOf(0.0f)
     val loaderState = mutableStateOf(true)
@@ -27,6 +37,13 @@ class PaidViewModel constructor(private val accountCode:Int, private val period:
 
     val periodOfList = mutableStateOf("")
     val allValues = mutableStateOf(0.0)
+    val paidEmailDaysRead = mutableStateOf("${prefs?.paidEmailDaysRead ?: 7}")
+    val paidSMSDaysRead = mutableStateOf("${prefs?.paidSMSDaysRead ?: 7}")
+    val errorPaidEmailDaysRead = mutableStateOf(false)
+    val errorPaidSMSDaysRead = mutableStateOf(false)
+
+    val settingState = mutableStateOf(false)
+
 
     fun newOne(){
         navController?.let {
@@ -78,6 +95,66 @@ class PaidViewModel constructor(private val accountCode:Int, private val period:
             }else{
                 navController?.let{ Toast.makeText(it.context, R.string.toast_unsuccessful_copy,Toast.LENGTH_LONG).show() }
             }
+        }
+    }
+
+    fun readEmail(context: Context){
+        settingState.value = false
+        viewModelScope.launch(Dispatchers.IO) {
+            readEmail()
+            withContext(Dispatchers.Main) {
+                Toast.makeText(context, R.string.email_read_process_completed, Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    fun saveSettings(context: Context) {
+        if(!errorPaidEmailDaysRead.value && !errorPaidSMSDaysRead.value) {
+            paidEmailDaysRead.value.toIntOrNull()?.let {
+                prefs?.paidEmailDaysRead = it
+            }
+            paidSMSDaysRead.value.toIntOrNull()?.let {
+                prefs?.paidSMSDaysRead = it
+            }
+            settingState.value = false
+            Toast.makeText(context, R.string.toast_saves_successful, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    fun validation(){
+        paidEmailDaysRead.value.takeIf { it.isNotEmpty() && NumbersUtil.isNumber(it) }?.let{
+            errorPaidEmailDaysRead.value = false
+        }?: errorPaidEmailDaysRead.let{it.value = true}
+
+        paidSMSDaysRead.value.takeIf { it.isNotEmpty() && NumbersUtil.isNumber(it) }?.let{
+            errorPaidSMSDaysRead.value = false
+        }?: errorPaidSMSDaysRead.let{it.value = true}
+    }
+
+    suspend fun readEmail(){
+        val numDaysRead = paidEmailDaysRead.value.toIntOrNull() ?: prefs?.paidEmailDaysRead ?: 7
+        try {
+            emailSvc?.getAll()?.filter { it.active }?.forEach { emailConfig ->
+
+                emailSvc.validateMessagePattern(emailConfig, numDaysRead).filter { it.matched }.forEach { validation ->
+
+                    val date = validation.date?.let {
+                        DateUtils.toLocalDate(it)
+                    }?.atStartOfDay()
+
+                    val value = validation.value?.toDoubleOrNull()
+                    if (date != null && value != null) {
+                        paidSmsSvc?.createBySms(
+                            name = validation.name ?: "",
+                            value = value,
+                            date = date,
+                            codeAccount = emailConfig.codeAccount
+                        )
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            Log.e(javaClass.name, e.message, e)
         }
     }
 

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/monthly/list/Monthly.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/monthly/list/Monthly.kt
@@ -11,12 +11,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.rounded.DirectionsRun
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.CalendarMonth
 import androidx.compose.material.icons.rounded.RemoveRedEye
-import androidx.compose.material.icons.rounded.SaveAs
-import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
@@ -111,6 +109,10 @@ viewModel.accountList
                         } ?: accountState?.let { it.value = null }
                     })
 
+                IconButton(onClick = { viewModel.settingState.value = true }) {
+                    Icon(imageVector = Icons.Rounded.Settings, contentDescription = stringResource(id = R.string.setting))
+                }
+
                 HelpWikiButton(wikiUrl = R.string.wiki_paid_url, descriptionContent = R.string.wiki_paid_description)
             }
 
@@ -118,39 +120,12 @@ viewModel.accountList
                 Accounts(viewModel = viewModel)
 
                 PiecePieGraph(list = listGraph)
-
-                Settings(viewModel = viewModel)
             }
 
         }
     }
-}
-
-@Composable
-private fun Settings(viewModel: MonthlyViewModel) {
-    val paidEmailDaysRead = viewModel.paidEmailDaysRead
-    Column(modifier = Modifier.padding(top = Dimensions.PADDING_SHORT)) {
-        HorizontalDivider()
-        Text(text = stringResource(R.string.setting), style = MaterialTheme.typography.titleMedium, modifier = Modifier.padding(vertical = Dimensions.PADDING_SHORT))
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            FieldText(
-                title = stringResource(R.string.msm_read_num),
-                value = paidEmailDaysRead.value,
-                modifier = Modifier.weight(1f)
-            ) { paidEmailDaysRead.value = it }
-
-            IconButton(onClick = { viewModel.saveSettings() }) {
-                Icon(imageVector = Icons.Rounded.SaveAs, contentDescription = stringResource(R.string.save))
-            }
-
-            IconButton(onClick = {
-                CoroutineScope(Dispatchers.IO).launch {
-                    viewModel.readEmail()
-                }
-            }) {
-                Icon(imageVector = Icons.AutoMirrored.Rounded.DirectionsRun, contentDescription = stringResource(R.string.email_read))
-            }
-        }
+    if(viewModel.settingState.value){
+        PopupSetting(viewModel = viewModel, state = viewModel.settingState)
     }
 }
 

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/monthly/list/Monthly.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/monthly/list/Monthly.kt
@@ -109,10 +109,6 @@ viewModel.accountList
                         } ?: accountState?.let { it.value = null }
                     })
 
-                IconButton(onClick = { viewModel.settingState.value = true }) {
-                    Icon(imageVector = Icons.Rounded.Settings, contentDescription = stringResource(id = R.string.setting))
-                }
-
                 HelpWikiButton(wikiUrl = R.string.wiki_paid_url, descriptionContent = R.string.wiki_paid_description)
             }
 
@@ -124,9 +120,7 @@ viewModel.accountList
 
         }
     }
-    if(viewModel.settingState.value){
-        PopupSetting(viewModel = viewModel, state = viewModel.settingState)
-    }
+
 }
 
 @Composable

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/monthly/list/PopUpView.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/monthly/list/PopUpView.kt
@@ -1,0 +1,74 @@
+package co.com.japl.module.paid.views.monthly.list
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ForwardToInbox
+import androidx.compose.material.icons.rounded.Cancel
+import androidx.compose.material.icons.rounded.Save
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import co.com.japl.module.paid.R
+import co.com.japl.module.paid.controllers.monthly.list.MonthlyViewModel
+import co.com.japl.ui.components.FieldText
+import co.com.japl.ui.components.FloatButton
+import co.com.japl.ui.components.Popup
+import co.com.japl.ui.theme.values.Dimensions
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PopupSetting(viewModel: MonthlyViewModel, state: MutableState<Boolean>) {
+    val paidEmailDaysRead = remember { viewModel.paidEmailDaysRead }
+    val errorPaidEmailDaysRead = remember { viewModel.errorPaidEmailDaysRead }
+    val paidSMSDaysRead = remember { viewModel.paidSMSDaysRead }
+    val errorPaidSMSDaysRead = remember { viewModel.errorPaidSMSDaysRead }
+    val context = LocalContext.current
+
+    Popup(title = R.string.setting, state = state) {
+        Scaffold(
+            floatingActionButton = {
+                Row {
+                    FloatButton(imageVector = Icons.AutoMirrored.Rounded.ForwardToInbox, descriptionIcon = R.string.email_read) {
+                        viewModel.readEmail(context)
+                    }
+                    FloatButton(imageVector = Icons.Rounded.Save, descriptionIcon = R.string.save) {
+                        viewModel.saveSettings(context)
+                    }
+                }
+            },
+            modifier = Modifier.padding(Dimensions.PADDING_SHORT)
+        ) {
+            Column(modifier = Modifier.padding(it)) {
+                FieldText(title = stringResource(id = R.string.msm_read_num),
+                    value = paidSMSDaysRead.value,
+                    hasErrorState = errorPaidSMSDaysRead,
+                    keyboardType = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    icon = Icons.Rounded.Cancel,
+                    validation = { viewModel.validation() },
+                    callback = {
+                        paidSMSDaysRead.value = it
+                    }, modifier = Modifier.padding(top = Dimensions.PADDING_SHORT).fillMaxWidth())
+
+                FieldText(title = stringResource(id = R.string.email_read_num),
+                    value = paidEmailDaysRead.value,
+                    hasErrorState = errorPaidEmailDaysRead,
+                    keyboardType = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    icon = Icons.Rounded.Cancel,
+                    validation = { viewModel.validation() },
+                    callback = {
+                        paidEmailDaysRead.value = it
+                    }, modifier = Modifier.padding(top = Dimensions.PADDING_SHORT).fillMaxWidth())
+            }
+        }
+    }
+}

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/paid/list/Paid.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/paid/list/Paid.kt
@@ -104,9 +104,8 @@ private fun Buttons(newOne:()->Unit){
 }
 
 @Composable private fun Header(viewModel: PaidViewModel){
-    val settingState = remember {
-        mutableStateOf(false)
-    }
+    val settingState = remember {viewModel.settingState}
+
     Row{
 
         FieldView(name = stringResource(id = R.string.period),
@@ -123,44 +122,7 @@ private fun Buttons(newOne:()->Unit){
             },modifier=Weight1f())
     }
     if(settingState.value){
-        Settings(settingState = settingState,prefs= viewModel.prefs)
-    }
-}
-
-@Composable private fun Settings( settingState: MutableState<Boolean>,prefs: Prefs?){
-    val daysSmsReadState = remember {
-        mutableStateOf(prefs?.paidSMSDaysRead?.toString()?:"0")
-    }
-    Popup(title = R.string.setting, state = settingState) {
-        Scaffold (floatingActionButton = {
-            FloatButton(imageVector = Icons.Rounded.Add, descriptionIcon = R.string.save) {
-                daysSmsReadState.value?.takeIf { it.isNotBlank() }?.let{
-                    prefs?.paidSMSDaysRead = it.toInt()
-                }
-                settingState.value = false
-            }
-            FloatButton(
-                imageVector = Icons.Rounded.Downloading, descriptionIcon = R.string.download_sms){
-
-                settingState.value = false
-            }
-
-        }) {
-            Column (modifier = Modifier
-                .padding(it)
-                .padding(Dimensions.PADDING_SHORT)) {
-                FieldText(title = stringResource(id = R.string.msm_read_num)
-                , value = daysSmsReadState.value
-                    , keyboardType = KeyboardOptions(keyboardType = KeyboardType.Number)
-                    , callback = {
-                        it.takeIf { it.isNotBlank() }?.let {
-                            daysSmsReadState.value = it
-                        }
-                    }
-                    ,modifier = Modifier.fillMaxWidth()
-                )
-            }
-        }
+        PopupSetting(viewModel = viewModel, state = settingState)
     }
 }
 
@@ -317,7 +279,7 @@ internal fun PaidPreviewDark() {
 
 @Composable
 private fun getViewModel():PaidViewModel{
-    val viewModel = PaidViewModel(paidSvc = null, accountCode = 0 , period = YearMonth.now(),prefs= null,navController = null)
+    val viewModel = PaidViewModel(paidSvc = null, accountCode = 0 , period = YearMonth.now(),prefs= null,navController = null, emailSvc = null, paidSmsSvc = null)
     viewModel.loaderState.value = false
     viewModel.allValues.value = 1000.0
     viewModel.periodOfList.value = "June 2022"

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/paid/list/PopUpView.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/paid/list/PopUpView.kt
@@ -1,4 +1,4 @@
-package co.com.japl.module.paid.views.monthly.list
+package co.com.japl.module.paid.views.paid.list
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -20,6 +20,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import co.com.japl.module.paid.R
 import co.com.japl.module.paid.controllers.monthly.list.MonthlyViewModel
+import co.com.japl.module.paid.controllers.paid.list.PaidViewModel
 import co.com.japl.ui.components.FieldText
 import co.com.japl.ui.components.FloatButton
 import co.com.japl.ui.components.Popup
@@ -27,7 +28,7 @@ import co.com.japl.ui.theme.values.Dimensions
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun PopupSetting(viewModel: MonthlyViewModel, state: MutableState<Boolean>) {
+fun PopupSetting(viewModel: PaidViewModel, state: MutableState<Boolean>) {
     val paidEmailDaysRead = remember { viewModel.paidEmailDaysRead }
     val errorPaidEmailDaysRead = remember { viewModel.errorPaidEmailDaysRead }
     val paidSMSDaysRead = remember { viewModel.paidSMSDaysRead }

--- a/japl-android-finances-paid-module/src/main/res/values/values.xml
+++ b/japl-android-finances-paid-module/src/main/res/values/values.xml
@@ -22,6 +22,7 @@
     <string name="end">Finalizar</string>
     <string name="setting">Configuración</string>
     <string name="msm_read_num">Número dias lectura SMS</string>
+    <string name="email_read_num">Número dias lectura Email</string>
 
     <string name="year">Año</string>
     <string name="month">Mes</string>


### PR DESCRIPTION
- Added PopupSetting to paid module to manage SMS and email lookback periods
- Updated MonthlyViewModel to handle setting persistence and validation
- Integrated settings icon in Monthly view to trigger the popup
- Refactored email reading logic for better reuse and UI feedback
- Added missing string resources for email lookback configuration