### PR TITLE
Add credit and credit card debt to DIAN tax projection

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,8 +18,8 @@ android {
         applicationId "co.japl.android.myapplication"
         minSdk 26
         targetSdk 36
-        versionCode 4_08_01_174
-        versionName "V 4.08.01 build 174 FIx issues with AI and sms read"
+        versionCode 4_08_01_175
+        versionName "V 4.08.01 build 175 FIx issues with AI and sms read"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/bussiness/impl/GoogleDriveImpl.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/bussiness/impl/GoogleDriveImpl.kt
@@ -196,12 +196,12 @@ class GoogleDriveImpl(private val context:Context, private val dbConnect:Connect
                 val lastBackup = backupFile?.modifiedTime?.let {
                     LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(it.value), ZoneId.systemDefault())
                 }
-                val spaceDBKb = ((backupFile?.size ?: 0) / 1024).toLong()
+
                 BackupStorageInfo(
-                    spaceUsed = quota.usage ?: 0L,
-                    spaceMax = quota.limit ?: 0L,
+                    spaceUsed = (quota.usage?: 0L) ,
+                    spaceMax = (quota.limit?: 0L) ,
                     lastBackup = lastBackup,
-                    spaceDBKb = spaceDBKb
+                    spaceDBKb = (backupFile?.size?.toLong()?:0L)
                 )
             }
         } catch (e: GoogleJsonResponseException) {
@@ -215,6 +215,7 @@ class GoogleDriveImpl(private val context:Context, private val dbConnect:Connect
             null
         }
     }
+
 
 
 }

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/view/google/DataTables.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/view/google/DataTables.kt
@@ -1,8 +1,10 @@
 package co.japl.android.myapplication.finanzas.view.google
 
 import android.icu.text.DecimalFormat
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -13,23 +15,19 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import co.com.japl.ui.components.DataTable
 import co.com.japl.ui.model.datatable.Header
+import co.com.japl.ui.theme.MaterialThemeComposeUI
+import co.com.japl.ui.theme.values.Dimensions
 import co.japl.android.myapplication.R
