### PR TITLE
Clean AI Response from Thinking/Reasoning Content

### DIFF
--- a/japl-android-finances-services/build.gradle.kts
+++ b/japl-android-finances-services/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.7.0")
     implementation("com.google.android.material:material:1.12.0")
     testImplementation("junit:junit:4.13.2")
+    testImplementation("org.json:json:20240303")
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
 }

--- a/japl-android-finances-services/src/main/java/co/japl/android/finances/services/core/LLMOutboundAdapter.kt
+++ b/japl-android-finances-services/src/main/java/co/japl/android/finances/services/core/LLMOutboundAdapter.kt
@@ -69,7 +69,8 @@ class LLMOutboundAdapter @Inject constructor() : ILLMOutboundPort {
                 val candidates = jsonResponse.getJSONArray("candidates")
                 val contentRes = candidates.getJSONObject(0).getJSONObject("content")
                 val partsRes = contentRes.getJSONArray("parts")
-                partsRes.getJSONObject(0).getString("text")
+                val text = partsRes.getJSONObject(0).getString("text")
+                cleanResponse(text)
             } else {
                 throw Exception("Error: ${connection.responseCode} ${connection.errorStream?.bufferedReader()?.readText()}")
             }
@@ -129,7 +130,8 @@ class LLMOutboundAdapter @Inject constructor() : ILLMOutboundPort {
                 val jsonResponse = JSONObject(response)
                 val choices = jsonResponse.getJSONArray("choices")
                 val messageObj = choices.getJSONObject(0).getJSONObject("message")
-                messageObj.getString("content")
+                val content = messageObj.getString("content")
+                cleanResponse(content)
             } else {
                 throw Exception("Error: ${connection.responseCode} ${connection.errorStream?.bufferedReader()?.readText()}")
             }
@@ -159,5 +161,30 @@ class LLMOutboundAdapter @Inject constructor() : ILLMOutboundPort {
                 throw Exception("Error: ${connection.responseCode} ${connection.errorStream?.bufferedReader()?.readText()}")
             }
         }
+    }
+
+    internal fun cleanResponse(content: String): String {
+        val thinkRegex = Regex("<think>.*?</think>", RegexOption.DOT_MATCHES_ALL)
+        var cleaned = content.replace(thinkRegex, "").trim()
+
+        if (cleaned.startsWith("{") && cleaned.endsWith("}")) {
+            try {
+                val json = JSONObject(cleaned)
+                val keys = listOf("response", "answer", "content")
+                val thinkingKeys = listOf("thinking", "thought", "reasoning")
+
+                if (thinkingKeys.any { json.has(it) }) {
+                    for (key in keys) {
+                        if (json.has(key)) {
+                            return json.getString(key).trim()
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                // Not a JSON or doesn't match expected pattern
+            }
+        }
+
+        return cleaned
     }
 }

--- a/japl-android-finances-services/src/test/java/co/japl/android/finances/services/core/LLMResponseCleaningTest.kt
+++ b/japl-android-finances-services/src/test/java/co/japl/android/finances/services/core/LLMResponseCleaningTest.kt
@@ -1,0 +1,64 @@
+package co.japl.android.finances.services.core
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LLMResponseCleaningTest {
+
+    private val adapter = LLMOutboundAdapter()
+
+    @Test
+    fun `test cleanResponse with simple text`() {
+        val input = "This is a simple response"
+        val expected = "This is a simple response"
+        assertEquals(expected, adapter.cleanResponse(input))
+    }
+
+    @Test
+    fun `test cleanResponse with think tags`() {
+        val input = "<think>I should calculate the sum of 2 and 2</think>The answer is 4"
+        val expected = "The answer is 4"
+        assertEquals(expected, adapter.cleanResponse(input))
+    }
+
+    @Test
+    fun `test cleanResponse with multiline think tags`() {
+        val input = """
+            <think>
+            Analyzing the request...
+            Done.
+            </think>
+            Final result.
+        """.trimIndent()
+        val expected = "Final result."
+        assertEquals(expected, adapter.cleanResponse(input).trim())
+    }
+
+    @Test
+    fun `test cleanResponse with thinking json - response key`() {
+        val input = """{"thinking": "calculating...", "response": "The result is 42"}"""
+        val expected = "The result is 42"
+        assertEquals(expected, adapter.cleanResponse(input))
+    }
+
+    @Test
+    fun `test cleanResponse with thinking json - content key`() {
+        val input = """{"thinking": "calculating...", "content": "The result is 42"}"""
+        val expected = "The result is 42"
+        assertEquals(expected, adapter.cleanResponse(input))
+    }
+
+    @Test
+    fun `test cleanResponse with thinking json - answer key`() {
+        val input = """{"thought": "thinking...", "answer": "This is the answer"}"""
+        val expected = "This is the answer"
+        assertEquals(expected, adapter.cleanResponse(input))
+    }
+
+    @Test
+    fun `test cleanResponse with nested json-like string in think tags`() {
+        val input = "<think>{\"reasoning\": \"...\"}</think>Actual content"
+        val expected = "Actual content"
+        assertEquals(expected, adapter.cleanResponse(input))
+    }
+}


### PR DESCRIPTION
This change implements a mechanism to filter out "thinking" or "reasoning" process from AI responses before they are returned to the UI. It handles both XML-like `<think>` tags and JSON-formatted responses where the actual answer is buried alongside a thinking field. Unit tests have been added to verify various response formats from Gemini and DeepSeek models.

---
*PR created automatically by Jules for task [4114632130545257627](https://jules.google.com/task/4114632130545257627) started by @nano871022*