### PR TITLE
Refactor fragments to ComposeView and fix package names

### DIFF
--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/BoughWalletController.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/BoughWalletController.kt
@@ -1,4 +1,4 @@
-package co.japl.android.myapplication.finanzas.controller.boughtcreditcard
+package co.com.japl.module.creditcard.fragments
 
 import android.os.Build
 import android.os.Bundle
@@ -6,7 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
-import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -16,13 +16,12 @@ import co.com.japl.finances.iports.inbounds.creditcard.bought.IBoughtPort
 import co.com.japl.module.creditcard.controllers.bought.forms.WalletViewModel
 import co.com.japl.module.creditcard.views.bought.forms.Wallet
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.BuyWalletCreditCardBinding
-import co.com.japl.ui.Prefs
 import co.com.japl.ui.factory.ViewModelFactory
 import co.com.japl.module.creditcard.params.BoughWalletParams
 import dagger.hilt.android.AndroidEntryPoint
 import java.time.LocalDateTime
 import javax.inject.Inject
+import co.japl.android.myapplication.finanzas.ApplicationInitial
 
 @AndroidEntryPoint
 class BoughWalletController: Fragment() {
@@ -56,16 +55,13 @@ class BoughWalletController: Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        val binding = BuyWalletCreditCardBinding.inflate(inflater,container,false)
-        binding.cvWalletBwcc.apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     Wallet(viewModel = viewModel)
                 }
             }
         }
-        return binding.root.rootView
     }
 
 

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/CashAdvanceSave.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/CashAdvanceSave.kt
@@ -1,4 +1,4 @@
-package co.japl.android.myapplication.finanzas.controller.boughtcreditcard
+package co.com.japl.module.creditcard.fragments
 
 import android.os.Build
 import android.os.Bundle
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
+import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -15,13 +16,12 @@ import co.com.japl.finances.iports.inbounds.creditcard.bought.IBoughtPort
 import co.com.japl.module.creditcard.controllers.bought.forms.AdvanceViewModel
 import co.com.japl.module.creditcard.views.bought.forms.Advance
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.CashAdvanceCreditCardBinding
-import co.com.japl.ui.Prefs
 import co.com.japl.ui.factory.ViewModelFactory
 import co.com.japl.module.creditcard.params.CashAdvanceParams
 import dagger.hilt.android.AndroidEntryPoint
 import java.time.LocalDateTime
 import javax.inject.Inject
+import co.japl.android.myapplication.finanzas.ApplicationInitial
 
 @AndroidEntryPoint
 class CashAdvanceSave: Fragment() {
@@ -56,16 +56,13 @@ class CashAdvanceSave: Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        val root = CashAdvanceCreditCardBinding.inflate(inflater,container,false)
-
-        root.cvComposeCacc.apply {
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     Advance(viewModel = viewModel)
                 }
             }
         }
-        return root.root.rootView
     }
 
 }

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/EmailFragment.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/EmailFragment.kt
@@ -1,4 +1,4 @@
-package co.japl.android.myapplication.finanzas.controller.boughtcreditcard
+package co.com.japl.module.creditcard.fragments
 
 import android.os.Build
 import android.os.Bundle
@@ -6,23 +6,21 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
+import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.common.ILLMService
 import co.com.japl.finances.iports.inbounds.creditcard.ICreditCardPort
 import co.com.japl.finances.iports.inbounds.creditcard.IEmailCreditCardPort
-import co.com.japl.module.creditcard.controllers.bought.forms.AdvanceViewModel
 import co.com.japl.module.creditcard.controllers.emailcreditcard.form.EmailCreditCardViewModel
 import co.com.japl.module.creditcard.views.email.form.EmailBought
 import co.com.japl.ui.Prefs
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.FragmentEmailCreditCardBinding
 import co.com.japl.ui.factory.ViewModelFactory
 import co.com.japl.module.creditcard.params.EmailCreditCardParams
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
-import kotlin.getValue
 
 @AndroidEntryPoint
 class EmailFragment: Fragment(){
@@ -56,16 +54,13 @@ class EmailFragment: Fragment(){
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        val root = FragmentEmailCreditCardBinding.inflate(inflater,container,false)
-
-        root.cvComposeEmailCc.apply {
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     EmailBought(viewModel = viewModel)
                 }
             }
         }
-        return root.root.rootView
     }
 
 }

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/EmailListFragment.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/EmailListFragment.kt
@@ -1,4 +1,4 @@
-package co.japl.android.myapplication.finanzas.controller.boughtcreditcard
+package co.com.japl.module.creditcard.fragments
 
 import androidx.fragment.app.Fragment
 import android.os.Build
@@ -7,21 +7,16 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
+import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.creditcard.IEmailCreditCardPort
-import co.com.japl.module.creditcard.controllers.bought.forms.AdvanceViewModel
-import co.com.japl.module.creditcard.controllers.emailcreditcard.form.EmailCreditCardViewModel
 import co.com.japl.module.creditcard.controllers.emailcreditcard.list.EmailListCreditCardViewModel
-import co.com.japl.module.creditcard.views.email.form.EmailBought
 import co.com.japl.module.creditcard.views.email.list.EmailList
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.FragmentEmailCreditCardBinding
 import co.com.japl.ui.factory.ViewModelFactory
-import co.com.japl.module.creditcard.params.EmailCreditCardParams
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
-import kotlin.getValue
 
 @AndroidEntryPoint
 class EmailListFragment : Fragment(){
@@ -47,15 +42,12 @@ class EmailListFragment : Fragment(){
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        val root = FragmentEmailCreditCardBinding.inflate(inflater,container,false)
-
-        root.cvComposeEmailCc.apply {
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     EmailList(viewModel = viewModel)
                 }
             }
         }
-        return root.root.rootView
     }
 }

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/ListBought.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/ListBought.kt
@@ -1,4 +1,4 @@
-package co.japl.android.myapplication.finanzas.controller.boughtcreditcard
+package co.com.japl.module.creditcard.fragments
 
 import android.os.Build
 import android.os.Bundle
@@ -6,29 +6,23 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
-import androidx.compose.ui.platform.ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
+import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.FragmentListBoughtBinding
-import co.com.japl.ui.Prefs
 import co.com.japl.module.creditcard.params.CreditCardQuotesParams
 import co.japl.android.myapplication.finanzas.view.creditcard.bought.BoughtList
 import dagger.hilt.android.AndroidEntryPoint
+import co.japl.android.myapplication.finanzas.ApplicationInitial
 
 @AndroidEntryPoint
 class ListBought : Fragment() {
-
-    private var _binding:FragmentListBoughtBinding? = null
-    private val binding get() = _binding!!
 
     @RequiresApi(Build.VERSION_CODES.S)
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        _binding = FragmentListBoughtBinding.inflate(inflater, container, false)
-        val rootView = binding.root
         val application = requireActivity().application
         val data = ListBoughtViewModel(application,findNavController(),ApplicationInitial.prefs)
 
@@ -37,15 +31,12 @@ class ListBought : Fragment() {
             data.setParams(params)
         }
 
-        binding.boughtListCompose?.apply {
-            setViewCompositionStrategy(DisposeOnViewTreeLifecycleDestroyed)
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     BoughtList(data)
                 }
             }
         }
