### PR TITLE
Refine DIAN Tax Declaration Logic

### DIFF
--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/adapters/inbound/implement/dian/GetTaxDeclarationUseCaseImpl.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/adapters/inbound/implement/dian/GetTaxDeclarationUseCaseImpl.kt
@@ -17,10 +17,11 @@ class GetTaxDeclarationUseCaseImpl @Inject constructor(
 
     override suspend fun getTaxDeclaration(year: Int): TaxDeclarationDTO {
         val uvt = configPort.getUVTValue(year)
-        val income = financialDataPort.getIncomeYTD(year)
-        val ccPurchases = financialDataPort.getCreditCardPurchasesYTD(year)
+        val income = financialDataPort.getIncomeForYear(year)
+        val ccPurchases = financialDataPort.getCreditCardPaymentsForYear(year)
+        val creditPayments = financialDataPort.getCreditPaymentsForYear(year)
         val debitPayments = financialDataPort.getDebitPaymentsYTD(year)
-        val totalConsumptions = ccPurchases.add(debitPayments)
+        val totalConsumptions = ccPurchases.add(debitPayments).add(creditPayments)
         val manualPatrimony = patrimonyPersistencePort.getAssets().sumOf { it.value }
 
         val reasons = mutableListOf<String>()

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/adapters/inbound/implement/dian/GetTaxProjectionUseCaseImpl.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/adapters/inbound/implement/dian/GetTaxProjectionUseCaseImpl.kt
@@ -16,22 +16,9 @@ class GetTaxProjectionUseCaseImpl @Inject constructor(
 ) : GetTaxProjectionUseCase {
 
     override suspend fun getProjection(year: Int): List<TaxProjectionDTO> {
-        val alpha = configPort.getAlphaSmoothingFactor()
         val uvt = configPort.getUVTValue(year)
-        val currentMonth = LocalDate.now().monthValue
-        val remainingMonths = 12 - currentMonth
-
-        if (remainingMonths <= 0) return emptyList()
-
         val incomeYTD = financialDataPort.getIncomeYTD(year)
-        val avgMonthlyIncomeActual = if (currentMonth > 0) incomeYTD.divide(BigDecimal.valueOf(currentMonth.toLong()), 2, RoundingMode.HALF_UP) else BigDecimal.ZERO
-        val avgMonthlyIncomeHist = financialDataPort.getAverageMonthlyIncomeHistorical()
-
-        val projectedIncome = incomeYTD.add(
-            (BigDecimal.valueOf(alpha).multiply(avgMonthlyIncomeActual).add(BigDecimal.valueOf(1 - alpha).multiply(avgMonthlyIncomeHist)))
-                .multiply(BigDecimal.valueOf(remainingMonths.toLong()))
-        )
-
+        val projectedIncome = financialDataPort.getProjectedIncome(year)
         val thresholdIncome = configPort.getIncomeThresholdUVT().multiply(uvt)
 
         return listOf(

--- a/japl-android-finances-services/src/main/java/co/japl/android/finances/services/core/FinancesModuleIntegrationAdapter.kt
+++ b/japl-android-finances-services/src/main/java/co/japl/android/finances/services/core/FinancesModuleIntegrationAdapter.kt
@@ -6,6 +6,9 @@ import co.japl.android.finances.services.dao.interfaces.IQuoteCreditCardDAO
 import co.japl.android.finances.services.dao.interfaces.ICreditDAO
 import co.japl.android.finances.services.dao.interfaces.IInputDAO
 import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.Month
+import java.time.temporal.ChronoUnit
 import javax.inject.Inject
 
 class FinancesModuleIntegrationAdapter @Inject constructor(
@@ -37,5 +40,95 @@ class FinancesModuleIntegrationAdapter @Inject constructor(
 
     override suspend fun getAverageMonthlyExpenseHistorical(): BigDecimal {
         return BigDecimal.ZERO
+    }
+
+    override suspend fun getIncomeForYear(year: Int): BigDecimal {
+        val inputs = inputDAO.getAll()
+        var total = BigDecimal.ZERO
+        inputs.forEach { input ->
+            val startOfYear = LocalDate.of(year, 1, 1)
+            val endOfYear = LocalDate.of(year, 12, 31)
+            val start = if (input.dateStart.isBefore(startOfYear)) startOfYear else input.dateStart
+            val end = if (input.dateEnd.isAfter(endOfYear)) endOfYear else input.dateEnd
+
+            if (start.isBefore(end) || start.isEqual(end)) {
+                val months = countOccurrences(start, end, input.kindOf)
+                total = total.add(input.value.multiply(BigDecimal.valueOf(months.toLong())))
+            }
+        }
+        return total
+    }
+
+    override suspend fun getProjectedIncome(year: Int): BigDecimal {
+        val inputs = inputDAO.getAll().filter { it.dateEnd.isAfter(LocalDate.now()) }
+        var total = BigDecimal.ZERO
+        inputs.forEach { input ->
+            val factor = when (input.kindOf.lowercase()) {
+                "mensual" -> 12
+                "bi-mensual" -> 6
+                "trimestral" -> 4
+                "cuatrimestral" -> 3
+                "semestral" -> 2
+                "anual" -> 1
+                else -> 0
+            }
+            total = total.add(input.value.multiply(BigDecimal.valueOf(factor.toLong())))
+        }
+        return total
+    }
+
+    override suspend fun getCreditCardPaymentsForYear(year: Int): BigDecimal {
+        val boughts = boughtDAO.getAll()
+        var total = BigDecimal.ZERO
+        boughts.forEach { bought ->
+            val startOfYear = LocalDate.of(year, 1, 1)
+            val endOfYear = LocalDate.of(year, 12, 31)
+            val start = if (bought.boughtDate.toLocalDate().isBefore(startOfYear)) startOfYear else bought.boughtDate.toLocalDate()
+            val end = if (bought.endDate.toLocalDate().isAfter(endOfYear)) endOfYear else bought.endDate.toLocalDate()
+
+            if (start.isBefore(end) || start.isEqual(end)) {
+                val months = ChronoUnit.MONTHS.between(start.withDayOfMonth(1), end.withDayOfMonth(1)) + 1
+                val quoteValue = bought.valueItem.divide(BigDecimal.valueOf(bought.month.toLong()), 2, java.math.RoundingMode.HALF_UP)
+                total = total.add(quoteValue.multiply(BigDecimal.valueOf(months)))
+            }
+        }
+        return total
+    }
+
+    override suspend fun getCreditPaymentsForYear(year: Int): BigDecimal {
+        val credits = creditDAO.getAll()
+        var total = BigDecimal.ZERO
+        credits.forEach { credit ->
+            val startOfYear = LocalDate.of(year, 1, 1)
+            val endOfYear = LocalDate.of(year, 12, 31)
+            val start = if (credit.date.isBefore(startOfYear)) startOfYear else credit.date
+            val endDate = credit.date.plusMonths(credit.periods.toLong())
+            val end = if (endDate.isAfter(endOfYear)) endOfYear else endDate
+
+            if (start.isBefore(end) || start.isEqual(end)) {
+                val months = ChronoUnit.MONTHS.between(start.withDayOfMonth(1), end.withDayOfMonth(1)) + 1
+                total = total.add(credit.quoteValue.multiply(BigDecimal.valueOf(months)))
+            }
+        }
+        return total
+    }
+
+    private fun countOccurrences(start: LocalDate, end: LocalDate, periodicity: String): Int {
+        val step = when (periodicity.lowercase()) {
+            "mensual" -> 1
+            "bi-mensual" -> 2
+            "trimestral" -> 3
+            "cuatrimestral" -> 4
+            "semestral" -> 6
+            "anual" -> 12
+            else -> return 0
+        }
+        var count = 0
+        var current = start
+        while (current.isBefore(end) || current.isEqual(end)) {
+            count++
+            current = current.plusMonths(step.toLong())
+        }
+        return count
     }
 }

--- a/japl-finances-iports/src/main/java/co/com/japl/finances/iports/outbounds/TaxOutboundPorts.kt
+++ b/japl-finances-iports/src/main/java/co/com/japl/finances/iports/outbounds/TaxOutboundPorts.kt
@@ -28,6 +28,11 @@ interface ExternalFinancialDataPort {
     suspend fun getOutstandingDebts(year: Int): BigDecimal
     suspend fun getAverageMonthlyIncomeHistorical(): BigDecimal
     suspend fun getAverageMonthlyExpenseHistorical(): BigDecimal
+
+    suspend fun getIncomeForYear(year: Int): BigDecimal
+    suspend fun getProjectedIncome(year: Int): BigDecimal
+    suspend fun getCreditCardPaymentsForYear(year: Int): BigDecimal
+    suspend fun getCreditPaymentsForYear(year: Int): BigDecimal
 }
 
 interface TaxHistoryPersistencePort {


### PR DESCRIPTION
This change refines the Colombian tax declaration (DIAN) logic. It implements a more accurate approach for calculating income projections using annualized multipliers (e.g., Monthly x12) and for calculating annual consumption by summing only those credit and credit card installments that occurred during the specific tax year being declared or projected.

---
*PR created automatically by Jules for task [14573244704717496286](https://jules.google.com/task/14573244704717496286) started by @nano871022*