### PR TITLE
Support deep link parameters in ViewModels using SavedStateHandle

### DIFF
--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/account/CreditCardViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/account/CreditCardViewModel.kt
@@ -25,7 +25,7 @@ class CreditCardViewModel @Inject constructor(
     private val creditCardSvc:ICreditCardPort
 ):ViewModel() {
 
-    private val codeCreditCard: Int? = savedStateHandle.get<String>(CreditCardParams.Params.ARG_PARAM_CODE)?.toIntOrNull()
+    private val codeCreditCard: Int? = CreditCardParams.download(savedStateHandle).orElse(null)?.toIntOrNull()
     var navController: NavController? = null
 
     var showProgress = mutableStateOf(true)

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/amortization/AmortizationViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/amortization/AmortizationViewModel.kt
@@ -14,6 +14,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.launch
 import androidx.lifecycle.SavedStateHandle
 import javax.inject.Inject
+import co.com.japl.module.creditcard.params.AmortizationTableParams
 
 @HiltViewModel
 class AmortizationViewModel @Inject constructor(
@@ -22,7 +23,7 @@ class AmortizationViewModel @Inject constructor(
     private val svc: IAmortizationTablePort?
 ): ViewModel(){
 
-	private val id: Int = savedStateHandle.get<Long>("CODE")?.toInt() ?: 0
+	private val id: Int by lazy { (AmortizationTableParams.download(savedStateHandle).get("CODE") as? Long)?.toInt() ?: 0 }
 	var navController: NavController? = null
 
 	val progressStatus = mutableStateOf(true)

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/params/AmortizationTableParams.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/params/AmortizationTableParams.kt
@@ -1,6 +1,7 @@
 package co.com.japl.module.creditcard.params
 
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import androidx.core.net.toUri
 import androidx.core.os.bundleOf
@@ -14,6 +15,7 @@ import co.com.japl.finances.iports.enums.AmortizationKindOfEnum
 import co.com.japl.module.creditcard.params.PeriodsParams.Params
 import com.google.gson.Gson
 import java.time.LocalDate
+import androidx.lifecycle.SavedStateHandle
 
 class AmortizationTableParams {
 
@@ -49,6 +51,31 @@ class AmortizationTableParams {
                         "CODE" to code
                     )
                 }
+            }
+            return mapOf()
+        }
+
+        fun download(savedStateHandle: SavedStateHandle):Map<String,Any>{
+            val code = savedStateHandle.get<Long>("CODE")
+            val creditCode = savedStateHandle.get<Long>("CREDIT_CODE")
+            val lastDate = savedStateHandle.get<LocalDate>("LAST_DATE")
+
+            if(code != null || creditCode != null){
+                return mapOf<String,Any>(
+                    "CODE" to (code ?: 0L),
+                    "CREDIT_CODE" to (creditCode ?: 0L),
+                    "LAST_DATE" to (lastDate ?: LocalDate.now())
+                )
+            }
+
+            savedStateHandle.get<Intent>(Params.PARAM_DEEPLINK)?.let { intent ->
+                 val uri = intent.dataString?.toUri()
+                 val date = uri?.getQueryParameter("last_date")?.let{ DateUtils.toLocalDate(it) }
+                 return mapOf<String,Any>(
+                        "CREDIT_CODE" to (uri?.getQueryParameter("credit_code")?.toLongOrNull()?:0.toLong()),
+                        "CODE" to (uri?.getQueryParameter("code")?.toLongOrNull()?:0.toLong()),
+                        "LAST_DATE" to (date?: LocalDate.now())
+                    )
             }
             return mapOf()
         }

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/params/CreditCardParams.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/params/CreditCardParams.kt
@@ -2,11 +2,13 @@ package co.com.japl.module.creditcard.params
 
 import android.content.Intent
 import android.net.Uri
+import androidx.core.net.toUri
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.core.os.bundleOf
+import androidx.lifecycle.SavedStateHandle
 import androidx.fragment.app.FragmentManager
 import androidx.navigation.NavController
 import co.com.japl.module.creditcard.R
@@ -45,6 +47,18 @@ class CreditCardParams(var parentFragmentManagers: FragmentManager) {
                     return Optional.ofNullable(Uri.parse((it[Params.ARG_DEEPLINK] as Intent).dataString).getQueryParameter(Params.ARG_PARAM_CODE_CREDIT_CARD))
 
                 }
+            }
+            return Optional.empty()
+        }
+
+        @RequiresApi(Build.VERSION_CODES.N)
+        fun download(savedStateHandle: SavedStateHandle):Optional<String>{
+            val code = savedStateHandle.get<String>(Params.ARG_PARAM_CODE)
+            if(code != null){
+                return Optional.ofNullable(code)
+            }
+            savedStateHandle.get<Intent>(Params.ARG_DEEPLINK)?.let { intent ->
+                return Optional.ofNullable(intent.dataString?.toUri()?.getQueryParameter(Params.ARG_PARAM_CODE_CREDIT_CARD))
             }
             return Optional.empty()
         }

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/params/CreditCardQuotesParams.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/params/CreditCardQuotesParams.kt
@@ -2,10 +2,12 @@ package co.com.japl.module.creditcard.params
 
 import android.content.Intent
 import android.net.Uri