-
-        return rootView
     }
 }

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/ListCreditCardQuote.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/ListCreditCardQuote.kt
@@ -1,4 +1,4 @@
-package co.japl.android.myapplication.finanzas.controller.boughtcreditcard
+package co.com.japl.module.creditcard.fragments
 
 import android.os.Build
 import android.os.Bundle
@@ -7,7 +7,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
-import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.common.ISMSRead
@@ -19,10 +19,9 @@ import co.com.japl.finances.iports.inbounds.creditcard.bought.IBoughtSmsPort
 import co.com.japl.module.creditcard.controllers.bought.lists.BoughtMonthlyViewModel
 import co.com.japl.module.creditcard.views.bought.BoughtMonthly
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.ListCreditCardQuoteBinding
-import co.com.japl.ui.Prefs
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
+import co.japl.android.myapplication.finanzas.ApplicationInitial
 
 @AndroidEntryPoint
 class ListCreditCardQuote : Fragment(){
@@ -32,13 +31,11 @@ class ListCreditCardQuote : Fragment(){
     @Inject lateinit var msmSvc: ISMSCreditCardPort
     @Inject lateinit var svc: IBoughtSmsPort
 
-    lateinit var _binding:ListCreditCardQuoteBinding
     @RequiresApi(Build.VERSION_CODES.S)
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-            _binding = ListCreditCardQuoteBinding.inflate(inflater)
             val viewModel = BoughtMonthlyViewModel(
                 creditRateSvc,
                 creditCardPort,
@@ -48,15 +45,13 @@ class ListCreditCardQuote : Fragment(){
                 msmSvc,
                 svc
             )
-            _binding.cvComposeLccq?.apply {
-                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            return ComposeView(requireContext()).apply {
                 setContent {
                     MaterialThemeComposeUI {
                         BoughtMonthly(viewModel = viewModel)
                     }
                 }
             }
-            return _binding.root.rootView
 
     }
 }

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/ListQuotesPaid.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/ListQuotesPaid.kt
@@ -1,4 +1,4 @@
-package co.japl.android.myapplication.finanzas.controller.boughtcreditcard
+package co.com.japl.module.creditcard.fragments
 
 import android.os.Build
 import android.os.Bundle
@@ -7,40 +7,35 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
-import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.creditcard.bought.lists.IBoughtListPort
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.FragmentListPeriodsBinding
 import co.com.japl.module.creditcard.params.PeriodsParams
 import co.com.japl.module.creditcard.controllers.paid.BoughtCreditCardViewModel
 import co.com.japl.module.creditcard.views.paid.PaidList
-import co.com.japl.ui.Prefs
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlin.properties.Delegates
+import co.japl.android.myapplication.finanzas.ApplicationInitial
 
 @AndroidEntryPoint
 class ListQuotesPaid : Fragment() {
     var creditCardId by Delegates.notNull<Int>()
 
     @Inject lateinit var port: IBoughtListPort
-    private lateinit var _binding : FragmentListPeriodsBinding
 
     @RequiresApi(Build.VERSION_CODES.O)
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        _binding = FragmentListPeriodsBinding.inflate(inflater, container, false)
-        val rootView = _binding.root
         arguments?.let{
             creditCardId = PeriodsParams.Companion.Historical.download(it)
         }
         Log.d(javaClass.name,"=== ListQuotesPaid start")
-        _binding.composeViewLp.apply {
-                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        return ComposeView(requireContext()).apply {
                 setContent {
                     MaterialThemeComposeUI {
                         PaidList(viewModel = BoughtCreditCardViewModel(port,creditCardId,findNavController(),ApplicationInitial.prefs))
@@ -48,6 +43,5 @@ class ListQuotesPaid : Fragment() {
                 }
             }
         }
-        return rootView
     }
 }

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/ListTaxCreditCard.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/ListTaxCreditCard.kt
@@ -1,4 +1,4 @@
-package co.japl.android.myapplication.finanzas.controller.taxes
+package co.com.japl.module.creditcard.fragments
 
 import android.os.Build
 import android.os.Bundle
@@ -6,7 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
-import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.creditcard.ICreditCardPort
@@ -14,7 +14,6 @@ import co.com.japl.finances.iports.inbounds.creditcard.ITaxPort
 import co.com.japl.module.creditcard.controllers.creditrate.lists.CreditRateListViewModel
 import co.com.japl.module.creditcard.views.creditrate.lists.CreditRateList
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.FragmentListTaxCreditCardBinding
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -24,25 +23,19 @@ class ListTaxCreditCard : Fragment() {
     @Inject lateinit var creditRateSvc: ITaxPort
     @Inject lateinit var creditCardSvc2: ICreditCardPort
 
-    lateinit var _bind : FragmentListTaxCreditCardBinding
-    val bind get() = _bind
-
     @RequiresApi(Build.VERSION_CODES.S)
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        _bind = FragmentListTaxCreditCardBinding.inflate(inflater)
         val viewModel = CreditRateListViewModel(requireContext(),creditCardSvc2,creditRateSvc,findNavController())
-        bind.cvComposableTcc.apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     CreditRateList(viewModel = viewModel)
                 }
             }
         }
-        return bind.root.rootView
     }
 
 }

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/QuoteBought.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/QuoteBought.kt
@@ -1,4 +1,4 @@
-package co.japl.android.myapplication.finanzas.controller.boughtcreditcard
+package co.com.japl.module.creditcard.fragments
 
 import android.os.Build
 import android.os.Bundle
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
+import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -18,13 +19,12 @@ import co.com.japl.finances.iports.inbounds.creditcard.bought.IBoughtPort
 import co.com.japl.module.creditcard.controllers.bought.forms.QuoteViewModel
 import co.com.japl.module.creditcard.views.bought.forms.Quote
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.BuysCreditCardBinding
-import co.com.japl.ui.Prefs
 import co.com.japl.ui.factory.ViewModelFactory
 import co.com.japl.module.creditcard.params.CreditCardQuotesParams
 import dagger.hilt.android.AndroidEntryPoint
 import java.time.LocalDateTime
 import javax.inject.Inject
+import co.japl.android.myapplication.finanzas.ApplicationInitial
 
 @AndroidEntryPoint
 class QuoteBought : Fragment(){
@@ -68,16 +68,12 @@ class QuoteBought : Fragment(){
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        val root = BuysCreditCardBinding.inflate(inflater, container, false)
-
-        root.cvComposableBcc.apply {
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     Quote(viewModel = viewModel)
                 }
             }
         }
-        return root.root.rootView
-
     }
 }

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/QuoteCreditVariable.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/QuoteCreditVariable.kt
@@ -1,11 +1,11 @@
-package co.japl.android.myapplication.finanzas.controller.simulators.variable
+package co.com.japl.module.creditcard.fragments
 
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
-import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -13,7 +13,6 @@ import co.com.japl.finances.iports.inbounds.creditcard.ISimulatorCreditVariableP
 import co.com.japl.module.creditcard.controllers.simulator.FormViewModel
 import co.com.japl.module.creditcard.views.simulator.Simulator
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.QuoteCreditVariableBinding
 import co.com.japl.ui.factory.ViewModelFactory
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -43,17 +42,12 @@ class QuoteCreditVariable : Fragment(){
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val rootView = QuoteCreditVariableBinding.inflate(inflater)
-
-        rootView.composeViewSqcv.apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     Simulator(viewModel)
                 }
             }
         }