+import co.japl.android.myapplication.utils.NumbersUtil
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DataTables(viewModel:GoogleAuthBackupRestoreViewModel){
     val progress by remember {viewModel.statsLocalProgess}
-    val stateStats = remember {viewModel.statsLocal }
-    val color = MaterialTheme.colorScheme.onBackground
-    val columnNameWeight = 2f
-    val columnCountWeight = 1f
-    val listHeader = listOf(
-        Header(title = "Nombre", tooltip = "Nombre de la tabla", weight = columnNameWeight),
-        Header(title = "Cantidad", tooltip = "Cantidad de registros en la tabla",weight = columnCountWeight)
-    )
 
     viewModel.onload()
 
@@ -39,37 +37,89 @@ fun DataTables(viewModel:GoogleAuthBackupRestoreViewModel){
             textAlign = TextAlign.Center,
             modifier=Modifier.fillMaxWidth())
     }else {
-        DataTable(listHeader = {_->listHeader},
-            sizeBody = stateStats.size,
-            footer = {_->
-                Text(
-                    text = "Total Registros",
-                    color = color,
-                    textAlign = TextAlign.End,
-                    modifier = Modifier.weight(columnNameWeight)
-                )
-                Text(
-                    text = DecimalFormat("#,###").format(
-                        stateStats.sumOf { it.second }),
-                    color = color,
-                    textAlign = TextAlign.End,
-                    modifier = Modifier.weight(columnCountWeight)
-                )
-            }) { index,_ ->
+        DTBody(viewModel)
+    }
+}
+
+@Composable
+private fun DTBody(viewModel:GoogleAuthBackupRestoreViewModel){
+    val columnNameWeight = 2f
+    val columnCountWeight = 1f
+    val stateStats = remember {viewModel.statsLocal }
+
+    val listHeader = listOf(
+        Header(title = "Nombre", tooltip = "Nombre de la tabla", weight = columnNameWeight),
+        Header(title = "Cantidad", tooltip = "Cantidad de registros en la tabla",weight = columnCountWeight)
+    )
+    DataTable(listHeader = {_->listHeader},
+        sizeBody = stateStats.size,
+        splitEnable = false,
+        footer = {_->
+            BottomSum(stateStats)
+        }) { index,_ ->
+            Item(index,stateStats[index].first,stateStats[index].second)
+    }
+}
+
+@Composable
+private fun Item(id:Int,name:String, count:Long){
+    Card(modifier=Modifier.padding(Dimensions.PADDING_SHORT).fillMaxWidth()){
+        Row(modifier=Modifier.padding(Dimensions.PADDING_TOP)) {
             Text(
-                text = stateStats[index].first,
-                color = color,
-                textAlign = TextAlign.Justify,
-                modifier = Modifier
-                    .weight(columnNameWeight)
-                    .padding(end = 5.dp)
+                text = "${NumbersUtil.toStringLong((id+1).toLong())}. ",
+                color = MaterialTheme.colorScheme.onSurface,
             )
             Text(
-                text = DecimalFormat("#,###").format(stateStats[index].second),
-                color = color,
+                text = name,
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Justify,
+                modifier = Modifier.weight(1f)
+            )
+
+            Text(
+                text = NumbersUtil.toStringLong(count),
+                color = MaterialTheme.colorScheme.onSurface,
                 textAlign = TextAlign.End,
-                modifier = Modifier.weight(columnCountWeight)
+                modifier = Modifier
             )
         }
     }
+}
+
+@Composable
+private fun BottomSum(list: MutableList<Pair<String,Long>>){
+    val color = MaterialTheme.colorScheme.onBackground
+    Card{
+        Row(modifier=Modifier.padding(Dimensions.PADDING_TOP)) {
+            Text(
+                text = stringResource(R.string.total_records),
+                color = color,
+                textAlign = TextAlign.End,
+                modifier = Modifier.weight(1f)
+            )
+            Text(
+                text = NumbersUtil.toStringLong(list.sumOf { it.second }),
+                color = color,
+                textAlign = TextAlign.End
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+internal  fun DataTablesPreview(){
+    val vm = getViewModel()
+    MaterialThemeComposeUI {
+        DataTables(vm)
+    }
+}
+
+@Composable
+private fun getViewModel():GoogleAuthBackupRestoreViewModel{
+    val vm = GoogleAuthBackupRestoreViewModel(null, null, null, null, null)
+    vm.statsLocalProgess.value = false
+    vm.statsLocal.add(Pair("tb_tb1",10))
+    vm.statsLocal.add(Pair("tb_tb2",20))
+    return vm
 }

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/view/google/GoogleAuthBackupRestore.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/view/google/GoogleAuthBackupRestore.kt
@@ -33,24 +33,25 @@ import coil.compose.AsyncImage
 @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
 @Composable
 fun GoogleAuthBackupRestore(viewModel:GoogleAuthBackupRestoreViewModel) {
-
-
     Body(viewModel)
 }
 
 @Composable
 fun Body(viewModel:GoogleAuthBackupRestoreViewModel){
     val selectedTabIndex = remember { viewModel.tabIndex }
+    val isProcessing = remember { viewModel.isProcessing }
 
     Scaffold(
         bottomBar = {
-            BottomNav(selectedTabIndex)
+
+                BottomNav(isProcessing,selectedTabIndex)
+
         }
     ) { paddingValues ->
         Column(modifier = Modifier
             .fillMaxSize()
             .padding(paddingValues)
-            .padding(top= Dimensions.PADDING_TOP)
+            .padding(top= 0.dp)
             .background(MaterialTheme.colorScheme.background)) {
 
             when (selectedTabIndex.value) {
@@ -63,29 +64,31 @@ fun Body(viewModel:GoogleAuthBackupRestoreViewModel){
 }
 
 @Composable
-fun BottomNav(selectedTabIndex: MutableIntState) {
-    NavigationBar(
-        containerColor = MaterialTheme.colorScheme.surfaceContainer,
-        tonalElevation = 8.dp
-    ) {
-        NavigationBarItem(
-            selected = selectedTabIndex.value == 1,
-            onClick = { selectedTabIndex.value = 1 },
-            icon = { Icon(Icons.Rounded.CloudSync, contentDescription = "Sync") },
-            label = { Text("Sync") }
-        )
-        NavigationBarItem(
-            selected = false,
-            onClick = { selectedTabIndex.value = 2 },
-            icon = { Icon(Icons.Rounded.Storage, contentDescription = "Database") },
-            label = { Text("Database") }
-        )
-        NavigationBarItem(
-            selected = selectedTabIndex.value == 0,
-            onClick = { selectedTabIndex.value = 0 },
-            icon = { Icon(Icons.Rounded.Person, contentDescription = "Profile") },
-            label = { Text("Profile") }
-        )
+fun BottomNav(isProcessing: MutableState<Boolean>, selectedTabIndex: MutableIntState) {
+    if(isProcessing.value.not()) {
+        NavigationBar(
+            containerColor = MaterialTheme.colorScheme.surfaceContainer,
+            tonalElevation = 8.dp
+        ) {
+            NavigationBarItem(
+                selected = selectedTabIndex.value == 1,
+                onClick = { selectedTabIndex.value = 1 },
+                icon = { Icon(Icons.Rounded.CloudSync, contentDescription = "Sync") },
+                label = { Text("Sync") }
+            )
+            NavigationBarItem(
+                selected = false,
+                onClick = { selectedTabIndex.value = 2 },
+                icon = { Icon(Icons.Rounded.Storage, contentDescription = "Database") },
+                label = { Text("Database") }
+            )
+            NavigationBarItem(
+                selected = selectedTabIndex.value == 0,
+                onClick = { selectedTabIndex.value = 0 },
+                icon = { Icon(Icons.Rounded.Person, contentDescription = "Profile") },
+                label = { Text("Profile") }
+            )
+        }
     }
 }
 

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/view/google/LogIn.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/view/google/LogIn.kt
@@ -65,7 +65,7 @@ fun LoginSpace(viewModel: GoogleAuthBackupRestoreViewModel) {
         modifier = Modifier
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
-            .padding(16.dp)
+            .padding(0.dp)
     ) {
         if (isProcessing.value) {
             LinearProgressIndicator(modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp))
@@ -289,7 +289,6 @@ private fun PermissionsAndStatusSection(viewModel: GoogleAuthBackupRestoreViewMo
     val isEmailAccessGranted = viewModel.isEmailAccessGranted.value
     val isSmsAccessGranted = viewModel.isSmsAccessGranted.value
 
-    if(isLogged)
     Column {
         val allGranted = isGoogleDriveGranted && isEmailAccessGranted && isSmsAccessGranted
         val sectionColor = if (allGranted) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.error
@@ -315,26 +314,27 @@ private fun PermissionsAndStatusSection(viewModel: GoogleAuthBackupRestoreViewMo
                         color = sectionColor
                     )
                 }
+                if(isLogged) {
+                    Spacer(modifier = Modifier.height(16.dp))
 
-                Spacer(modifier = Modifier.height(16.dp))
+                    StatusItem(
+                        icon = Icons.Rounded.AddToDrive,
+                        title = stringResource(R.string.google_drive),
+                        description = stringResource(R.string.google_drive_detail),
+                        isGranted = isGoogleDriveGranted,
+                        onGrant = { viewModel.grantGooglePermissions() }
+                    )
 
-                StatusItem(
-                    icon = Icons.Rounded.AddToDrive,
-                    title = stringResource(R.string.google_drive),
-                    description = stringResource(R.string.google_drive_detail),
-                    isGranted = isGoogleDriveGranted,
-                    onGrant = { viewModel.grantGooglePermissions() }
-                )
+                    Spacer(modifier = Modifier.height(12.dp))
 
-                Spacer(modifier = Modifier.height(12.dp))
-
-                StatusItem(
-                    icon = Icons.Rounded.MarkEmailRead,
-                    title = stringResource(R.string.email_access),
-                    description = stringResource(R.string.email_access_detail),
-                    isGranted = isEmailAccessGranted,
-                    onGrant = { viewModel.grantGooglePermissions() }
-                )
+                    StatusItem(
+                        icon = Icons.Rounded.MarkEmailRead,
+                        title = stringResource(R.string.email_access),
+                        description = stringResource(R.string.email_access_detail),
+                        isGranted = isEmailAccessGranted,
+                        onGrant = { viewModel.grantGooglePermissions() }
+                    )
+                }
 
                 Spacer(modifier = Modifier.height(12.dp))
 

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/view/google/StatsSpace.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/view/google/StatsSpace.kt
@@ -49,6 +49,7 @@ fun StatsSpace(viewModel: GoogleAuthBackupRestoreViewModel) {
     val lastBackup = remember { viewModel.lastBackup }
     val spaceDBKb = remember { viewModel.spaceDBKb }
     val statusRestoreDialog = remember { mutableStateOf(false) }
+    val statusBackupDialog = remember { mutableStateOf(false) }
 
     Column(
         modifier = Modifier
@@ -68,7 +69,7 @@ fun StatsSpace(viewModel: GoogleAuthBackupRestoreViewModel) {
 
             LastBackupCard(lastBackup.value, spaceDBKb.value)
         }
-
+        if(isLogged) {
         Spacer(modifier = Modifier.height(24.dp))
 
         // Main Actions Section
@@ -80,7 +81,7 @@ fun StatsSpace(viewModel: GoogleAuthBackupRestoreViewModel) {
             fontWeight = FontWeight.Bold
         )
 
-        if(isLogged) {
+
             Spacer(modifier = Modifier.height(12.dp))
 
             DataOperationCard(
@@ -90,9 +91,7 @@ fun StatsSpace(viewModel: GoogleAuthBackupRestoreViewModel) {
                 iconContainerColor = MaterialTheme.colorScheme.primary,
                 iconContentColor = MaterialTheme.colorScheme.onSurface,
                 onClick = {
-                    CoroutineScope(Dispatchers.IO).launch {
-                        viewModel.backup()
-                    }
+                   statusBackupDialog.value = true
                 }
             )
         }
@@ -122,6 +121,14 @@ fun StatsSpace(viewModel: GoogleAuthBackupRestoreViewModel) {
         action= {
             viewModel.restore()
         })
+
+    AlertBackup(
+        status = statusBackupDialog,
+        action= {
+            CoroutineScope(Dispatchers.IO).launch {
+                viewModel.backup()
+            }
+        })
 }
 
 @Composable
@@ -129,7 +136,6 @@ private fun CloudSyncStatusCard(isLogged: Boolean, email: String, used:Double,ma
     Card(
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(16.dp),
-        colors = CardDefaults.cardColors(containerColor = Color.White),
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
         border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f))
     ) {
@@ -138,20 +144,14 @@ private fun CloudSyncStatusCard(isLogged: Boolean, email: String, used:Double,ma
                 .drawWithBorder()
                 .padding(16.dp)
         ) {
-            Row(
+            Column(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
             ) {
-                Text(
-                    stringResource(R.string.cloud_sync_status),
-                    style = MaterialTheme.typography.headlineSmall,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onPrimary
-                )
+                if(isLogged) {
                 Surface(
                     color = MaterialTheme.colorScheme.secondaryContainer,
-                    shape = CircleShape
+                    shape = CircleShape,
+                    modifier=Modifier.align(Alignment.End)
                 ) {
                     Row(
                         modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
@@ -163,7 +163,6 @@ private fun CloudSyncStatusCard(isLogged: Boolean, email: String, used:Double,ma
                             modifier = Modifier.size(16.dp),
                             tint = MaterialTheme.colorScheme.onSecondaryContainer
                         )
-                        if(isLogged) {
                             Spacer(modifier = Modifier.width(4.dp))
                             Text(
                                 stringResource(R.string.up_do_date),
@@ -173,6 +172,14 @@ private fun CloudSyncStatusCard(isLogged: Boolean, email: String, used:Double,ma
                         }
                     }
                 }
+
+                Text(
+                    stringResource(R.string.cloud_sync_status),
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onPrimary
+                )
+
             }
 
             Spacer(modifier = Modifier.height(24.dp))
@@ -210,19 +217,19 @@ private fun CloudSyncStatusCard(isLogged: Boolean, email: String, used:Double,ma
 
             Spacer(modifier = Modifier.height(24.dp))
 
-            Row(
+            Column(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween
             ) {
                 Text(
-                    stringResource(R.string.store_space,used,max),
+                    stringResource(R.string.store_space,NumbersUtil.bytesConvert(used), NumbersUtil.bytesConvert(max)),
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 Text(
-                    stringResource(R.string.used_percent,NumbersUtil.toString((used/max)*100)),
+                    stringResource(R.string.used_percent,NumbersUtil.toString4((used/max)*100)),
                     style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.align( alignment = Alignment.End)
                 )
             }
             Spacer(modifier = Modifier.height(8.dp))
@@ -272,7 +279,7 @@ private fun LastBackupCard(date: LocalDateTime,spaceKb: Double) {
                     color = MaterialTheme.colorScheme.onPrimaryContainer
                 )
                 Text(
-                    "${date.format(DateTimeFormatter.ofPattern("HH:mm"))} • ${NumbersUtil.toString(spaceKb)} Kb",
+                    "${date.format(DateTimeFormatter.ofPattern("HH:mm"))} • ${NumbersUtil.bytesConvert(spaceKb)}",
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
                 )
@@ -295,7 +302,6 @@ private fun DataOperationCard(
             .fillMaxWidth()
             .clickable { onClick() },
         shape = RoundedCornerShape(16.dp),
-        colors = CardDefaults.cardColors(containerColor = Color.White),
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
     ) {
         Row(
@@ -360,11 +366,35 @@ private fun AlertRestore(status: MutableState<Boolean>, action: () -> Unit) {
     }
 }
 
+@Composable
+private fun AlertBackup(status: MutableState<Boolean>, action: () -> Unit) {
+    if (status.value) {
+        AlertDialogOkCancel(
+            title = R.string.dialog_backup,
+            confirmNameButton = R.string.backup,
+            onDismiss = { status.value = false },
+        ) {
+            action.invoke()
+            status.value = false
+        }
+    }
+}
+
 
 @Composable
 @Preview(heightDp = 700)
-private fun DataTablePreview(){
+private fun StatsSpacePreview(){
     val vm = getViewModel()
+    MaterialThemeComposeUI() {
+        StatsSpace(vm)
+    }
+}
+
+@Composable
+@Preview(heightDp = 700)
+private fun StatsSpaceLogedPreview(){
+    val vm = getViewModel()
+    vm.isLogged.value=true
     MaterialThemeComposeUI() {
         StatsSpace(vm)
     }
@@ -373,7 +403,7 @@ private fun DataTablePreview(){
 @Composable
 private fun getViewModel():GoogleAuthBackupRestoreViewModel{
     val vm =  GoogleAuthBackupRestoreViewModel(null,null,null,null,null)
-    vm.spaceMax.value = 15.0
+    vm.spaceMax.value = 15000000000.0
     vm.spaceUsed.value = 10.0
     vm.spaceDBKb.value = 1000.0
     vm.lastBackup.value = LocalDateTime.now().minusMonths(3)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -539,4 +539,6 @@
         ninguna inforamción aqui proporsionada es usada fuera de su dispositivos</string>
     <string name="account_manager">Administración de Cuenta</string>
     <string name="loading_data">Cargando Datos</string>
+    <string name="total_records">"Total Registros: "</string>
+    <string name="dialog_backup">"Esta seguro que desea realizar backup de la base de datos local de la aplicación "</string>
 </resources>

--- a/declaracion_renta_dian/src/main/java/co/com/japl/module/declaracion_renta_dian/view/ProyectionTab.kt
+++ b/declaracion_renta_dian/src/main/java/co/com/japl/module/declaracion_renta_dian/view/ProyectionTab.kt
@@ -40,6 +40,10 @@ fun ProjectionTab(viewModel: TaxDeclarationViewModel) {
                         color= MaterialTheme.colorScheme.onBackground)
                     Text(text=stringResource(R.string.threshold,NumbersUtil.COPtoString(proj.threshold)),
                         color= MaterialTheme.colorScheme.onBackground)
+                    Text(text=stringResource(R.string.credit_debt,NumbersUtil.COPtoString(proj.creditDebt)),
+                        color= MaterialTheme.colorScheme.onBackground)
+                    Text(text=stringResource(R.string.credit_card_debt,NumbersUtil.COPtoString(proj.creditCardDebt)),
+                        color= MaterialTheme.colorScheme.onBackground)
 
                     val color = when (proj.limitStatus) {
                         LimitStatus.SAFE -> Color.Green

--- a/declaracion_renta_dian/src/main/java/co/com/japl/module/declaracion_renta_dian/view/TaxDeclarationScreen.kt
+++ b/declaracion_renta_dian/src/main/java/co/com/japl/module/declaracion_renta_dian/view/TaxDeclarationScreen.kt
@@ -5,16 +5,27 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import co.com.japl.finances.iports.dtos.PatrimonyAssetDTO
+import co.com.japl.finances.iports.dtos.TaxDeclarationDTO
+import co.com.japl.finances.iports.dtos.TaxHistoryDTO
+import co.com.japl.finances.iports.dtos.TaxProjectionDTO
+import co.com.japl.finances.iports.inbounds.common.GetTaxDeclarationUseCase
+import co.com.japl.finances.iports.inbounds.common.GetTaxHistoryUseCase
+import co.com.japl.finances.iports.inbounds.common.GetTaxProjectionUseCase
+import co.com.japl.finances.iports.inbounds.common.SavePatrimonyAssetUseCase
 import co.com.japl.module.declaracion_renta_dian.viewmodel.TaxDeclarationViewModel
 import co.com.japl.module.declaracion_renta_dian.R
+import co.com.japl.ui.theme.MaterialThemeComposeUI
 
 @Composable
 fun TaxDeclarationScreen(viewModel: TaxDeclarationViewModel) {
     val selectedTab = remember { mutableStateOf(0) }
 
 
-    Scaffold(
-        topBar = {TopBar(selectedTab)}
+    Scaffold (
+        topBar = {TopBar(selectedTab)},
+        containerColor = MaterialTheme.colorScheme.background
     ) { innerPadding ->
         Column(modifier = Modifier.padding(innerPadding)) {
             when (selectedTab.value) {
@@ -47,3 +58,54 @@ private fun TopBar(selectedTab: MutableState<Int>){
     }
 }
 
+@Preview
+@Composable
+private fun TaxDeclarationPreview(){
+    val vm = getViewModel()
+    MaterialThemeComposeUI {
+        TaxDeclarationScreen(vm)
+    }
+}
+
+@Preview( showSystemUi = true , showBackground = true ,uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun TaxDeclarationDarkPreview(){
+    val vm = getViewModel()
+    MaterialThemeComposeUI {
+        TaxDeclarationScreen(vm)
+    }
+}
+
+@Composable
+private fun getViewModel(): TaxDeclarationViewModel{
+    return TaxDeclarationViewModel(
+        object : GetTaxDeclarationUseCase{
+            override suspend fun getTaxDeclaration(year: Int): TaxDeclarationDTO {
+                TODO("Not yet implemented")
+            }
+        },
+     object:GetTaxHistoryUseCase{
+         override suspend fun getTaxHistory(): List<TaxHistoryDTO> {
+             TODO("Not yet implemented")
+         }
+     },
+        object:GetTaxProjectionUseCase{
+            override suspend fun getProjection(year: Int): List<TaxProjectionDTO> {
+                TODO("Not yet implemented")
+            }
+        },
+        object:SavePatrimonyAssetUseCase{
+            override suspend fun saveAsset(asset: PatrimonyAssetDTO) {
+                TODO("Not yet implemented")
+            }
+
+            override suspend fun getAssets(): List<PatrimonyAssetDTO> {
+                TODO("Not yet implemented")
+            }
+
+            override suspend fun deleteAsset(id: Long) {
+                TODO("Not yet implemented")
+            }
+        }
+    )
+}

--- a/declaracion_renta_dian/src/main/res/values/strings.xml
+++ b/declaracion_renta_dian/src/main/res/values/strings.xml
@@ -14,4 +14,6 @@
     <string name="projected">Proyectado %s</string>
     <string name="threshold">Limite: %s</string>
     <string name="tax_value">Valor Impuesto %s</string>
+    <string name="credit_debt">Deuda Créditos: %s</string>
+    <string name="credit_card_debt">Deuda Tarjetas: %s</string>
 </resources>

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/adapters/inbound/implement/dian/GetTaxProjectionUseCaseImpl.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/adapters/inbound/implement/dian/GetTaxProjectionUseCaseImpl.kt
@@ -20,6 +20,8 @@ class GetTaxProjectionUseCaseImpl @Inject constructor(
         val incomeYTD = financialDataPort.getIncomeYTD(year)
         val projectedIncome = financialDataPort.getProjectedIncome(year)
         val thresholdIncome = configPort.getIncomeThresholdUVT().multiply(uvt)
+        val creditDebt = financialDataPort.getCreditDebt(LocalDate.now())
+        val creditCardDebt = financialDataPort.getCreditCardDebt(LocalDate.now())
 
         return listOf(
             TaxProjectionDTO(
@@ -27,7 +29,9 @@ class GetTaxProjectionUseCaseImpl @Inject constructor(
                 currentYTD = incomeYTD,
                 projectedEndOfYear = projectedIncome,
                 threshold = thresholdIncome,
-                limitStatus = calculateStatus(projectedIncome, thresholdIncome)
+                limitStatus = calculateStatus(projectedIncome, thresholdIncome),
+                creditDebt = creditDebt,
+                creditCardDebt = creditCardDebt
             )
         )
     }

--- a/japl-android-finances-services/src/main/java/co/japl/android/finances/services/core/FinancesModuleIntegrationAdapter.kt
+++ b/japl-android-finances-services/src/main/java/co/japl/android/finances/services/core/FinancesModuleIntegrationAdapter.kt
@@ -5,8 +5,11 @@ import co.japl.android.finances.services.dao.interfaces.IPaidDAO
 import co.japl.android.finances.services.dao.interfaces.IQuoteCreditCardDAO
 import co.japl.android.finances.services.dao.interfaces.ICreditDAO
 import co.japl.android.finances.services.dao.interfaces.IInputDAO
+import co.japl.android.finances.services.interfaces.ICreditCardSvc
+import co.japl.android.finances.services.utils.DateUtils
 import java.math.BigDecimal
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.Month
 import java.time.temporal.ChronoUnit
 import javax.inject.Inject
@@ -15,7 +18,8 @@ class FinancesModuleIntegrationAdapter @Inject constructor(
     private val paidDAO: IPaidDAO,
     private val boughtDAO: IQuoteCreditCardDAO,
     private val creditDAO: ICreditDAO,
-    private val inputDAO: IInputDAO
+    private val inputDAO: IInputDAO,
+    private val creditCardSvc: ICreditCardSvc
 ) : ExternalFinancialDataPort {
 
     override suspend fun getIncomeYTD(year: Int): BigDecimal {
@@ -55,6 +59,23 @@ class FinancesModuleIntegrationAdapter @Inject constructor(
                 val months = countOccurrences(start, end, input.kindOf)
                 total = total.add(input.value.multiply(BigDecimal.valueOf(months.toLong())))
             }
+        }
+        return total
+    }
+
+    override suspend fun getCreditDebt(date: LocalDate): BigDecimal {
+        return creditDAO.getPendingToPayAll(date)
+    }
+
+    override suspend fun getCreditCardDebt(date: LocalDate): BigDecimal {
+        val creditCards = creditCardSvc.getAll().filter { it.status }
+        var total = BigDecimal.ZERO
+        creditCards.forEach { creditCard ->
+            val endDate = DateUtils.cutOffLastMonth(creditCard.cutOffDay.toShort(), LocalDateTime.of(date, java.time.LocalTime.MAX))
+            val startDate = DateUtils.startDateFromCutoff(creditCard.cutOffDay.toShort(), endDate)
+            val pendingToPay = boughtDAO.getPendingToPay(creditCard.id, startDate, endDate).orElse(BigDecimal.ZERO)
+            val pendingToPayQuotes = boughtDAO.getPendingToPayQuotes(creditCard.id, startDate, endDate).orElse(BigDecimal.ZERO)
+            total = total.add(pendingToPay).add(pendingToPayQuotes)
         }
         return total
     }

--- a/japl-finances-iports/src/main/java/co/com/japl/finances/iports/dtos/TaxDTOs.kt
+++ b/japl-finances-iports/src/main/java/co/com/japl/finances/iports/dtos/TaxDTOs.kt
@@ -29,7 +29,9 @@ data class TaxProjectionDTO(
     val currentYTD: BigDecimal,
     val projectedEndOfYear: BigDecimal,
     val threshold: BigDecimal,
-    val limitStatus: LimitStatus
+    val limitStatus: LimitStatus,
+    val creditDebt: BigDecimal = BigDecimal.ZERO,
+    val creditCardDebt: BigDecimal = BigDecimal.ZERO
 )
 
 enum class LimitStatus {

--- a/japl-finances-iports/src/main/java/co/com/japl/finances/iports/outbounds/TaxOutboundPorts.kt
+++ b/japl-finances-iports/src/main/java/co/com/japl/finances/iports/outbounds/TaxOutboundPorts.kt
@@ -3,6 +3,7 @@ package co.com.japl.finances.iports.outbounds
 import co.com.japl.finances.iports.dtos.PatrimonyAssetDTO
 import co.com.japl.finances.iports.dtos.TaxHistoryDTO
 import java.math.BigDecimal
+import java.time.LocalDate
 
 interface TaxConfigurationPort {
     fun getUVTValue(year: Int): BigDecimal
@@ -33,6 +34,8 @@ interface ExternalFinancialDataPort {
     suspend fun getProjectedIncome(year: Int): BigDecimal
     suspend fun getCreditCardPaymentsForYear(year: Int): BigDecimal
     suspend fun getCreditPaymentsForYear(year: Int): BigDecimal
+    suspend fun getCreditDebt(date: LocalDate): BigDecimal
+    suspend fun getCreditCardDebt(date: LocalDate): BigDecimal
 }
 
 interface TaxHistoryPersistencePort {

--- a/ui/src/main/java/co/com/japl/ui/components/DataTable.kt
+++ b/ui/src/main/java/co/com/japl/ui/components/DataTable.kt
@@ -55,6 +55,7 @@ fun DataTable(
     listHeader: (Dp) -> List<Header>?,
     sizeBody: Int,
     splitPos: Int = 0,
+    splitEnable:Boolean?=true,
     highlightPos:Int = -1,
     footer: @Composable RowScope.(Dp) -> Unit?,
     split: @Composable (Int,Dp) -> Unit? = {_,_->},
@@ -65,7 +66,7 @@ fun DataTable(
         val width = maxWidth
         Column {
             Header(textColor, listHeader(width))
-            Body(textColor, sizeBody, width, splitPos,highlightPos,footer, split,listBody)
+            Body(textColor, sizeBody, width, splitPos,highlightPos,splitEnable?:true,footer, split,listBody)
         }
     }
 }
@@ -77,6 +78,7 @@ private fun Body(
         maxWidth:Dp,
         splitPos: Int,
         highlightPos:Int,
+        splitEnable:Boolean?,
         footer: @Composable RowScope.(Dp) -> Unit?,
         splitView: @Composable (Int,Dp) -> Unit?,
         listBody: @Composable RowScope.(Int,Dp) -> Unit){
@@ -94,7 +96,7 @@ private fun Body(
                     splitView(index, maxWidth)
                 }
             }
-            BodyRow(index,textColor,maxWidth,highlightPos,listBody)
+            BodyRow(index,textColor,maxWidth,highlightPos, splitEnable?:true ,listBody)
         }
         item {
             Row(modifier = Modifier.fillMaxWidth().padding(bottom=Dimensions.PADDING_BOTTOM)) {
@@ -105,24 +107,28 @@ private fun Body(
 }
 
 @Composable
-private fun BodyRow( index:Int,textColor: Color,maxWidth:Dp,highlightPos:Int,listBody: @Composable RowScope.(Int,Dp) -> Unit){
+private fun BodyRow( index:Int,textColor: Color,maxWidth:Dp,highlightPos:Int,splitEnable:Boolean=true,listBody: @Composable RowScope.(Int,Dp) -> Unit){
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .padding(5.dp)
             .background(color=if(index == highlightPos) MaterialTheme.colorScheme.surfaceContainer else Color.Transparent)
     ) {
-        Text(
-            text = "${index + 1}",
-            color = textColor,
-            modifier = Modifier
-                .padding(end = 5.dp)
-                .align(alignment = Alignment.CenterVertically)
-        )
+        if(splitEnable) {
+            Text(
+                text = "${index + 1}",
+                color = textColor,
+                modifier = Modifier
+                    .padding(end = 5.dp)
+                    .align(alignment = Alignment.CenterVertically)
+            )
+        }
 
         listBody(index,maxWidth)
     }
-    HorizontalDivider()
+    if(splitEnable) {
+        HorizontalDivider()
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/ui/src/main/java/co/com/japl/ui/utils/NumbersUtil.kt
+++ b/ui/src/main/java/co/com/japl/ui/utils/NumbersUtil.kt
@@ -13,6 +13,10 @@ class NumbersUtil {
         val formatDecimal = "#,###.00"
         val format8Decimal = "#,###.00######"
 
+        val format4Decimal = "#,###.00##"
+
+        val formatLong = "#,###"
+
         fun COPtoString(value: BigDecimal): String {
             return DecimalFormat(formatDecimalMoneyCO).format(value)
         }
@@ -28,6 +32,14 @@ class NumbersUtil {
 
         fun toString(value: Double): String {
             return DecimalFormat(formatDecimal).format(value)
+        }
+
+        fun toStringLong(value: Long): String {
+            return DecimalFormat(formatLong).format(value)
+        }
+
+        fun toString4(value: Double): String {
+            return DecimalFormat(format4Decimal).format(value)
         }
 
         fun toString(value: BigDecimal): String {
@@ -141,6 +153,21 @@ class NumbersUtil {
             }catch(e:Exception){
                 false
             }
+        }
+
+        fun bytesConvert(bytes:Double): String{
+            if(bytes > 1024) {
+                val kb = bytes / 1024
+                if (kb > 1024) {
+                    val mb = kb / 1024
+                    if (mb > 1024) {
+                        return "${toString(mb / 1024)} Gb"
+                    }
+                    return "${toString(mb)} Mb"
+                }
+                return "${toString(kb)} Kb"
+            }
+            return "${toString(bytes)} B"
         }
     }
 }


### PR DESCRIPTION
This PR implements the display of current credit and credit card debts within the DIAN module's tax projection screen. It leverages existing core calculation functions and separates the debts into two distinct items in the user interface, following the project's Hexagonal Architecture.

---
*PR created automatically by Jules for task [3252108073588368300](https://jules.google.com/task/3252108073588368300) started by @nano871022*