+import androidx.core.net.toUri
 import android.os.Build
 import android.os.Bundle
 import androidx.annotation.RequiresApi
 import androidx.core.os.bundleOf
+import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavController
 import co.com.japl.module.creditcard.R
 import co.com.japl.ui.utils.DateUtils
@@ -108,6 +110,26 @@ class CreditCardQuotesParams {
                 }
             }
 
+            @RequiresApi(Build.VERSION_CODES.O)
+            fun download(savedStateHandle: SavedStateHandle): Triple<Int, LocalDateTime, Short> {
+                val code = savedStateHandle.get<Int>(Params.PARAM_CREDIT_CARD_CODE)
+                val cutOff = savedStateHandle.get<String>(Params.PARAM_CREDIT_CARD_CUTOFF)?.let { DateUtils.toLocalDateTime(it) }
+                val cutoffDay = savedStateHandle.get<Short>(Params.PARAM_CREDIT_CARD_CUTOFF_DAY)
+
+                if (code != null && cutOff != null && cutoffDay != null) {
+                    return Triple(code, cutOff, cutoffDay)
+                }
+
+                savedStateHandle.get<Intent>(Params.PARAM_DEEPLINK)?.let { intent ->
+                    val uri = intent.dataString?.toUri()
+                    val c = uri?.getQueryParameter(Params.PARAM_CODE_CREDIT_CARD)?.toIntOrNull() ?: 0
+                    val co = uri?.getQueryParameter(Params.PARAM_CUTOFF)?.let { DateUtils.toLocalDateTime(it) } ?: LocalDateTime.now()
+                    val cd = uri?.getQueryParameter(Params.PARAM_CUTOFF_DAY)?.toShortOrNull() ?: 0
+                    return Triple(c, co, cd)
+                }
+                return Triple(0, LocalDateTime.now(), 0)
+            }
+
             fun toBack(navController: NavController) {
                 navController.popBackStack()
             }
@@ -141,6 +163,26 @@ class CreditCardQuotesParams {
                         return Triple(code, name, id)
                     }
                 }