-        return rootView.root
-
     }
 }

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/SmsFragment.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/SmsFragment.kt
@@ -1,4 +1,4 @@
-package co.japl.android.myapplication.finanzas.controller.boughtcreditcard
+package co.com.japl.module.creditcard.fragments
 
 import android.os.Build
 import android.os.Bundle
@@ -6,7 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
-import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.common.ILLMService
@@ -16,7 +16,6 @@ import co.com.japl.module.creditcard.controllers.smscreditcard.form.SmsCreditCar
 import co.com.japl.module.creditcard.views.sms.forms.Sms
 import co.com.japl.ui.Prefs
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.FragmentSmsCreditCardBinding
 import co.com.japl.module.creditcard.params.SmsCreditCardParams
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -34,7 +33,6 @@ class SmsFragment: Fragment()  {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val view = FragmentSmsCreditCardBinding.inflate(inflater,container,false)
         val code = arguments?.let{SmsCreditCardParams.download(it)}
         val viewModel = SmsCreditCardViewModel(
             codeSMSCC = code,
@@ -44,15 +42,12 @@ class SmsFragment: Fragment()  {
             navController = findNavController(),
             prefs = prefs
         )
-        view.cvComposeLscc?.apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     Sms(viewModel)
                 }
             }
-
         }
-        return view.root.rootView
     }
 }

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/SmsListFragment.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/SmsListFragment.kt
@@ -1,4 +1,4 @@
-package co.japl.android.myapplication.finanzas.controller.boughtcreditcard
+package co.com.japl.module.creditcard.fragments
 
 import android.os.Build
 import android.os.Bundle
@@ -6,7 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
-import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.creditcard.ICreditCardPort
@@ -14,7 +14,6 @@ import co.com.japl.finances.iports.inbounds.creditcard.ISMSCreditCardPort
 import co.com.japl.module.creditcard.controllers.smscreditcard.list.SmsCreditCardViewModel
 import co.com.japl.module.creditcard.views.sms.list.SMS
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.FragmentListSmsCreditCardBinding
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -22,28 +21,24 @@ import javax.inject.Inject
 class SmsListFragment: Fragment()  {
 
     @Inject lateinit var creditCardSvc:ICreditCardPort
-    @Inject lateinit var smsCreditCardSvc:ISMSCreditCardPort
+    @Inject lateinit var msmSvc:ISMSCreditCardPort
 
     @RequiresApi(Build.VERSION_CODES.S)
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val view = FragmentListSmsCreditCardBinding.inflate(inflater,container,false)
         val viewModel = SmsCreditCardViewModel(
-            svc = smsCreditCardSvc,
+            svc = msmSvc,
             creditCardSvc = creditCardSvc,
             navController = findNavController()
         )
-        view.cvComposeLscc?.apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     SMS(viewModel)
                 }
             }
-
         }
-        return view.root.rootView
     }
 }

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/Taxes.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/fragments/Taxes.kt
@@ -1,4 +1,4 @@
-package co.japl.android.myapplication.finanzas.controller.taxes
+package co.com.japl.module.creditcard.fragments
 
 import android.os.Build
 import android.os.Bundle
@@ -6,7 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
-import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.creditcard.ICreditCardPort
@@ -14,7 +14,6 @@ import co.com.japl.finances.iports.inbounds.creditcard.ITaxPort
 import co.com.japl.module.creditcard.controllers.creditrate.forms.CreateRateViewModel
 import co.com.japl.module.creditcard.views.creditrate.forms.CreditRate
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.FragmentTaxesBinding
 import co.com.japl.module.creditcard.params.TaxesParams
 import co.com.japl.ui.utils.NumbersUtil
 import dagger.hilt.android.AndroidEntryPoint
@@ -26,7 +25,6 @@ class Taxes : Fragment() {
     @Inject lateinit var service:ITaxPort
     @Inject lateinit var creditCardSvc:ICreditCardPort
 
-    private lateinit var _binding : FragmentTaxesBinding
     private var codeCreditCard:Int? = null
     private var codeCreditRate:Int? = null
 
@@ -36,18 +34,15 @@ class Taxes : Fragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        _binding = FragmentTaxesBinding.inflate(inflater)
         getParameters()
         val viewModel = CreateRateViewModel(codeCreditCard,codeCreditRate,service,creditCardSvc,findNavController())
-        _binding.cvComponentFts.apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     CreditRate(viewModel = viewModel)
                 }
             }
         }
-        return _binding.root.rootView
     }
 
     private fun getParameters(){

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/AboutIt.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/AboutIt.kt
@@ -5,33 +5,23 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
-import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.ComposeView
 import co.com.japl.homeconnect.about.ui.About
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.japl.android.myapplication.BuildConfig
-import co.japl.android.myapplication.R
-import co.com.japl.module.credit.databinding.FragmentAboutItBinding
 
 class AboutIt : Fragment() {
-
-    private var _bind : FragmentAboutItBinding ? = null
-    private val bind get() = _bind!!
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        _bind = FragmentAboutItBinding.inflate(inflater,container,false)
-        val root = bind.root
-        bind.firstCardCompose.apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     About(versionDetail = BuildConfig.VERSION_NAME, applicationId = BuildConfig.APPLICATION_ID)
                 }
             }
         }
-        return root
     }
 }

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/google/GDriveConnectFragment.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/google/GDriveConnectFragment.kt
@@ -7,7 +7,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
-import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.japl.android.myapplication.finanzas.bussiness.DB.connections.ConnectDB
@@ -37,20 +37,17 @@ class GDriveConnectFragment : Fragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        val root = FragmentGDriveConnectBinding.inflate(inflater)
         service = GoogleSignInnImplement(requireActivity())
         driveSvc = GoogleDriveImpl(requireActivity(),dbConnect as ConnectDB)
         loginSimpleSvc = GoogleSignInSimpleImplement(requireActivity())
         loginWebSvc = GoogleSignInWebImplement(requireActivity())
-        root.cwComposeFddc.apply {
-            val viewModel = GoogleAuthBackupRestoreViewModel(requireActivity(),service,loginSimpleSvc,loginWebSvc,driveSvc)
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        val viewModel = GoogleAuthBackupRestoreViewModel(requireActivity(),service,loginSimpleSvc,loginWebSvc,driveSvc)
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     GoogleAuthBackupRestore(viewModel)
                 }
             }
         }
-        return root.root.rootView
     }
 }

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/recap/RecapFragment.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/recap/RecapFragment.kt
@@ -6,24 +6,22 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
-import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.recap.IRecapPort
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.FragmentRecapBinding
-import co.com.japl.ui.Prefs
 import co.japl.android.myapplication.finanzas.controller.recap.views.Recap
 import co.japl.finances.core.usercases.interfaces.creditcard.bought.lists.IBought
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
+import co.japl.android.myapplication.finanzas.ApplicationInitial
 
 @AndroidEntryPoint
 class RecapFragment @Inject constructor() : Fragment() {
     @Inject lateinit var recapSvc:IRecapPort
     @Inject lateinit var boughtCreditCardSvc : IBought
 
-    private var _binding: FragmentRecapBinding? = null
     private val recapViewModel by lazy {RecapViewModel(recapSvc,boughtCreditCardSvc,ApplicationInitial.prefs,findNavController())}
 
     @RequiresApi(Build.VERSION_CODES.S)
@@ -31,17 +29,13 @@ class RecapFragment @Inject constructor() : Fragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        _binding = FragmentRecapBinding.inflate(inflater, container, false)
-        val root = _binding?.root
-        _binding?.firstCardCompose?.apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     Recap(recapViewModel)
                 }
             }
         }
