### PR TITLE
Decentralize enums and params from iports to feature modules

### DIFF
--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/enums/MoreOptionsItemsCreditCard.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/enums/MoreOptionsItemsCreditCard.kt
@@ -1,9 +1,10 @@
-package co.com.japl.finances.iports.enums
+package co.com.japl.module.creditcard.enums
 
 import androidx.annotation.StringRes
 import co.com.japl.ui.R
+import co.com.japl.ui.enums.IMoreOptions
 
-enum class MoreOptionsItemsCreditCard(@StringRes val title: Int) {
+enum class MoreOptionsItemsCreditCard(@StringRes val title: Int) : IMoreOptions {
 
     EDIT(R.string.ccio_edit),
     AMORTIZATION(R.string.ccio_amortization),
@@ -13,4 +14,6 @@ enum class MoreOptionsItemsCreditCard(@StringRes val title: Int) {
     DIFFER_INSTALLMENT(R.string.differ_installment),
     CLONE(R.string.ccio_clone)
     ,RESTORE(R.string.ccio_restore);
+
+    override fun getName() = title
 }

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/AmortizationTableFragment.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/AmortizationTableFragment.kt
@@ -13,7 +13,7 @@ import androidx.navigation.fragment.findNavController
 import co.com.japl.module.creditcard.controllers.amortization.AmortizationViewModel
 import co.com.japl.module.creditcard.views.amortization.AmortizationTable
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.finances.iports.params.AmortizationTableParams
+import co.com.japl.module.creditcard.params.AmortizationTableParams
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/BoughWalletController.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/BoughWalletController.kt
@@ -19,7 +19,7 @@ import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.com.japl.module.credit.databinding.BuyWalletCreditCardBinding
 import co.com.japl.ui.Prefs
 import co.com.japl.ui.factory.ViewModelFactory
-import co.com.japl.finances.iports.params.BoughWalletParams
+import co.com.japl.module.creditcard.params.BoughWalletParams
 import dagger.hilt.android.AndroidEntryPoint
 import java.time.LocalDateTime
 import javax.inject.Inject

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/CashAdvanceSave.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/CashAdvanceSave.kt
@@ -18,7 +18,7 @@ import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.com.japl.module.credit.databinding.CashAdvanceCreditCardBinding
 import co.com.japl.ui.Prefs
 import co.com.japl.ui.factory.ViewModelFactory
-import co.com.japl.finances.iports.params.CashAdvanceParams
+import co.com.japl.module.creditcard.params.CashAdvanceParams
 import dagger.hilt.android.AndroidEntryPoint
 import java.time.LocalDateTime
 import javax.inject.Inject

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/CreateCreditCardFragment.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/CreateCreditCardFragment.kt
@@ -13,7 +13,7 @@ import androidx.navigation.fragment.findNavController
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.com.japl.module.creditcard.controllers.account.CreditCardViewModel
 import co.com.japl.module.creditcard.views.account.forms.CreditCard
-import co.com.japl.finances.iports.params.CreditCardParams
+import co.com.japl.module.creditcard.params.CreditCardParams
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/CreditCardSettingFragment.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/CreditCardSettingFragment.kt
@@ -13,7 +13,7 @@ import androidx.navigation.fragment.findNavController
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.com.japl.module.creditcard.views.setting.forms.CreditCardSetting
 import co.com.japl.module.creditcard.controllers.setting.CreditCardSettingViewModel
-import co.com.japl.finances.iports.params.CreditCardSettingParams
+import co.com.japl.module.creditcard.params.CreditCardSettingParams
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/EmailFragment.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/EmailFragment.kt
@@ -19,7 +19,7 @@ import co.com.japl.ui.Prefs
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.com.japl.module.credit.databinding.FragmentEmailCreditCardBinding
 import co.com.japl.ui.factory.ViewModelFactory
-import co.com.japl.finances.iports.params.EmailCreditCardParams
+import co.com.japl.module.creditcard.params.EmailCreditCardParams
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlin.getValue

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/EmailListFragment.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/EmailListFragment.kt
@@ -18,7 +18,7 @@ import co.com.japl.module.creditcard.views.email.list.EmailList
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.com.japl.module.credit.databinding.FragmentEmailCreditCardBinding
 import co.com.japl.ui.factory.ViewModelFactory
-import co.com.japl.finances.iports.params.EmailCreditCardParams
+import co.com.japl.module.creditcard.params.EmailCreditCardParams
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlin.getValue

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/ListBought.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/ListBought.kt
@@ -12,7 +12,7 @@ import androidx.navigation.fragment.findNavController
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.com.japl.module.credit.databinding.FragmentListBoughtBinding
 import co.com.japl.ui.Prefs
-import co.com.japl.finances.iports.params.CreditCardQuotesParams
+import co.com.japl.module.creditcard.params.CreditCardQuotesParams
 import co.japl.android.myapplication.finanzas.view.creditcard.bought.BoughtList
 import dagger.hilt.android.AndroidEntryPoint
 

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/ListBoughtViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/ListBoughtViewModel.kt
@@ -13,8 +13,8 @@ import co.com.japl.finances.iports.inbounds.creditcard.bought.lists.IBoughtListP
 import co.com.japl.ui.Prefs
 import co.japl.android.myapplication.finanzas.modules.EntryPoint
 import co.com.japl.finances.iports.pojo.BoughtCreditCard
-import co.com.japl.finances.iports.params.CashAdvanceParams
-import co.com.japl.finances.iports.params.CreditCardQuotesParams
+import co.com.japl.module.creditcard.params.CashAdvanceParams
+import co.com.japl.module.creditcard.params.CreditCardQuotesParams
 import co.japl.android.myapplication.pojo.CreditCard
 import dagger.hilt.EntryPoints
 import kotlinx.coroutines.runBlocking

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/ListCreditCardSettingFragment.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/ListCreditCardSettingFragment.kt
@@ -13,7 +13,7 @@ import androidx.navigation.fragment.findNavController
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.com.japl.module.creditcard.controllers.setting.CreditCardSettingListViewModel
 import co.com.japl.module.creditcard.views.setting.lists.CreditCardSettingList
-import co.com.japl.finances.iports.params.ListCreditCardSettingParams
+import co.com.japl.module.creditcard.params.ListCreditCardSettingParams
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/ListQuotesPaid.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/ListQuotesPaid.kt
@@ -13,7 +13,7 @@ import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.creditcard.bought.lists.IBoughtListPort
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.com.japl.module.credit.databinding.FragmentListPeriodsBinding
-import co.com.japl.finances.iports.params.PeriodsParams
+import co.com.japl.module.creditcard.params.PeriodsParams
 import co.com.japl.module.creditcard.controllers.paid.BoughtCreditCardViewModel
 import co.com.japl.module.creditcard.views.paid.PaidList
 import co.com.japl.ui.Prefs

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/QuoteBought.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/QuoteBought.kt
@@ -21,7 +21,7 @@ import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.com.japl.module.credit.databinding.BuysCreditCardBinding
 import co.com.japl.ui.Prefs
 import co.com.japl.ui.factory.ViewModelFactory
-import co.com.japl.finances.iports.params.CreditCardQuotesParams
+import co.com.japl.module.creditcard.params.CreditCardQuotesParams
 import dagger.hilt.android.AndroidEntryPoint
 import java.time.LocalDateTime
 import javax.inject.Inject

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/RecurrentBoughtListFragment.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/RecurrentBoughtListFragment.kt
@@ -16,7 +16,7 @@ import co.japl.android.myapplication.finanzas.modules.EntryPoint
 import dagger.hilt.EntryPoints
 import dagger.hilt.android.AndroidEntryPoint
 import androidx.navigation.fragment.findNavController
-import co.com.japl.finances.iports.params.CreditCardQuotesParams
+import co.com.japl.module.creditcard.params.CreditCardQuotesParams
 import co.com.japl.ui.Prefs
 import javax.inject.Inject
 

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/SmsFragment.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/SmsFragment.kt
@@ -17,7 +17,7 @@ import co.com.japl.module.creditcard.views.sms.forms.Sms
 import co.com.japl.ui.Prefs
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.com.japl.module.credit.databinding.FragmentSmsCreditCardBinding
-import co.com.japl.finances.iports.params.SmsCreditCardParams
+import co.com.japl.module.creditcard.params.SmsCreditCardParams
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/Taxes.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/Taxes.kt
@@ -15,7 +15,7 @@ import co.com.japl.module.creditcard.controllers.creditrate.forms.CreateRateView
 import co.com.japl.module.creditcard.views.creditrate.forms.CreditRate
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.com.japl.module.credit.databinding.FragmentTaxesBinding
-import co.com.japl.finances.iports.params.TaxesParams
+import co.com.japl.module.creditcard.params.TaxesParams
 import co.com.japl.ui.utils.NumbersUtil
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/params/AmortizationTableParams.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/params/AmortizationTableParams.kt
@@ -1,0 +1,60 @@
+package co.com.japl.module.creditcard.params
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.core.net.toUri
+import androidx.core.os.bundleOf
+import androidx.navigation.NavController
+import co.com.japl.ui.utils.DateUtils
+import co.com.japl.ui.R
+import co.japl.android.finances.services.dto.CalcDTO
+
+import co.com.japl.finances.iports.enums.AmortizationKindOfEnum
+import co.com.japl.module.creditcard.params.PeriodsParams.Params
+import com.google.gson.Gson
+import java.time.LocalDate
+
+class AmortizationTableParams {
+
+    object params{
+        val ARG_PARAM_CREDIT_VALUE = "credit_value"
+        val ARG_PARAM_KIND_OF_AMORTIZATION = "kind_of_amortization"
+    }
+
+    companion object{
+        fun newInstance(creditValue:CalcDTO,navController: NavController){
+            val parameters = bundleOf(params.ARG_PARAM_CREDIT_VALUE to Gson().toJson(creditValue),params.ARG_PARAM_KIND_OF_AMORTIZATION to AmortizationKindOfEnum.EXTRA_VALUE_AMORTIZATION)
+            navController.navigate(R.id.action_item_menu_side_listsave_to_amortizationTableFragment,parameters)
+        }
+
+        fun newInstanceQuotes(code:Long,navController:NavController){
+            val parameters = bundleOf("CODE" to code)
+            navController.navigate(R.id.action_list_bought_to_amortizationTableFragment,parameters)
+        }
+
+        fun download(argument: Bundle):Map<String,Any>{
+            argument.let {
+                if( it.containsKey(Params.PARAM_DEEPLINK) ){
+                    val intent = (it.get(Params.PARAM_DEEPLINK) as Intent).dataString?.toUri()
+                    val date = intent?.getQueryParameter("last_date")?.let{ DateUtils.toLocalDate(it) }
+                    return@download mapOf<String,Any>(
+                        "CREDIT_CODE" to (intent?.getQueryParameter("credit_code")?.toLong()?:0.toLong()),
+                        "CODE" to (intent?.getQueryParameter("code")?.toLong()?:0.toLong()),
+                        "LAST_DATE" to (date?: LocalDate.now())
+                    )
+                }else{
+                    val code = it.getLong("CODE")
+                    return@download mapOf<String,Any>(
+                        "CODE" to code
+                    )
+                }
+            }
+            return mapOf()
+        }
+
+        fun toBack(navController: NavController){
+            navController.popBackStack()
+        }
+    }
+
+}

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/params/BoughWalletParams.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/params/BoughWalletParams.kt
@@ -1,4 +1,4 @@
-package co.com.japl.finances.iports.params
+package co.com.japl.module.creditcard.params
 
 import android.content.Intent
 import android.net.Uri
@@ -6,13 +6,12 @@ import android.os.Bundle
 import androidx.core.os.bundleOf
 import androidx.navigation.NavController
 import co.com.japl.ui.R
-import co.com.japl.ui.utils.NumbersUtil
 
-class CashAdvanceParams {
+class BoughWalletParams {
 
     object params{
         val ARG_PARAM_CODE_CREDIT_CARD = "cod_credit_card"
-        val ARG_PARA_CREDIT_CARD_CODE = "CreditCardCode"
+        val ARG_PARAM_CREDIT_CARD_CODE = "CreditCardCode"
         val ARG_PARAM_CODE_BOUGHT = "cod_bought"
         val ARG_PARAM_BOUGHT_ID_CREDIT_CARD = "bought_id_credit_card"
         val PARAM_DEEPLINK = "android-support-nav:controller:deepLinkIntent"
@@ -21,12 +20,7 @@ class CashAdvanceParams {
     companion object{
         fun newInstance(code:Int,navController: NavController){
             val parameters = bundleOf(params.ARG_PARAM_CODE_CREDIT_CARD to code.toString())
-            navController.navigate(R.id.action_item_menu_side_boughtmade_to_cash_advance_fragment,parameters)
-        }
-
-        fun newInstanceFloat(code:Int,navController: NavController){
-            val parameters = bundleOf(params.ARG_PARAM_CODE_CREDIT_CARD to code.toString())
-            navController.navigate(R.id.action_list_bought_to_cash_advance_fragment,parameters)
+            navController.navigate(R.id.action_item_menu_side_boughtmade_to_boughWalletController,parameters)
         }
         fun download(argument:Bundle):Pair<Int,Int?>{
             argument.let {
@@ -38,11 +32,9 @@ class CashAdvanceParams {
                         codeCreditCard = it.toInt()
                     }
                 }
-                it.getString(params.ARG_PARAM_CODE_CREDIT_CARD)?.let {
-                    codeCreditCard = it.toInt()
-                }
+                codeCreditCard =  codeCreditCard?:it.getString(params.ARG_PARAM_CODE_CREDIT_CARD)?.toInt()
 
-                it.getString(params.ARG_PARA_CREDIT_CARD_CODE)?.takeIf{ it?.isNotBlank() == true && NumbersUtil.isNumber(it)}?.let{
+                it.getString(params.ARG_PARAM_CREDIT_CARD_CODE)?.let {
                     codeCreditCard = it.toInt()
                 }
 
@@ -52,13 +44,14 @@ class CashAdvanceParams {
                         codeBought = it.toInt()
                     }
                 }
-                codeBought = codeBought?:it.getString(params.ARG_PARAM_CODE_BOUGHT)?.toInt()
+                codeBought =  codeBought?:it.getString(params.ARG_PARAM_CODE_BOUGHT)?.toInt()
                 it.getInt(params.ARG_PARAM_BOUGHT_ID_CREDIT_CARD)?.let {
                     codeBought = it
                 }
                 return Pair(codeCreditCard!!,codeBought)
             }
         }
+
         fun toBack(navController: NavController){
             navController.popBackStack()
         }

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/params/CashAdvanceParams.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/params/CashAdvanceParams.kt
@@ -1,4 +1,4 @@
-package co.com.japl.finances.iports.params
+package co.com.japl.module.creditcard.params
 
 import android.content.Intent
 import android.net.Uri
@@ -6,12 +6,13 @@ import android.os.Bundle
 import androidx.core.os.bundleOf
 import androidx.navigation.NavController
 import co.com.japl.ui.R
+import co.com.japl.ui.utils.NumbersUtil
 
-class BoughWalletParams {
+class CashAdvanceParams {
 
     object params{
         val ARG_PARAM_CODE_CREDIT_CARD = "cod_credit_card"
-        val ARG_PARAM_CREDIT_CARD_CODE = "CreditCardCode"
+        val ARG_PARA_CREDIT_CARD_CODE = "CreditCardCode"
         val ARG_PARAM_CODE_BOUGHT = "cod_bought"
         val ARG_PARAM_BOUGHT_ID_CREDIT_CARD = "bought_id_credit_card"
         val PARAM_DEEPLINK = "android-support-nav:controller:deepLinkIntent"
@@ -20,7 +21,12 @@ class BoughWalletParams {
     companion object{
         fun newInstance(code:Int,navController: NavController){
             val parameters = bundleOf(params.ARG_PARAM_CODE_CREDIT_CARD to code.toString())
-            navController.navigate(R.id.action_item_menu_side_boughtmade_to_boughWalletController,parameters)
+            navController.navigate(R.id.action_item_menu_side_boughtmade_to_cash_advance_fragment,parameters)
+        }
+
+        fun newInstanceFloat(code:Int,navController: NavController){
+            val parameters = bundleOf(params.ARG_PARAM_CODE_CREDIT_CARD to code.toString())
+            navController.navigate(R.id.action_list_bought_to_cash_advance_fragment,parameters)
         }
         fun download(argument:Bundle):Pair<Int,Int?>{
             argument.let {
@@ -32,9 +38,11 @@ class BoughWalletParams {
                         codeCreditCard = it.toInt()
                     }
                 }
-                codeCreditCard =  codeCreditCard?:it.getString(params.ARG_PARAM_CODE_CREDIT_CARD)?.toInt()
+                it.getString(params.ARG_PARAM_CODE_CREDIT_CARD)?.let {
+                    codeCreditCard = it.toInt()
+                }
 
-                it.getString(params.ARG_PARAM_CREDIT_CARD_CODE)?.let {
+                it.getString(params.ARG_PARA_CREDIT_CARD_CODE)?.takeIf{ it?.isNotBlank() == true && NumbersUtil.isNumber(it)}?.let{
                     codeCreditCard = it.toInt()
                 }
 
@@ -44,14 +52,13 @@ class BoughWalletParams {
                         codeBought = it.toInt()
                     }
                 }
-                codeBought =  codeBought?:it.getString(params.ARG_PARAM_CODE_BOUGHT)?.toInt()
+                codeBought = codeBought?:it.getString(params.ARG_PARAM_CODE_BOUGHT)?.toInt()
                 it.getInt(params.ARG_PARAM_BOUGHT_ID_CREDIT_CARD)?.let {
                     codeBought = it
                 }
                 return Pair(codeCreditCard!!,codeBought)
             }
         }
-
         fun toBack(navController: NavController){
             navController.popBackStack()
         }

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/params/CreditCardParams.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/params/CreditCardParams.kt
@@ -1,4 +1,4 @@
-package co.com.japl.finances.iports.params
+package co.com.japl.module.creditcard.params
 
 import android.content.Intent
 import android.net.Uri
@@ -10,7 +10,6 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.FragmentManager
 import androidx.navigation.NavController
 import co.com.japl.ui.R
-import co.com.japl.finances.iports.params.CreditCardParams.Params.ARG_PARAM_CODE
 import java.util.*
 
 class CreditCardParams(var parentFragmentManagers: FragmentManager) {

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/params/CreditCardQuotesParams.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/params/CreditCardQuotesParams.kt
@@ -1,4 +1,4 @@
-package co.com.japl.finances.iports.params
+package co.com.japl.module.creditcard.params
 
 import android.content.Intent
 import android.net.Uri

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/params/CreditCardSettingParams.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/params/CreditCardSettingParams.kt
@@ -1,4 +1,4 @@
-package co.com.japl.finances.iports.params
+package co.com.japl.module.creditcard.params
 
 import android.content.Intent
 import android.net.Uri
@@ -7,8 +7,8 @@ import android.util.Log
 import androidx.core.os.bundleOf
 import androidx.navigation.NavController
 import co.com.japl.ui.R
-import co.com.japl.finances.iports.params.CreditCardSettingParams.Params.ARG_CODE_CREDIT_CARD
-import co.com.japl.finances.iports.params.CreditCardSettingParams.Params.ARG_ID
+import co.com.japl.module.creditcard.params.CreditCardSettingParams.Params.ARG_CODE_CREDIT_CARD
+import co.com.japl.module.creditcard.params.CreditCardSettingParams.Params.ARG_ID
 
 class CreditCardSettingParams {
     object Params {

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/params/EmailCreditCardParams.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/params/EmailCreditCardParams.kt
@@ -1,24 +1,24 @@
-package co.com.japl.finances.iports.params
+package co.com.japl.module.creditcard.params
 
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 
 
-object EmailPaidsParams {
+object EmailCreditCardParams {
     const val PARAM_DEEPLINK = "android-support-nav:controller:deepLinkIntent"
-    const val CODE_EMAIL_PD = "code_email_paid"
+    const val CODE_EMAIL_CC = "code_email_credit_card"
 
     fun download(bundle: Bundle): Int {
         if(bundle.containsKey(PARAM_DEEPLINK)) {
             val intent = bundle.get(PARAM_DEEPLINK) as Intent
-            val value = Uri.parse(intent.dataString).getQueryParameter(CODE_EMAIL_PD)
+            val value = Uri.parse(intent.dataString).getQueryParameter(CODE_EMAIL_CC)
             return value?.toInt()?:0
         }
-        return bundle.getInt(CODE_EMAIL_PD, 0)
+        return bundle.getInt(CODE_EMAIL_CC, 0)
     }
 
     fun upload(bundle: Bundle, code: Int) {
-        bundle.putInt(CODE_EMAIL_PD, code)
+        bundle.putInt(CODE_EMAIL_CC, code)
     }
 }

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/params/ListCreditCardSettingParams.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/params/ListCreditCardSettingParams.kt
@@ -1,4 +1,4 @@
-package co.com.japl.finances.iports.params
+package co.com.japl.module.creditcard.params
 
 import android.content.Intent
 import android.net.Uri
@@ -7,7 +7,7 @@ import android.util.Log
 import androidx.core.os.bundleOf
 import androidx.navigation.NavController
 import co.com.japl.ui.R
-import co.com.japl.finances.iports.params.CreditCardSettingParams.Params.ARG_CODE_CREDIT_CARD
+import co.com.japl.module.creditcard.params.CreditCardSettingParams.Params.ARG_CODE_CREDIT_CARD
 
 class ListCreditCardSettingParams {
     object Params {

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/params/PeriodsParams.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/params/PeriodsParams.kt
@@ -1,4 +1,4 @@
-package co.com.japl.finances.iports.params
+package co.com.japl.module.creditcard.params
 
 import android.content.Intent
 import android.net.Uri

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/params/SmsCreditCardParams.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/params/SmsCreditCardParams.kt
@@ -1,4 +1,4 @@
-package co.com.japl.finances.iports.params
+package co.com.japl.module.creditcard.params
 
 import android.content.Intent
 import android.net.Uri
@@ -8,7 +8,6 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.FragmentManager
 import androidx.navigation.NavController
 import co.com.japl.ui.R
-import co.com.japl.finances.iports.params.CreditCardParams.Params.ARG_PARAM_CODE
 
 class SmsCreditCardParams(var parentFragmentManagers: FragmentManager) {
     object Params {

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/params/TaxesParams.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/params/TaxesParams.kt
@@ -1,4 +1,4 @@
-package co.com.japl.finances.iports.params
+package co.com.japl.module.creditcard.params
 
 import android.content.Intent
 import android.net.Uri
@@ -6,10 +6,10 @@ import android.os.Bundle
 import androidx.core.os.bundleOf
 import androidx.navigation.NavController
 import co.com.japl.ui.R
-import co.com.japl.finances.iports.params.TaxesParams.Params.ARG_CODE_CREDIT_CARD
-import co.com.japl.finances.iports.params.TaxesParams.Params.ARG_CODE_CREDIT_RATE
-import co.com.japl.finances.iports.params.TaxesParams.Params.ARG_PARAM1
-import co.com.japl.finances.iports.params.TaxesParams.Params.ARG_PARAM2
+import co.com.japl.module.creditcard.params.TaxesParams.Params.ARG_CODE_CREDIT_CARD
+import co.com.japl.module.creditcard.params.TaxesParams.Params.ARG_CODE_CREDIT_RATE
+import co.com.japl.module.creditcard.params.TaxesParams.Params.ARG_PARAM1
+import co.com.japl.module.creditcard.params.TaxesParams.Params.ARG_PARAM2
 
 class TaxesParams {
     object Params {

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/MainActivity.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/MainActivity.kt
@@ -24,7 +24,7 @@ import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.*
 import co.com.japl.ui.interfaces.ISMSObserver
-import co.com.japl.finances.iports.params.CreditCardQuotesParams
+import co.com.japl.module.creditcard.params.CreditCardQuotesParams
 import co.japl.android.myapplication.finanzas.controller.*
 import co.japl.android.myapplication.finanzas.interfaces.ISMSBoadcastReceiver
 import co.japl.android.myapplication.finanzas.modules.EntryPoint

--- a/credit/src/main/java/co/com/japl/module/credit/fragments/AdditionalCreditFragment.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/fragments/AdditionalCreditFragment.kt
@@ -13,7 +13,7 @@ import androidx.navigation.fragment.findNavController
 import co.com.japl.module.credit.controllers.forms.AdditionalFormViewModel
 import co.com.japl.module.credit.views.forms.AdditionalForm
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.finances.iports.params.AdditionalCreditParams
+import co.com.japl.module.credit.params.AdditionalCreditParams
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 

--- a/credit/src/main/java/co/com/japl/module/credit/fragments/AdditionalListFragment.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/fragments/AdditionalListFragment.kt
@@ -13,7 +13,7 @@ import androidx.navigation.fragment.findNavController
 import co.com.japl.module.credit.controllers.list.AdditionalViewModel
 import co.com.japl.module.credit.views.lists.Additional
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.finances.iports.params.CreditFixParams
+import co.com.japl.module.credit.params.CreditFixParams
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 

--- a/credit/src/main/java/co/com/japl/module/credit/fragments/AmortizationCreditFragment.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/fragments/AmortizationCreditFragment.kt
@@ -13,7 +13,7 @@ import androidx.navigation.fragment.findNavController
 import co.com.japl.module.credit.controllers.creditamortization.CreditAmortizationViewModel
 import co.com.japl.module.credit.views.creditamortization.CreditAmortizationScreen
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.finances.iports.params.AmortizationCreditParams
+import co.com.japl.module.credit.params.AmortizationCreditParams
 import dagger.hilt.android.AndroidEntryPoint
 import java.time.LocalDate
 import javax.inject.Inject

--- a/credit/src/main/java/co/com/japl/module/credit/fragments/AmortizationTableFragment.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/fragments/AmortizationTableFragment.kt
@@ -12,7 +12,7 @@ import androidx.fragment.app.viewModels
 import co.com.japl.module.credit.controllers.amortization.AmortizationViewModel
 import co.com.japl.module.credit.views.amortization.AmortizationScreen
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.finances.iports.params.AmortizationTableParams
+import co.com.japl.module.credit.params.AmortizationTableParams
 import dagger.hilt.android.AndroidEntryPoint
 import java.time.LocalDate
 import javax.inject.Inject

--- a/credit/src/main/java/co/com/japl/module/credit/fragments/ExtraValueListController.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/fragments/ExtraValueListController.kt
@@ -13,7 +13,7 @@ import co.com.japl.module.credit.controllers.extravalue.ExtraValueListViewModel
 import co.com.japl.module.credit.views.extravalue.ExtraValueListScreen
 import co.com.japl.ui.R
 import co.com.japl.module.credit.databinding.FragmentExtraValueListBinding
-import co.com.japl.finances.iports.params.ExtraValueListParam
+import co.com.japl.module.credit.params.ExtraValueListParam
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 

--- a/credit/src/main/java/co/com/japl/module/credit/params/AdditionalCreditParams.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/params/AdditionalCreditParams.kt
@@ -1,4 +1,4 @@
-package co.com.japl.finances.iports.params
+package co.com.japl.module.credit.params
 
 import android.content.Intent
 import android.os.Build

--- a/credit/src/main/java/co/com/japl/module/credit/params/AmortizationCreditParams.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/params/AmortizationCreditParams.kt
@@ -1,11 +1,11 @@
-package co.com.japl.finances.iports.params
+package co.com.japl.module.credit.params
 
 import android.content.Intent
 import android.os.Bundle
 import androidx.core.net.toUri
 import androidx.navigation.NavController
 import co.com.japl.ui.utils.DateUtils
-import co.com.japl.finances.iports.params.AdditionalCreditParams.Params
+import co.com.japl.module.credit.params.AdditionalCreditParams.Params
 import java.time.LocalDate
 
 class AmortizationCreditParams {

--- a/credit/src/main/java/co/com/japl/module/credit/params/AmortizationTableParams.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/params/AmortizationTableParams.kt
@@ -1,4 +1,4 @@
-package co.com.japl.finances.iports.params
+package co.com.japl.module.credit.params
 
 import android.content.Intent
 import android.os.Bundle
@@ -10,7 +10,7 @@ import co.com.japl.ui.R
 import co.japl.android.finances.services.dto.CalcDTO
 
 import co.com.japl.finances.iports.enums.AmortizationKindOfEnum
-import co.com.japl.finances.iports.params.AdditionalCreditParams.Params
+import co.com.japl.module.credit.params.AdditionalCreditParams.Params
 import com.google.gson.Gson
 import java.time.LocalDate
 

--- a/credit/src/main/java/co/com/japl/module/credit/params/CreditFixListParams.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/params/CreditFixListParams.kt
@@ -1,4 +1,4 @@
-package co.com.japl.finances.iports.params
+package co.com.japl.module.credit.params
 
 import android.os.Build
 import android.os.Bundle

--- a/credit/src/main/java/co/com/japl/module/credit/params/CreditFixParams.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/params/CreditFixParams.kt
@@ -1,4 +1,4 @@
-package co.com.japl.finances.iports.params
+package co.com.japl.module.credit.params
 
 import android.content.Intent
 import android.net.Uri

--- a/credit/src/main/java/co/com/japl/module/credit/params/ExtraValueListParam.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/params/ExtraValueListParam.kt
@@ -1,4 +1,4 @@
-package co.com.japl.finances.iports.params
+package co.com.japl.module.credit.params
 
 import android.content.Intent
 import android.os.Bundle

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/AccountFragment.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/AccountFragment.kt
@@ -11,7 +11,7 @@ import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.inputs.IAccountPort
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.com.japl.module.credit.databinding.FragmentAccountBinding
-import co.com.japl.finances.iports.params.AccountParams
+import co.com.japl.module.paid.params.AccountParams
 import co.com.japl.module.paid.views.accounts.form.AccountForm
 import co.com.japl.module.paid.controllers.accounts.form.AccountViewModel
 import dagger.hilt.android.AndroidEntryPoint

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/EmailPaidFragment.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/EmailPaidFragment.kt
@@ -18,7 +18,7 @@ import co.com.japl.ui.Prefs
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.com.japl.module.credit.databinding.FragmentEmailCreditCardBinding
 import co.com.japl.ui.factory.ViewModelFactory
-import co.com.japl.finances.iports.params.EmailPaidsParams
+import co.com.japl.module.paid.params.EmailPaidsParams
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/InputFragment.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/InputFragment.kt
@@ -12,7 +12,7 @@ import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.inputs.IInputPort
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.com.japl.module.credit.databinding.FragmentInputBinding
-import co.com.japl.finances.iports.params.InputListParams
+import co.com.japl.module.paid.params.InputListParams
 import co.com.japl.module.paid.views.Inputs.form.InputForm
 import co.com.japl.module.paid.controllers.Inputs.form.InputViewModel
 import dagger.hilt.android.AndroidEntryPoint

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/InputListFragment.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/InputListFragment.kt
@@ -12,7 +12,7 @@ import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.inputs.IInputPort
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.com.japl.module.credit.databinding.FragmentInputListBinding
-import co.com.japl.finances.iports.params.AccountParams
+import co.com.japl.module.paid.params.AccountParams
 import co.com.japl.module.paid.views.Inputs.list.InputList
 import co.com.japl.module.paid.controllers.Inputs.list.InputListModelView
 import dagger.hilt.android.AndroidEntryPoint

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/PaidFragment.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/PaidFragment.kt
@@ -15,7 +15,7 @@ import co.com.japl.module.paid.controllers.paid.form.PaidViewModel
 import co.com.japl.module.paid.views.paid.form.Paid
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.com.japl.module.credit.databinding.FragmentPaidBinding
-import co.com.japl.finances.iports.params.PaidsParams
+import co.com.japl.module.paid.params.PaidsParams
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/PaidListFragment.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/PaidListFragment.kt
@@ -17,7 +17,7 @@ import co.com.japl.module.paid.views.paid.list.Paid
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.com.japl.module.credit.databinding.FragmentPaidListBinding
 import co.com.japl.ui.Prefs
-import co.com.japl.finances.iports.params.PaidsParams
+import co.com.japl.module.paid.params.PaidsParams
 import dagger.hilt.android.AndroidEntryPoint
 import java.time.YearMonth
 import javax.inject.Inject

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/PaidsFragment.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/PaidsFragment.kt
@@ -20,7 +20,7 @@ import co.com.japl.module.paid.views.monthly.list.Monthly
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.com.japl.module.credit.databinding.FragmentPaidsBinding
 import co.com.japl.ui.Prefs
-import co.com.japl.finances.iports.params.PaidsParams
+import co.com.japl.module.paid.params.PaidsParams
 import dagger.hilt.android.AndroidEntryPoint
 import java.time.YearMonth
 import javax.inject.Inject

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/PeriodsPaidFragment.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/PeriodsPaidFragment.kt
@@ -14,7 +14,7 @@ import co.com.japl.module.paid.controllers.period.list.PeriodsViewModel
 import co.com.japl.module.paid.views.periods.list.Period
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.com.japl.module.credit.databinding.FragmentPeriodsPaidBinding
-import co.com.japl.finances.iports.params.PeriodPaidParam
+import co.com.japl.module.paid.params.PeriodPaidParam
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/SmsFragment.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/SmsFragment.kt
@@ -16,7 +16,7 @@ import co.com.japl.module.paid.views.sms.form.Sms
 import co.com.japl.ui.Prefs
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.com.japl.module.credit.databinding.FragmentSmsPaidBinding
-import co.com.japl.finances.iports.params.SmsPaidParams
+import co.com.japl.module.paid.params.SmsPaidParams
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/params/AccountParams.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/params/AccountParams.kt
@@ -1,4 +1,4 @@
-package co.com.japl.finances.iports.params
+package co.com.japl.module.paid.params
 
 import android.content.Intent
 import android.net.Uri
@@ -39,8 +39,8 @@ class AccountParams {
 
         fun download(parameters:Bundle):Int{
             parameters.let{
-                if(it.containsKey(InputListParams.PARAMS.ARG_DEEPLINK)) {
-                    val intent = it.get(InputListParams.PARAMS.ARG_DEEPLINK) as Intent
+                if(it.containsKey(PARAMS.ARG_DEEPLINK)) {
+                    val intent = it.get(PARAMS.ARG_DEEPLINK) as Intent
                     if(Uri.parse(intent.dataString).getQueryParameter(PARAMS.PARAM_ID_ACCOUNT) != null){
                         return Uri.parse(intent.dataString).getQueryParameter(PARAMS.PARAM_ID_ACCOUNT)!!.toInt()
                     }

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/params/EmailPaidsParams.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/params/EmailPaidsParams.kt
@@ -1,24 +1,24 @@
-package co.com.japl.finances.iports.params
+package co.com.japl.module.paid.params
 
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 
 
-object EmailCreditCardParams {
+object EmailPaidsParams {
     const val PARAM_DEEPLINK = "android-support-nav:controller:deepLinkIntent"
-    const val CODE_EMAIL_CC = "code_email_credit_card"
+    const val CODE_EMAIL_PD = "code_email_paid"
 
     fun download(bundle: Bundle): Int {
         if(bundle.containsKey(PARAM_DEEPLINK)) {
             val intent = bundle.get(PARAM_DEEPLINK) as Intent
-            val value = Uri.parse(intent.dataString).getQueryParameter(CODE_EMAIL_CC)
+            val value = Uri.parse(intent.dataString).getQueryParameter(CODE_EMAIL_PD)
             return value?.toInt()?:0
         }
-        return bundle.getInt(CODE_EMAIL_CC, 0)
+        return bundle.getInt(CODE_EMAIL_PD, 0)
     }
 
     fun upload(bundle: Bundle, code: Int) {
-        bundle.putInt(CODE_EMAIL_CC, code)
+        bundle.putInt(CODE_EMAIL_PD, code)
     }
 }

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/params/InputListParams.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/params/InputListParams.kt
@@ -1,4 +1,4 @@
-package co.com.japl.finances.iports.params
+package co.com.japl.module.paid.params
 
 import android.content.Intent
 import android.os.Bundle

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/params/PaidsParams.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/params/PaidsParams.kt
@@ -1,4 +1,4 @@
-package co.com.japl.finances.iports.params
+package co.com.japl.module.paid.params
 
 import android.content.Intent
 import android.net.Uri

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/params/PeriodPaidParam.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/params/PeriodPaidParam.kt
@@ -1,4 +1,4 @@
-package co.com.japl.finances.iports.params
+package co.com.japl.module.paid.params
 
 import android.content.Intent
 import android.net.Uri

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/params/SmsPaidParams.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/params/SmsPaidParams.kt
@@ -1,4 +1,4 @@
-package co.com.japl.finances.iports.params
+package co.com.japl.module.paid.params
 
 import android.content.Intent
 import android.net.Uri
@@ -8,7 +8,6 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.FragmentManager
 import androidx.navigation.NavController
 import co.com.japl.ui.R
-import co.com.japl.finances.iports.params.CreditCardParams.Params.ARG_PARAM_CODE
 
 class SmsPaidParams(var parentFragmentManagers: FragmentManager) {
     object Params {

--- a/ui/src/main/java/co/com/japl/ui/utils/NumbersUtil.kt
+++ b/ui/src/main/java/co/com/japl/ui/utils/NumbersUtil.kt
@@ -1,4 +1,4 @@
-package co.japl.android.myapplication.utils
+package co.com.japl.ui.utils
 
 import android.util.Log
 import android.widget.EditText


### PR DESCRIPTION
This refactoring task decentralizes code from the shared `japl-finances-iports` module into the specific feature modules where they are used.

Key changes:
- Moved `MoreOptionsItemsCreditCard.kt` to `CreditCardModule` and updated it to implement `IMoreOptions`.
- Relocated all navigation parameter (Params) classes to their respective modules (`CreditCardModule`, `credit`, and `japl-android-finances-paid-module`).
- Split `AmortizationTableParams.kt` into two module-specific versions to eliminate dependencies between the `credit` and `CreditCardModule`.
- Updated package declarations and imports throughout the entire project.
- Cleaned up redundant imports and addressed compilation blockers.

---
*PR created automatically by Jules for task [2302293456582294355](https://jules.google.com/task/2302293456582294355) started by @nano871022*