### PR TITLE
Resolve Manifest Merger Conflict for App Icons

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.CREDENTIAL_MANAGER_QUERY_CANDIDATE_CREDENTIALS" />
     <uses-permission android:name="android.permission.INTERNET"/>
@@ -28,7 +29,8 @@
         android:label="@string/app_name"
 
         android:supportsRtl="true"
-        android:theme="@style/Theme.finances">
+        android:theme="@style/Theme.finances"
+        tools:replace="android:icon,android:roundIcon">
 
         <meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version"/>
 


### PR DESCRIPTION
The build was failing due to manifest merger conflicts between the main app and the `:about-module` dependency regarding the `android:icon` and `android:roundIcon` attributes.

This change adds the `tools:replace` directive to the main `AndroidManifest.xml` to ensure the app's icons take precedence over those defined in the library module.

---
*PR created automatically by Jules for task [6769678911081324125](https://jules.google.com/task/6769678911081324125) started by @nano871022*