-        return root
     }
 
 }

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/setting/LLMConnectionSetting.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/setting/LLMConnectionSetting.kt
@@ -6,12 +6,11 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
-import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import co.com.japl.finances.iports.inbounds.common.ILLMService
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.FragmentLlmConnectionBinding
-import co.com.japl.ui.Prefs
+import co.japl.android.myapplication.finanzas.ApplicationInitial
 import co.japl.android.myapplication.finanzas.view.setting.LLMConnectionForm
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -27,16 +26,13 @@ class LLMConnectionSetting : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val binding = FragmentLlmConnectionBinding.inflate(inflater)
         val viewModel = LLMConnectionViewModel(prefs = ApplicationInitial.prefs, context = requireContext(), llmService = llmSvc)
-        binding.composeViewLlmcnt.apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     LLMConnectionForm(viewModel = viewModel)
                 }
             }
         }
-        return binding.root.rootView
     }
 }

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/setting/SettingsApp.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/setting/SettingsApp.kt
@@ -6,11 +6,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
-import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.FragmentSettingsAppBinding
-import co.com.japl.ui.Prefs
+import co.japl.android.myapplication.finanzas.ApplicationInitial
 import co.japl.android.myapplication.finanzas.view.setting.SettingsApp
 
 class SettingsApp : Fragment() {
@@ -23,17 +22,14 @@ class SettingsApp : Fragment() {
         savedInstanceState: Bundle?
         ):View?{
 
-        val binding = FragmentSettingsAppBinding.inflate(inflater)
         val viewModel = SettingsAppViewModel(prefs=ApplicationInitial.prefs, context = requireContext())
-        binding.cvComposeFsa.apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     SettingsApp(viewModel=viewModel)
                 }
             }
         }
-        return binding.root.rootView
     }
 
 }

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -7,7 +7,7 @@
 
     <fragment
         android:id="@+id/item_menu_side_boughtmade"
-        android:name="co.japl.android.myapplication.finanzas.controller.boughtcreditcard.ListCreditCardQuote"
+        android:name="co.com.japl.module.creditcard.fragments.ListCreditCardQuote"
         android:label="@string/bought_made"
         tools:layout="@layout/list_credit_card_quote">
 
@@ -45,7 +45,7 @@
     </fragment>
     <fragment
         android:id="@+id/item_menu_side_simulatorCredit"
-        android:name="co.japl.android.myapplication.finanzas.controller.simulators.fix.SimulatorCredit"
+        android:name="co.com.japl.module.credit.fragments.SimulatorCredit"
         android:label="@string/quote_credit"
         tools:layout="@layout/fragment_simulator_credit">
         <action
@@ -57,7 +57,7 @@
 
     <fragment
         android:id="@+id/item_menu_side_quoteCreditVariable"
-        android:name="co.japl.android.myapplication.finanzas.controller.simulators.variable.QuoteCreditVariable"
+        android:name="co.com.japl.module.creditcard.fragments.QuoteCreditVariable"
         android:label="@string/quote_credit_variable"
         tools:layout="@layout/quote_credit_variable">
 
@@ -68,7 +68,7 @@
 
     <fragment
         android:id="@+id/list_bought"
-        android:name="co.japl.android.myapplication.finanzas.controller.boughtcreditcard.ListBought"
+        android:name="co.com.japl.module.creditcard.fragments.ListBought"
         android:label="@string/list_save"
         tools:layout="@layout/fragment_list_bought">
         <action
@@ -91,7 +91,7 @@
 
     <fragment
         android:id="@+id/list_periods"
-        android:name="co.japl.android.myapplication.finanzas.controller.boughtcreditcard.ListQuotesPaid"
+        android:name="co.com.japl.module.creditcard.fragments.ListQuotesPaid"
         android:label="@string/list_periods"
         tools:layout="@layout/fragment_list_periods">
 
@@ -106,7 +106,7 @@
 
     <fragment
         android:id="@+id/item_menu_side_listsave"
-        android:name="co.japl.android.myapplication.finanzas.controller.simulators.ListSave"
+        android:name="co.com.japl.module.credit.fragments.ListSave"
         android:label="@string/list_save"
         tools:layout="@layout/fragment_list_save" >
         <action
@@ -118,7 +118,7 @@
 
     <fragment
         android:id="@+id/buy_credit_card"
-        android:name="co.japl.android.myapplication.finanzas.controller.boughtcreditcard.QuoteBought"
+        android:name="co.com.japl.module.creditcard.fragments.QuoteBought"
         android:label="@string/add_buy"
         tools:layout="@layout/buys_credit_card" >
         <deepLink app:uri="android-app://co.com.japl.finanzas.module.app/bought"/>
@@ -159,7 +159,7 @@
 
     <fragment
         android:id="@+id/item_menu_setting_taxes"
-        android:name="co.japl.android.myapplication.finanzas.controller.taxes.ListTaxCreditCard"
+        android:name="co.com.japl.module.creditcard.fragments.ListTaxCreditCard"
         android:label="@string/taxs_credit_card"
         tools:layout="@layout/fragment_list_tax_credit_card" >
         <action
@@ -172,7 +172,7 @@
     </fragment>
     <fragment
         android:id="@+id/taxes"
-        android:name="co.japl.android.myapplication.finanzas.controller.taxes.Taxes"
+        android:name="co.com.japl.module.creditcard.fragments.Taxes"
         android:label="@string/tax"
         tools:layout="@layout/fragment_taxes" >
         <deepLink app:uri="android-app://co.com.japl.finanzas.modulo.app/credit_rate"/>
@@ -180,7 +180,7 @@
 
     <fragment
         android:id="@+id/cash_advance_fragment"
-        android:name="co.japl.android.myapplication.finanzas.controller.boughtcreditcard.CashAdvanceSave"
+        android:name="co.com.japl.module.creditcard.fragments.CashAdvanceSave"
         android:label="@string/cash_advance"
         tools:layout="@layout/cash_advance_credit_card" >
         <deepLink app:uri="android-app://co.com.japl.finanzas.module.app/cashAdvanceBought"/>
@@ -214,7 +214,7 @@
     </fragment>
     <fragment
         android:id="@+id/boughWalletController"
-        android:name="co.japl.android.myapplication.finanzas.controller.boughtcreditcard.BoughWalletController"
+        android:name="co.com.japl.module.creditcard.fragments.BoughWalletController"
         android:label="@string/bough_wallet"
         tools:layout="@layout/buy_wallet_credit_card">
         <deepLink app:uri="android-app://co.com.japl.finanzas.module.app/boughtWalletBought"/>
@@ -364,7 +364,7 @@
     </fragment>
     <fragment
         android:id="@+id/menu_item_paids"
-        android:name="co.japl.android.myapplication.finanzas.controller.paids.PaidsFragment"
+        android:name="co.com.japl.module.paid.fragments.PaidsFragment"
         android:label="@string/paids"
         tools:layout="@layout/fragment_paids" >
         <action
@@ -390,7 +390,7 @@
     </fragment>
     <fragment
         android:id="@+id/periodsPaidFragment"
