### PR TITLE
Fix app icon and Google Drive crash

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,8 +18,8 @@ android {
         applicationId "co.japl.android.myapplication"
         minSdk 26
         targetSdk 36
-        versionCode 4_08_01_172
-        versionName "V 4.08.01 build 172 FIx issues with AI and sms read"
+        versionCode 4_08_01_173
+        versionName "V 4.08.01 build 173 FIx issues with AI and sms read"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,7 +23,8 @@
          android:usesCleartextTraffic="true"
         android:name=".finanzas.ApplicationInitial"
         android:allowBackup="true"
-
+        android:icon="@mipmap/ic_finanzas"
+        android:roundIcon="@mipmap/ic_finanzas_round"
         android:label="@string/app_name"
 
         android:supportsRtl="true"

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/bussiness/impl/GoogleDriveImpl.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/bussiness/impl/GoogleDriveImpl.kt
@@ -78,10 +78,10 @@ class GoogleDriveImpl(private val context:Context, private val dbConnect:Connect
         }
     }
     private fun getDrive(account: GoogleSignInAccount?):Drive? {
-        return account?.let {
+        return account?.email?.takeIf { it.isNotBlank() }?.let { email ->
             val transport = GoogleNetHttpTransport.newTrustedTransport()
             GoogleAccountCredential.usingOAuth2(context, SCOPES).apply {
-                selectedAccountName = account.email
+                selectedAccountName = email
             }?.let { credential ->
                 return Drive.Builder(transport, GsonFactory.getDefaultInstance(), credential)
                     .setApplicationName("Finanzas")
@@ -93,12 +93,14 @@ class GoogleDriveImpl(private val context:Context, private val dbConnect:Connect
     fun getDrive(authorizationResult:AuthorizationResult):Drive? {
         val transport = GoogleNetHttpTransport.newTrustedTransport()
         val account = authorizationResult.toGoogleSignInAccount()
-        return GoogleAccountCredential.usingOAuth2(context, SCOPES).apply {
-            selectedAccountName = account?.email
-        }?.let { credential ->
-            return Drive.Builder(transport, GsonFactory.getDefaultInstance(), credential)
-                .setApplicationName("Finanzas")
-                .build()
+        return account?.email?.takeIf { it.isNotBlank() }?.let { email ->
+            GoogleAccountCredential.usingOAuth2(context, SCOPES).apply {
+                selectedAccountName = email
+            }?.let { credential ->
+                return Drive.Builder(transport, GsonFactory.getDefaultInstance(), credential)
+                    .setApplicationName("Finanzas")
+                    .build()
+            }
         }
     }
 


### PR DESCRIPTION
This submission fixes two issues:
1. The application icon was not showing correctly after installation, defaulting to the Android logo. I've updated the `AndroidManifest.xml` to explicitly use the `ic_finanzas` resources.
2. A fatal `java.lang.IllegalArgumentException` was occurring during Google Drive operations because the account name was null. I've updated `GoogleDriveImpl.kt` to ensure a non-blank email is available before attempting to create the `GoogleAccountCredential`.

---
*PR created automatically by Jules for task [11153565073556152149](https://jules.google.com/task/11153565073556152149) started by @nano871022*