+            }
+
+            @RequiresApi(Build.VERSION_CODES.O)
+            fun download(savedStateHandle: SavedStateHandle): Triple<Int, String, Int> {
+                val code = savedStateHandle.get<Int>(Params.PARAM_CREDIT_CARD_CODE)
+                val name = savedStateHandle.get<String>(Params.PARAM_CREDIT_CARD_NAME)
+                val id = savedStateHandle.get<Int>(Params.PARAM_BOUGHT_ID)
+
+                if (code != null && name != null && id != null) {
+                    return Triple(code, name, id)
+                }
+
+                savedStateHandle.get<Intent>(Params.PARAM_DEEPLINK)?.let { intent ->
+                    val uri = intent.dataString?.toUri()
+                    val c = uri?.getQueryParameter(Params.PARAM_CREDIT_CARD_CODE)?.toIntOrNull() ?: 0
+                    val n = uri?.getQueryParameter(Params.PARAM_CREDIT_CARD_NAME) ?: ""
+                    val b = uri?.getQueryParameter(Params.PARAM_BOUGHT_ID)?.toIntOrNull() ?: 0
+                    return Triple(c, n, b)
+                }
+                return Triple(0, "", 0)
             }
 
             fun downloadOldBoughtId(argument: Bundle): Int {

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/params/PeriodsParams.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/params/PeriodsParams.kt
@@ -2,11 +2,13 @@ package co.com.japl.module.creditcard.params
 
 import android.content.Intent
 import android.net.Uri
+import androidx.core.net.toUri
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.core.os.bundleOf
+import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavController
 import co.com.japl.module.creditcard.R
 
@@ -40,6 +42,20 @@ class PeriodsParams {
                         Uri.parse(intent.dataString).getQueryParameter(Params.PARAM_CODE_CREDIT_CARD)?.let {
                             return it.toInt()
                         }
+                    }
+                }
+                return 0
+            }
+
+            @RequiresApi(Build.VERSION_CODES.O)
+            fun download(savedStateHandle: SavedStateHandle): Int {
+                val code = savedStateHandle.get<Int>(Params.PARAM_CREDIT_CARD_CODE)
+                if (code != null) {
+                    return code
+                }
+                savedStateHandle.get<Intent>(Params.PARAM_DEEPLINK)?.let { intent ->
+                    intent.dataString?.toUri()?.getQueryParameter(Params.PARAM_CODE_CREDIT_CARD)?.let {
+                        return it.toIntOrNull() ?: 0
                     }
                 }
                 return 0

--- a/credit/src/main/java/co/com/japl/module/credit/controllers/amortization/AmortizationViewModel.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/controllers/amortization/AmortizationViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.launch
 import java.time.LocalDate
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
+import co.com.japl.module.credit.params.AmortizationTableParams
 
 @HiltViewModel
 class AmortizationViewModel @Inject constructor(
@@ -23,8 +24,9 @@ class AmortizationViewModel @Inject constructor(
     private val amortizationSvc: IAmortizationTablePort?
 ) : ViewModel() {
 
-    private val code: Int = savedStateHandle.get<Long>("CODE")?.toInt() ?: 0
-    private val lastDate: LocalDate = savedStateHandle.get<LocalDate>("LAST_DATE") ?: LocalDate.now()
+    private val params: Map<String, Any> by lazy { AmortizationTableParams.download(savedStateHandle) }
+    private val code: Int get() = (params.get("CODE") as? Long)?.toInt() ?: 0
+    private val lastDate: LocalDate get() = params.get("LAST_DATE") as? LocalDate ?: LocalDate.now()
 
     private val _state = MutableStateFlow(AmortizationState())
     val state = _state.asStateFlow()

--- a/credit/src/main/java/co/com/japl/module/credit/controllers/creditamortization/CreditAmortizationViewModel.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/controllers/creditamortization/CreditAmortizationViewModel.kt
@@ -19,6 +19,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import java.time.LocalDate
 import androidx.lifecycle.SavedStateHandle
 import javax.inject.Inject
+import co.com.japl.module.credit.params.AmortizationCreditParams
 
 @HiltViewModel
 class CreditAmortizationViewModel @Inject constructor(
@@ -29,8 +30,9 @@ class CreditAmortizationViewModel @Inject constructor(
     private val amortizationSvc: IAmortizationTablePort?
 ): ViewModel() {
 
-    private val creditCode: Int = savedStateHandle.get<Long>("CREDIT_CODE")?.toInt() ?: 0
-    private val lastDate: LocalDate = savedStateHandle.get<LocalDate>("LAST_DATE") ?: LocalDate.now()
+    private val params: Map<String, Any> by lazy { AmortizationCreditParams.download(savedStateHandle) }
+    private val creditCode: Int get() = (params.get("CREDIT_CODE") as? Long)?.toInt() ?: 0
+    private val lastDate: LocalDate get() = params.get("LAST_DATE") as? LocalDate ?: LocalDate.now()
     lateinit var navController: NavController
         set
 

--- a/credit/src/main/java/co/com/japl/module/credit/params/AmortizationCreditParams.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/params/AmortizationCreditParams.kt
@@ -1,12 +1,14 @@
 package co.com.japl.module.credit.params
 
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import androidx.core.net.toUri
 import androidx.navigation.NavController
 import co.com.japl.ui.utils.DateUtils
 import co.com.japl.module.credit.params.AdditionalCreditParams.Params
 import java.time.LocalDate
+import androidx.lifecycle.SavedStateHandle
 
 class AmortizationCreditParams {
 
@@ -27,6 +29,31 @@ class AmortizationCreditParams {
                         "CODE" to code
                     )
                 }
+            }
+            return mapOf()
+        }
+
+        fun download(savedStateHandle: SavedStateHandle):Map<String,Any>{
+            val code = savedStateHandle.get<Long>("CODE")
+            val creditCode = savedStateHandle.get<Long>("CREDIT_CODE")
+            val lastDate = savedStateHandle.get<LocalDate>("LAST_DATE")
+
+            if(code != null || creditCode != null){
+                return mapOf<String,Any>(
+                    "CODE" to (code ?: 0L),
+                    "CREDIT_CODE" to (creditCode ?: 0L),
+                    "LAST_DATE" to (lastDate ?: LocalDate.now())
+                )
+            }
+
+            savedStateHandle.get<Intent>(Params.PARAM_DEEPLINK)?.let { intent ->
+                 val uri = intent.dataString?.toUri()
+                 val date = uri?.getQueryParameter("last_date")?.let{ DateUtils.toLocalDate(it) }
+                 return mapOf<String,Any>(
+                        "CREDIT_CODE" to (uri?.getQueryParameter("credit_code")?.toLongOrNull()?:0.toLong()),
+                        "CODE" to (uri?.getQueryParameter("code")?.toLongOrNull()?:0.toLong()),
+                        "LAST_DATE" to (date?: LocalDate.now())
+                    )
             }
             return mapOf()
         }

--- a/credit/src/main/java/co/com/japl/module/credit/params/AmortizationTableParams.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/params/AmortizationTableParams.kt
@@ -1,6 +1,7 @@
 package co.com.japl.module.credit.params
 
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import androidx.core.net.toUri
 import androidx.core.os.bundleOf
@@ -13,6 +14,7 @@ import co.com.japl.finances.iports.enums.AmortizationKindOfEnum
 import co.com.japl.module.credit.params.AdditionalCreditParams.Params
 import com.google.gson.Gson
 import java.time.LocalDate
+import androidx.lifecycle.SavedStateHandle
 
 class AmortizationTableParams {
 
@@ -48,6 +50,31 @@ class AmortizationTableParams {
                         "CODE" to code
                     )
                 }
+            }
+            return mapOf()
+        }
+
+        fun download(savedStateHandle: SavedStateHandle):Map<String,Any>{
+            val code = savedStateHandle.get<Long>("CODE")
+            val creditCode = savedStateHandle.get<Long>("CREDIT_CODE")
+            val lastDate = savedStateHandle.get<LocalDate>("LAST_DATE")
+
+            if(code != null || creditCode != null){
+                return mapOf<String,Any>(
+                    "CODE" to (code ?: 0L),
+                    "CREDIT_CODE" to (creditCode ?: 0L),
+                    "LAST_DATE" to (lastDate ?: LocalDate.now())
+                )
+            }
+
+            savedStateHandle.get<Intent>(Params.PARAM_DEEPLINK)?.let { intent ->
+                 val uri = intent.dataString?.toUri()
+                 val date = uri?.getQueryParameter("last_date")?.let{ DateUtils.toLocalDate(it) }
+                 return mapOf<String,Any>(
+                        "CREDIT_CODE" to (uri?.getQueryParameter("credit_code")?.toLongOrNull()?:0.toLong()),
+                        "CODE" to (uri?.getQueryParameter("code")?.toLongOrNull()?:0.toLong()),
+                        "LAST_DATE" to (date?: LocalDate.now())
+                    )
             }
             return mapOf()
         }


### PR DESCRIPTION
This PR fixes an issue where ViewModels using `SavedStateHandle` were unable to retrieve parameters when the navigation was triggered via a deep link.

The fix involves:
1.  **Centralized Parameter Retrieval**: Added a new `download(SavedStateHandle)` overload to the decentralized `Params` classes (`AmortizationTableParams`, `CreditCardParams`, etc.). This method attempts to retrieve values from the standard bundle first, falling back to parsing the deep link URI from the `Intent` if present.
2.  **ViewModel Refactoring**: Updated ViewModels to use these helper methods instead of directly querying the `SavedStateHandle`.
3.  **Safety and Robustness**:
    *   Used safe parsing (`toIntOrNull`, `toLongOrNull`, etc.) for all deep link query parameters to prevent `NumberFormatException` crashes.
    *   Optimized ViewModels with `lazy` properties to ensure the parsing logic is only executed once.
    *   Fixed missing imports and ensured consistent `@RequiresApi` usage.
4.  **Cleanup**: Removed extraneous binary files accidentally added during development.

Verified with unit tests in the affected modules (`:CreditCardModule` and `:credit`).

---
*PR created automatically by Jules for task [6170349586031231360](https://jules.google.com/task/6170349586031231360) started by @nano871022*