-        android:name="co.japl.android.myapplication.finanzas.controller.paids.PeriodsPaidFragment"
+        android:name="co.com.japl.module.paid.fragments.PeriodsPaidFragment"
         android:label="@string/periods"
         tools:layout="@layout/fragment_periods_paid" >
         <action
@@ -430,22 +430,22 @@
     </fragment>
     <fragment
         android:id="@+id/item_menu_side_recap"
-        android:name="co.japl.android.myapplication.finanzas.controller.RecapFragment"
+        android:name="co.japl.android.myapplication.finanzas.controller.recap.RecapFragment"
         android:label="@string/recap"
         tools:layout="@layout/fragment_recap" />
     <fragment
         android:id="@+id/item_menu_setting_check_payments"
-        android:name="co.japl.android.myapplication.finanzas.controller.paids.CheckPaymentsFragment"
+        android:name="co.com.japl.module.paid.fragments.CheckPaymentsFragment"
         android:label="@string/check_payments_title"
         tools:layout="@layout/fragment_check_payments" />
     <fragment
         android:id="@+id/item_menu_setting_check_paids"
-        android:name="co.japl.android.myapplication.finanzas.controller.paids.PeriodCheckPaymentsFragment"
+        android:name="co.com.japl.module.paid.fragments.PeriodCheckPaymentsFragment"
         android:label="@string/paids"
         tools:layout="@layout/fragment_period_check_payments" />
     <fragment
         android:id="@+id/extraValueListController"
-        android:name="co.japl.android.myapplication.finanzas.controller.ExtraValueListController"
+        android:name="co.com.japl.module.credit.fragments.ExtraValueListController"
         android:layout="@layout/fragment_extra_value_list"
         android:label="ExtraValueListController" >
         <deepLink app:uri="android-app://co.com.japl.finanzas.module.creditfix/extraValue"/>
@@ -469,7 +469,7 @@
 
     <fragment
         android:id="@+id/sms_list_paid"
-        android:name="co.japl.android.myapplication.finanzas.controller.paids.SmsListFragment"
+        android:name="co.com.japl.module.paid.fragments.SmsListFragment"
         android:label="@string/fragment_list_sms_paid"
         tools:layout="@layout/fragment_list_sms_credit_card" >
         <action
@@ -478,7 +478,7 @@
     </fragment>
     <fragment
         android:id="@+id/sms_paid"
-        android:name="co.japl.android.myapplication.finanzas.controller.paids.SmsFragment"
+        android:name="co.com.japl.module.paid.fragments.SmsFragment"
         android:label="@string/fragment_sms_paid"
         tools:layout="@layout/fragment_sms_paid" >
         <deepLink app:uri="android-app://co.com.japl.finanzas.module.app/paid/sms"/>
@@ -491,7 +491,7 @@
 
     <fragment
         android:id="@+id/recurrent_list_credit_card"
-        android:name="co.japl.android.myapplication.finanzas.controller.boughtcreditcard.RecurrentBoughtListFragment"
+        android:name="co.com.japl.module.creditcard.fragments.RecurrentBoughtListFragment"
         android:label="@string/recurrent" >
         <deepLink app:uri="android-app://co.com.japl.finanzas.module.creditcard/recurrentList"/>
     </fragment>
@@ -504,7 +504,7 @@
 
     <fragment
         android:id="@+id/email_list_credit_card"
-        android:name="co.japl.android.myapplication.finanzas.controller.boughtcreditcard.EmailListFragment"
+        android:name="co.com.japl.module.creditcard.fragments.EmailListFragment"
         android:label="@string/email_list"
         tools:layout="@layout/fragment_list_email_credit_card">
         <action
@@ -526,7 +526,7 @@
 
     <fragment
         android:id="@+id/email_list_paid"
-        android:name="co.japl.android.myapplication.finanzas.controller.paids.EmailListPaidFragment"
+        android:name="co.com.japl.module.paid.fragments.EmailListPaidFragment"
         android:label="@string/email_list"
         tools:layout="@layout/fragment_list_email_credit_card">
         <action
@@ -537,7 +537,7 @@
 
     <fragment
         android:id="@+id/email_paid"
-        android:name="co.japl.android.myapplication.finanzas.controller.paids.EmailPaidFragment"
+        android:name="co.com.japl.module.paid.fragments.EmailPaidFragment"
         android:label="@string/email_address"
         tools:layout="@layout/fragment_email_credit_card">
         <deepLink app:uri="android-app://co.com.japl.finanzas.module.app/paid/email/form" />

--- a/credit/src/main/java/co/com/japl/module/credit/fragments/ExtraValueListController.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/fragments/ExtraValueListController.kt
@@ -1,19 +1,17 @@
-package co.japl.android.myapplication.finanzas.controller
+package co.com.japl.module.credit.fragments
 
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import co.com.japl.finances.iports.inbounds.credit.IExtraValueAmortizationCreditPort
 import co.com.japl.module.credit.controllers.extravalue.ExtraValueListViewModel
 import co.com.japl.module.credit.views.extravalue.ExtraValueListScreen
-import co.com.japl.ui.R
-import co.com.japl.module.credit.databinding.FragmentExtraValueListBinding
 import co.com.japl.module.credit.params.ExtraValueListParam
+import co.com.japl.ui.factory.ViewModelFactory
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -41,13 +39,12 @@ class ExtraValueListController : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val root = FragmentExtraValueListBinding.inflate(inflater)
-        root.composeView.apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        return ComposeView(requireContext()).apply {
             setContent {
+                co.com.japl.ui.theme.MaterialThemeComposeUI {
                     ExtraValueListScreen(viewModel)
+                }
             }
         }
-        return root.root
     }
 }

--- a/credit/src/main/java/co/com/japl/module/credit/fragments/ListSave.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/fragments/ListSave.kt
@@ -1,4 +1,4 @@
-package co.japl.android.myapplication.finanzas.controller.simulators
+package co.com.japl.module.credit.fragments
 
 import android.os.Build
 import android.os.Bundle
@@ -7,19 +7,15 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
-import androidx.navigation.findNavController
 import co.japl.android.myapplication.finanzas.controller.simulators.list.ListSimulator
 import co.japl.android.myapplication.finanzas.controller.simulators.list.ListViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.viewmodel.viewModelFactory
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.credit.ISimulatorCreditFixPort
 import co.com.japl.finances.iports.inbounds.creditcard.ISimulatorCreditVariablePort
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.FragmentListSaveBinding
 import co.com.japl.ui.factory.ViewModelFactory
 import javax.inject.Inject
 
@@ -48,15 +44,12 @@ class ListSave : Fragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val root = FragmentListSaveBinding.inflate(inflater)
-        root.composeViewFls.apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.Default)
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     ListSimulator(viewModel)
                 }
               }
         }
-        return root.root
     }
 }

--- a/credit/src/main/java/co/com/japl/module/credit/fragments/SimulatorCredit.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/fragments/SimulatorCredit.kt
@@ -1,4 +1,4 @@
-package co.japl.android.myapplication.finanzas.controller.simulators.fix
+package co.com.japl.module.credit.fragments
 
 import android.os.Build
 import android.os.Bundle
@@ -6,16 +6,14 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
-import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.navigation.NavController
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.credit.ISimulatorCreditFixPort
 import co.com.japl.module.credit.controllers.simulator.SimulatorFixViewModel
 import co.com.japl.module.credit.views.simulator.Simulator
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.FragmentSimulatorCreditBinding
 import co.com.japl.ui.factory.ViewModelFactory
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -45,16 +43,12 @@ class SimulatorCredit : Fragment(){
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val rootView = FragmentSimulatorCreditBinding.inflate(inflater,container,false)
-        rootView.composeViewSqc.apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     Simulator(viewModel)
                 }
             }
         }
-        return rootView.root
-
     }
 }

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/AccountFragment.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/AccountFragment.kt
@@ -1,4 +1,4 @@
-package co.japl.android.myapplication.finanzas.controller.account
+package co.com.japl.module.paid.fragments
 
 import android.os.Build
 import android.os.Bundle
@@ -7,10 +7,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
+import androidx.compose.ui.platform.ComposeView
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.inputs.IAccountPort
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.FragmentAccountBinding
 import co.com.japl.module.paid.params.AccountParams
 import co.com.japl.module.paid.views.accounts.form.AccountForm
 import co.com.japl.module.paid.controllers.accounts.form.AccountViewModel
@@ -21,27 +21,24 @@ import javax.inject.Inject
 class AccountFragment : Fragment() {
     @Inject lateinit var accountSvc:IAccountPort
     private var idAccount = 0
-    private lateinit var _binding : FragmentAccountBinding
 
     @RequiresApi(Build.VERSION_CODES.S)
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        _binding = FragmentAccountBinding.inflate(inflater)
         arguments?.let {
             idAccount = AccountParams.download(it)
         }
 
         val viewModel = AccountViewModel(idAccount,accountSvc,findNavController())
-        _binding.cvComponentFa.apply {
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     AccountForm(viewModel = viewModel)
                 }
             }
         }
-        return _binding.root.rootView
     }
 
 }

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/AccountListFragment.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/AccountListFragment.kt
@@ -1,4 +1,4 @@
-package co.japl.android.myapplication.finanzas.controller.account
+package co.com.japl.module.paid.fragments
 
 import android.os.Build
 import android.os.Bundle
@@ -7,12 +7,11 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
-import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.ComposeView
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.inputs.IAccountPort
 import co.com.japl.finances.iports.inbounds.inputs.IInputPort
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.FragmentAccountListBinding
 import co.com.japl.module.paid.views.accounts.list.AccountList
 import co.com.japl.module.paid.controllers.accounts.list.AccountViewModel
 import dagger.hilt.android.AndroidEntryPoint
@@ -23,28 +22,18 @@ class AccountListFragment : Fragment() {
     @Inject lateinit var service:IAccountPort
     @Inject lateinit var inputSvc:IInputPort
 
-    private lateinit var _binding:FragmentAccountListBinding
-    private val binding get() = _binding
-
     @RequiresApi(Build.VERSION_CODES.S)
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        _binding = FragmentAccountListBinding.inflate(inflater, container, false)
         val viewModel = AccountViewModel(service,inputSvc, findNavController())
-        binding.cvAccountList.apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     AccountList(viewModel = viewModel)
                 }
             }
         }
-        return binding.root.rootView
     }
-
-
-
-
 }

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/CheckPaymentsFragment.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/CheckPaymentsFragment.kt
@@ -1,4 +1,4 @@
-package co.japl.android.myapplication.finanzas.controller.paids
+package co.com.japl.module.paid.fragments
 
 import android.os.Build
 import android.os.Bundle
@@ -6,11 +6,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
-import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import co.com.japl.finances.iports.inbounds.common.ICheckPaymentPort
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.FragmentCheckPaymentsBinding
 import co.com.japl.module.paid.views.checkpaids.CheckList
 import dagger.hilt.android.AndroidEntryPoint
 import java.time.YearMonth
@@ -27,18 +26,15 @@ class CheckPaymentsFragment : Fragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        val root = FragmentCheckPaymentsBinding.inflate(inflater)
         val period = YearMonth.now()
         val viewModel = CheckListViewModel(period,svc)
-        root.cvComponentFcp.apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     CheckList(viewModel = viewModel)
                 }
             }
         }
-        return root.root.rootView
     }
 
 

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/EmailListPaidFragment.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/EmailListPaidFragment.kt
@@ -1,4 +1,4 @@
-package co.japl.android.myapplication.finanzas.controller.paids
+package co.com.japl.module.paid.fragments
 
 import android.os.Build
 import android.os.Bundle
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
+import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -13,8 +14,6 @@ import co.com.japl.finances.iports.inbounds.paid.IEmailPaidPort
 import co.com.japl.module.paid.controllers.emailpaid.list.EmailListPaidViewModel
 import co.com.japl.module.paid.views.email.list.EmailListPaid
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.FragmentListEmailCreditCardBinding
-import co.com.japl.module.credit.databinding.FragmentListEmailPaidBinding
 import co.com.japl.ui.factory.ViewModelFactory
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -43,16 +42,13 @@ class EmailListPaidFragment: Fragment(){
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val root = FragmentListEmailPaidBinding.inflate(inflater,container,false)
-
-        root.cvComposeListEmailPd.apply {
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     EmailListPaid(viewModel = viewModel)
                 }
             }
         }
-        return root.root
     }
 
 }

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/EmailPaidFragment.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/EmailPaidFragment.kt
@@ -1,4 +1,4 @@
-package co.japl.android.myapplication.finanzas.controller.paids
+package co.com.japl.module.paid.fragments
 
 import android.os.Build
 import android.os.Bundle
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
+import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -16,7 +17,6 @@ import co.com.japl.module.paid.controllers.emailpaid.form.EmailPaidViewModel
 import co.com.japl.module.paid.views.email.form.EmailPaid
 import co.com.japl.ui.Prefs
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.FragmentEmailCreditCardBinding
 import co.com.japl.ui.factory.ViewModelFactory
 import co.com.japl.module.paid.params.EmailPaidsParams
 import dagger.hilt.android.AndroidEntryPoint
@@ -54,16 +54,13 @@ class EmailPaidFragment: Fragment(){
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val root = FragmentEmailCreditCardBinding.inflate(inflater,container,false)
-
-        root.cvComposeEmailCc.apply {
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     EmailPaid(viewModel = viewModel)
                 }
             }
         }
-        return root.root
     }
 
 }

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/InputFragment.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/InputFragment.kt
@@ -1,4 +1,4 @@
-package co.japl.android.myapplication.finanzas.controller.account
+package co.com.japl.module.paid.fragments
 
 import android.os.Build
 import android.os.Bundle
@@ -7,11 +7,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
-import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.ComposeView
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.inputs.IInputPort
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.FragmentInputBinding
 import co.com.japl.module.paid.params.InputListParams
 import co.com.japl.module.paid.views.Inputs.form.InputForm
 import co.com.japl.module.paid.controllers.Inputs.form.InputViewModel
@@ -26,26 +25,21 @@ class InputFragment : Fragment(){
 
     @Inject lateinit var service:IInputPort
 
-    lateinit var _binding : FragmentInputBinding
-
     @RequiresApi(Build.VERSION_CODES.S)
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        _binding = FragmentInputBinding.inflate(inflater,container,false)
         val arg = arguments?.let { InputListParams.download(it) }?:mapOf()
         accountCode = arg["ACCOUNT"]?:0
         inputCode = arg["INPUT"]?:0
         val viewModel = InputViewModel(accountCode,inputCode,service,findNavController())
-        _binding.cvComponentFi.apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     InputForm(viewModel = viewModel)
                 }
             }
         }
-        return _binding.root.rootView
     }
 }

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/InputListFragment.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/InputListFragment.kt
@@ -1,4 +1,4 @@
-package co.japl.android.myapplication.finanzas.controller.account
+package co.com.japl.module.paid.fragments
 
 import android.os.Build
 import android.os.Bundle
@@ -7,11 +7,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
-import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.ComposeView
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.inputs.IInputPort
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.FragmentInputListBinding
 import co.com.japl.module.paid.params.AccountParams
 import co.com.japl.module.paid.views.Inputs.list.InputList
 import co.com.japl.module.paid.controllers.Inputs.list.InputListModelView
@@ -24,25 +23,18 @@ class InputListFragment : Fragment(){
 
     @Inject lateinit var portSvc:IInputPort
 
-    private var _binding: FragmentInputListBinding? = null
-    private val binding get() = _binding!!
-
     @RequiresApi(Build.VERSION_CODES.S)
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        _binding = FragmentInputListBinding.inflate(inflater,container,false)
-        val root = binding.root
         accountCode = arguments?.let{AccountParams.download(it)}?:0
-        binding.listViewComposableIl.apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     InputList(modelView = InputListModelView(requireContext(),accountCode,findNavController() ,portSvc))
                 }
             }
         }
-        return root
     }
 }

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/ListProjectFragment.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/ListProjectFragment.kt
@@ -1,4 +1,4 @@
-package co.japl.android.myapplication.finanzas.controller.projections
+package co.com.japl.module.paid.fragments
 
 import android.os.Build
 import android.os.Bundle
@@ -6,14 +6,13 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
-import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.paid.IProjectionListPort
 import co.com.japl.module.paid.controllers.projections.list.ProjectionListViewModel
 import co.com.japl.module.paid.views.projections.list.ProjectionList
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.FragmentListProjectionBinding
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -28,17 +27,14 @@ class ListProjectFragment : Fragment(){
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val root = FragmentListProjectionBinding.inflate(inflater)
         val viewModel = ProjectionListViewModel(context?.applicationContext!!,svc,findNavController())
-        root.composeviewFlp.apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     ProjectionList(viewModel=viewModel)
                 }
             }
         }
-        return root.root
     }
 
 

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/PaidFragment.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/PaidFragment.kt
@@ -1,4 +1,4 @@
-package co.japl.android.myapplication.finanzas.controller.paids
+package co.com.japl.module.paid.fragments
 
 import android.os.Build
 import android.os.Bundle
@@ -7,14 +7,13 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
-import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.ComposeView
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.inputs.IAccountPort
 import co.com.japl.finances.iports.inbounds.paid.IPaidPort
 import co.com.japl.module.paid.controllers.paid.form.PaidViewModel
 import co.com.japl.module.paid.views.paid.form.Paid
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.FragmentPaidBinding
 import co.com.japl.module.paid.params.PaidsParams
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -30,7 +29,6 @@ class PaidFragment : Fragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        val root = FragmentPaidBinding.inflate( inflater)
         val codeAccount = PaidsParams.downloadCodeAccount(requireArguments())
         val codePaid = PaidsParams.downloadCodePaid(requireArguments())
 
@@ -41,15 +39,13 @@ class PaidFragment : Fragment() {
             accountSvc = accountSvc,
             navController = findNavController()
         )
-        root.cwComposeFp.apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     Paid(viewModel)
                 }
             }
         }
-        return root.root.rootView
     }
 
 }

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/PaidListFragment.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/PaidListFragment.kt
@@ -1,4 +1,4 @@
-package co.japl.android.myapplication.finanzas.controller.paids
+package co.com.japl.module.paid.fragments
 
 import android.os.Build
 import android.os.Bundle
@@ -7,7 +7,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
-import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.ComposeView
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.paid.IEmailPaidPort
 import co.com.japl.finances.iports.inbounds.paid.IPaidPort
@@ -15,12 +15,11 @@ import co.com.japl.finances.iports.inbounds.paid.ISmsPort
 import co.com.japl.module.paid.controllers.paid.list.PaidViewModel
 import co.com.japl.module.paid.views.paid.list.Paid
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.FragmentPaidListBinding
-import co.com.japl.ui.Prefs
 import co.com.japl.module.paid.params.PaidsParams
 import dagger.hilt.android.AndroidEntryPoint
 import java.time.YearMonth
 import javax.inject.Inject
+import co.japl.android.myapplication.finanzas.ApplicationInitial
 
 @AndroidEntryPoint
 class PaidListFragment : Fragment()  {
@@ -36,7 +35,6 @@ class PaidListFragment : Fragment()  {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        val root = FragmentPaidListBinding.inflate(inflater)
         val date = PaidsParams.downloadList(requireArguments())
         val codeAccount = PaidsParams.downloadCodeAccount(requireArguments())
 
@@ -49,16 +47,13 @@ class PaidListFragment : Fragment()  {
             emailSvc = emailSvc,
             paidSmsSvc = paidSmsSvc
         )
-        root.cvPaidFpl.apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     Paid(viewModel = viewModel)
                 }
             }
         }
-
-        return root.root.rootView
     }
 
 }

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/PaidsFragment.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/PaidsFragment.kt
@@ -1,4 +1,4 @@
-package co.japl.android.myapplication.finanzas.controller.paids
+package co.com.japl.module.paid.fragments
 
 import android.os.Build
 import android.os.Bundle
@@ -7,7 +7,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
-import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.ComposeView
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.inputs.IAccountPort
 import co.com.japl.finances.iports.inbounds.inputs.IInputPort
@@ -18,12 +18,11 @@ import co.com.japl.finances.iports.inbounds.paid.ISmsPort
 import co.com.japl.module.paid.controllers.monthly.list.MonthlyViewModel
 import co.com.japl.module.paid.views.monthly.list.Monthly
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.FragmentPaidsBinding
-import co.com.japl.ui.Prefs
 import co.com.japl.module.paid.params.PaidsParams
 import dagger.hilt.android.AndroidEntryPoint
 import java.time.YearMonth
 import javax.inject.Inject
+import co.japl.android.myapplication.finanzas.ApplicationInitial
 
 @AndroidEntryPoint
 class PaidsFragment : Fragment() {
@@ -44,7 +43,6 @@ class PaidsFragment : Fragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        val root = FragmentPaidsBinding.inflate(inflater,container,false)
         val period = arguments?.let{PaidsParams.downloadPeriod(it)}
         val viewModel = MonthlyViewModel(
             paidSvc = service,
@@ -56,15 +54,12 @@ class PaidsFragment : Fragment() {
             smsSvc = smsSvc,
             navController = findNavController()
         )
-        root.cvPaidsFp.apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     Monthly(viewModel = viewModel)
                 }
             }
         }
-
-        return root.root.rootView
     }
 }

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/PeriodCheckPaymentsFragment.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/PeriodCheckPaymentsFragment.kt
@@ -1,4 +1,4 @@
-package co.japl.android.myapplication.finanzas.controller.paids
+package co.com.japl.module.paid.fragments
 
 import android.os.Build
 import android.os.Bundle
@@ -7,10 +7,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
-import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.ComposeView
 import co.com.japl.finances.iports.inbounds.common.ICheckPaymentPort
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.FragmentPeriodCheckPaymentsBinding
 import co.com.japl.module.paid.views.checkpaids.list.CheckPaids
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -25,17 +24,14 @@ class PeriodCheckPaymentsFragment : Fragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        val root = FragmentPeriodCheckPaymentsBinding.inflate( inflater)
        val viewModel = PeriodCheckPaymentViewModel( checkPaymentSvc)
-        root.cvComposeFpcp.apply { 
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     CheckPaids(viewModel = viewModel)
                 }
             }
         }
-        return root.root.rootView
     }
 
 }

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/PeriodsPaidFragment.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/PeriodsPaidFragment.kt
@@ -1,4 +1,4 @@
-package co.japl.android.myapplication.finanzas.controller.paids
+package co.com.japl.module.paid.fragments
 
 import android.os.Build
 import android.os.Bundle
@@ -7,13 +7,12 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
-import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.ComposeView
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.paid.IPeriodPaidPort
 import co.com.japl.module.paid.controllers.period.list.PeriodsViewModel
 import co.com.japl.module.paid.views.periods.list.Period
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.FragmentPeriodsPaidBinding
 import co.com.japl.module.paid.params.PeriodPaidParam
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -29,22 +28,19 @@ class PeriodsPaidFragment : Fragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        val root =  FragmentPeriodsPaidBinding.inflate(inflater)
         val codeAccount = arguments?.let{PeriodPaidParam().downloadList(it)}
         val viewModel = PeriodsViewModel(
             codeAccount = codeAccount,
             paidSvc = service,
             navController = findNavController()
         )
-        root.cvComposeFpp.apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     Period(viewModel = viewModel)
                 }
             }
         }
-        return root.root.rootView
     }
 
 }

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/ProjectionFragment.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/ProjectionFragment.kt
@@ -1,4 +1,4 @@
-package co.japl.android.myapplication.finanzas.controller.projections
+package co.com.japl.module.paid.fragments
 
 import android.os.Build
 import android.os.Bundle
@@ -6,7 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
-import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -14,7 +14,6 @@ import co.com.japl.finances.iports.inbounds.paid.IProjectionFormPort
 import co.com.japl.module.paid.controllers.projections.forms.ProjectionFormViewModel
 import co.com.japl.module.paid.views.projections.form.ProjectionForm
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.FragmentProjectionBinding
 import co.com.japl.ui.factory.ViewModelFactory
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -45,15 +44,12 @@ class ProjectionFragment : Fragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val root = FragmentProjectionBinding.inflate(inflater)
-        root.composableviewFpj.apply {
-            setViewCompositionStrategy(strategy = ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed )
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     ProjectionForm(viewModel)
                 }
             }
         }
-        return root.root
     }
 }

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/ProjectionsFragment.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/ProjectionsFragment.kt
@@ -1,4 +1,4 @@
-package co.japl.android.myapplication.finanzas.controller.projections
+package co.com.japl.module.paid.fragments
 
 import android.os.Build
 import android.os.Bundle
@@ -6,7 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
-import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -14,7 +14,6 @@ import co.com.japl.finances.iports.inbounds.paid.IProjectionsPort
 import co.com.japl.module.paid.controllers.projections.list.ProjectionsViewModel
 import co.com.japl.module.paid.views.projections.list.Projections
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.FragmentProjectionsBinding
 import co.com.japl.ui.factory.ViewModelFactory
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -41,15 +40,12 @@ class ProjectionsFragment : Fragment(){
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val root = FragmentProjectionsBinding.inflate(inflater)
-        root.componentviewPjt.apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     Projections(viewModel = viewModel)
                 }
             }
         }
-        return root.root
     }
 }

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/SmsFragment.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/SmsFragment.kt
@@ -1,4 +1,4 @@
-package co.japl.android.myapplication.finanzas.controller.paids
+package co.com.japl.module.paid.fragments
 
 import android.os.Build
 import android.os.Bundle
@@ -6,7 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
-import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.inputs.IAccountPort
@@ -15,7 +15,6 @@ import co.com.japl.module.paid.controllers.sms.form.SmsViewModel
 import co.com.japl.module.paid.views.sms.form.Sms
 import co.com.japl.ui.Prefs
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.FragmentSmsPaidBinding
 import co.com.japl.module.paid.params.SmsPaidParams
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -32,7 +31,6 @@ class SmsFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        val root = FragmentSmsPaidBinding.inflate(inflater)
         val code = arguments?.let{SmsPaidParams.download(it)}
         val viewModel = SmsViewModel(
             codeSMS = code,
@@ -41,14 +39,12 @@ class SmsFragment : Fragment() {
             navController = findNavController(),
             prefs = prefs
         )
-        root.cvComposeFsp.apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     Sms(viewModel = viewModel)
                 }
             }
         }
-        return root.root.rootView
     }
 }

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/SmsListFragment.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/fragments/SmsListFragment.kt
@@ -1,4 +1,4 @@
-package co.japl.android.myapplication.finanzas.controller.paids
+package co.com.japl.module.paid.fragments
 
 import android.os.Build
 import android.os.Bundle
@@ -6,7 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
-import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import co.com.japl.finances.iports.inbounds.inputs.IAccountPort
@@ -14,7 +14,6 @@ import co.com.japl.finances.iports.inbounds.paid.ISMSPaidPort
 import co.com.japl.module.paid.controllers.sms.list.SmsViewModel
 import co.com.japl.module.paid.views.sms.list.SMS
 import co.com.japl.ui.theme.MaterialThemeComposeUI
-import co.com.japl.module.credit.databinding.FragmentSmsPaidListBinding
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -28,20 +27,17 @@ class SmsListFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        val root = FragmentSmsPaidListBinding.inflate(inflater)
         val viewModel = SmsViewModel(
             svc = smsSvc,
             accountSvc = accountSvc,
             navController = findNavController()
         )
-        root.cvComposeFspl.apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        return ComposeView(requireContext()).apply {
             setContent {
                 MaterialThemeComposeUI {
                     SMS(viewModel = viewModel)
                 }
             }
         }
-        return root.root.rootView
     }
 }


### PR DESCRIPTION
This PR refactors fragments across several modules to improve modularity and consistency. 

Key changes:
1.  **ComposeView Migration**: Fragments no longer use `ViewBinding` to host Compose UI. Instead, they instantiate and return `ComposeView(requireContext())` directly in `onCreateView`. This resolves issues where feature modules were trying to access layout bindings defined in the `app` module.
2.  **Package Name Standardization**: Fragments have been moved to (or their package declarations updated to) `co.com.japl.module.<feature>.fragments`.
3.  **Navigation Graph Update**: `nav_graph.xml` in the `app` module has been comprehensively updated to use the new fully qualified names for all refactored fragments.
4.  **Theme Consistency**: All refactored fragment content is now wrapped in `MaterialThemeComposeUI` to ensure a consistent look and feel across the application.
5.  **Code Cleanup**: Removed numerous unused ViewBinding imports and variable declarations. Deleted Kotlin compiler session artifacts.

Modules affected: `CreditCardModule`, `japl-android-finances-paid-module`, `credit`, and `app`.

---
*PR created automatically by Jules for task [12528455665215443099](https://jules.google.com/task/12528455665215443099) started by @nano871022*