### PR TITLE
Threading, UI, and Simulator Improvements

### DIFF
--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/amortization/AmortizationViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/amortization/AmortizationViewModel.kt
@@ -11,7 +11,9 @@ import co.com.japl.finances.iports.enums.KindAmortization
 import co.com.japl.finances.iports.inbounds.creditcard.IAmortizationTablePort
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import androidx.lifecycle.SavedStateHandle
 import javax.inject.Inject
 import co.com.japl.module.creditcard.params.AmortizationTableParams
@@ -34,12 +36,10 @@ class AmortizationViewModel @Inject constructor(
 	}
 	
 	fun execute() = viewModelScope.launch{
-		callApi()
-	}
-
-	suspend fun callApi(){
 		try {
-			svc?.getAmortization(id, KindAmortization.VARIABLE_QUOTE_SIMULATOR, true)?.let {
+			withContext(Dispatchers.IO) {
+				svc?.getAmortization(id, KindAmortization.VARIABLE_QUOTE_SIMULATOR, true)
+			}?.let {
 				list.addAll(it)
 			}
 			progressStatus.value = false

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/bought/forms/QuoteViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/bought/forms/QuoteViewModel.kt
@@ -27,11 +27,13 @@ import co.com.japl.ui.utils.DateUtils
 import co.com.japl.ui.utils.FormUIState
 import co.com.japl.ui.utils.initialFieldState
 import co.com.japl.ui.utils.NumbersUtil
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -220,23 +222,37 @@ class QuoteViewModel(private val codeCreditCard:Int,
 
     }
 
-    fun create(){
+    fun create() = viewModelScope.launch {
         validate()
         if(validate) {
-            boughtSvc?.let {
+            boughtSvc?.let { svcPort ->
                 bought?.let { bought ->
-                    val id = it.create(bought, prefs.simulator)
+                    val id = withContext(Dispatchers.IO) {
+                        svcPort.create(bought, prefs.simulator)
+                    }
                     if (id > 0) {
                         if (oldBoughtId > 0) {
-                            boughtSvc.endingRecurrentPayment(oldBoughtId, LocalDateTime.now())
+                            withContext(Dispatchers.IO) {
+                                svcPort.endingRecurrentPayment(oldBoughtId, LocalDateTime.now())
+                            }
                         }
                         buyCreditCardSettingSvc?.let { svc ->
                             settingName.value.value?.let { value ->
-                                svc.createOrUpdate(getBuyCreditCardSetting(id, value.first))
-                            } ?: buySetting?.let { svc.delete(it.id) }
+                                withContext(Dispatchers.IO) {
+                                    svc.createOrUpdate(getBuyCreditCardSetting(id, value.first))
+                                }
+                            } ?: buySetting?.let {
+                                withContext(Dispatchers.IO) {
+                                    svc.delete(it.id)
+                                }
+                            }
                         }
                         tagSvc?.let { svc ->
-                            tagSelected.value.value?.let { value -> svc.createOrUpdate(value.id, id) }
+                            tagSelected.value.value?.let { value ->
+                                withContext(Dispatchers.IO) {
+                                    svc.createOrUpdate(value.id, id)
+                                }
+                            }
                         }
                         navController?.let { navController ->
                             Toast.makeText(
@@ -259,23 +275,37 @@ class QuoteViewModel(private val codeCreditCard:Int,
         }
     }
 
-    fun createAndBack(){
+    fun createAndBack() = viewModelScope.launch {
         validate()
         if(validate) {
-            boughtSvc?.let {
+            boughtSvc?.let { svcPort ->
                 bought?.let { bought ->
-                    val id = it.create(bought, prefs.simulator)
+                    val id = withContext(Dispatchers.IO) {
+                        svcPort.create(bought, prefs.simulator)
+                    }
                     if (id > 0) {
                         if (oldBoughtId > 0) {
-                            boughtSvc.endingRecurrentPayment(oldBoughtId, LocalDateTime.now())
+                            withContext(Dispatchers.IO) {
+                                svcPort.endingRecurrentPayment(oldBoughtId, LocalDateTime.now())
+                            }
                         }
                         buyCreditCardSettingSvc?.let { svc ->
                             settingName.value.value?.let { value ->
-                                svc.createOrUpdate(getBuyCreditCardSetting(id, value.first))
-                            } ?: buySetting?.let { svc.delete(it.id) }
+                                withContext(Dispatchers.IO) {
+                                    svc.createOrUpdate(getBuyCreditCardSetting(id, value.first))
+                                }
+                            } ?: buySetting?.let {
+                                withContext(Dispatchers.IO) {
+                                    svc.delete(it.id)
+                                }
+                            }
                         }
                         tagSvc?.let { svc ->
-                            tagSelected.value.value?.let { value -> svc.createOrUpdate(value.id, id) }
+                            tagSelected.value.value?.let { value ->
+                                withContext(Dispatchers.IO) {
+                                    svc.createOrUpdate(value.id, id)
+                                }
+                            }
                         }
                         navController?.let { navController ->
                             Toast.makeText(
@@ -298,18 +328,33 @@ class QuoteViewModel(private val codeCreditCard:Int,
         }
     }
 
-    fun update(){
+    fun update() = viewModelScope.launch {
         validate()
         if(validate) {
-            boughtSvc?.let {
-                if(it.update(bought!!,prefs.simulator)) {
+            boughtSvc?.let { svcPort ->
+                val result = withContext(Dispatchers.IO) {
+                    svcPort.update(bought!!, prefs.simulator)
+                }
+                if(result) {
                     buyCreditCardSettingSvc?.let{svc->
                         settingName.value.value?.let{ value ->
-                            bought?.let{dto->svc.createOrUpdate(getBuyCreditCardSetting(dto.id,value.first))}
-                        }?:buySetting?.let {svc.delete(it.id)}
+                            bought?.let{dto->
+                                withContext(Dispatchers.IO) {
+                                    svc.createOrUpdate(getBuyCreditCardSetting(dto.id, value.first))
+                                }
+                            }
+                        }?:buySetting?.let {
+                            withContext(Dispatchers.IO) {
+                                svc.delete(it.id)
+                            }
+                        }
                     }
                     tagSvc?.let { svc ->
-                        tagSelected.value.value?.let{svc.createOrUpdate(it.id,codeBought)}
+                        tagSelected.value.value?.let{
+                            withContext(Dispatchers.IO) {
+                                svc.createOrUpdate(it.id, codeBought)
+                            }
+                        }
                     }
                     navController?.let { navController ->
                         Toast.makeText(
@@ -331,7 +376,7 @@ class QuoteViewModel(private val codeCreditCard:Int,
         }
     }
 
-    fun createTag(tagName:String):TagDTO?=
+    suspend fun createTag(tagName:String):TagDTO?=
          tagSvc?.let {
             val tag = TagDTO(
                 id = 0,
@@ -339,7 +384,9 @@ class QuoteViewModel(private val codeCreditCard:Int,
                 active = true,
                 create = LocalDate.now()
             )
-            val id =  it.create(tag)
+            val id = withContext(Dispatchers.IO) {
+                it.create(tag)
+            }
             return tag.copy(id = id)
         }
 
@@ -361,8 +408,11 @@ class QuoteViewModel(private val codeCreditCard:Int,
         }
     }
 
-    fun deleteTag(codeTag:Int){
-        if(tagSvc?.delete(codeTag) == true){
+    fun deleteTag(codeTag:Int) = viewModelScope.launch {
+        val result = withContext(Dispatchers.IO) {
+            tagSvc?.delete(codeTag) == true
+        }
+        if(result){
             navController?.let {navController->
                 Toast.makeText(navController.context,R.string.toast_successful_deleted,Toast.LENGTH_SHORT).show().also {
                     loadTags()
@@ -467,7 +517,7 @@ class QuoteViewModel(private val codeCreditCard:Int,
         }
     }
 
-    fun main()= runBlocking {
+    fun main() = viewModelScope.launch {
         progress.floatValue = 0.1f
         execute()
         progress.floatValue = 1.0f
@@ -478,8 +528,10 @@ class QuoteViewModel(private val codeCreditCard:Int,
         progress.floatValue = 0.2f
         dateBought.onValueChange(DateUtils.localDateToStringDate(LocalDate.now()))
         progress.floatValue = 0.3f
-        creditCardSvc?.let {
-            it.getCreditCard(codeCreditCard)?.let {
+        creditCardSvc?.let { svcPort ->
+            withContext(Dispatchers.IO) {
+                svcPort.getCreditCard(codeCreditCard)
+            }?.let {
                 creditCardName.onValueChange(it.name)
                 DateUtils.cutOff(it.cutOffDay, period.toLocalDate())?.let {
                     cutOffDate = it
@@ -488,17 +540,21 @@ class QuoteViewModel(private val codeCreditCard:Int,
             }
         }
 
-        creditRateSvc?.let {
-            it.get(codeCreditCard,cutOffDate?.monthValue!!,cutOffDate?.year!!,KindInterestRateEnum.CREDIT_CARD)?.let {
+        creditRateSvc?.let { svcPort ->
+            withContext(Dispatchers.IO) {
+                svcPort.get(codeCreditCard, cutOffDate?.monthValue!!, cutOffDate?.year!!, KindInterestRateEnum.CREDIT_CARD)
+            }?.let {
                 taxDto = it
                 creditRate.onValueChange(it.value.toString())
                 creditRateKind.onValueChange( it.kindOfTax?.getName()?: KindOfTaxEnum.MONTHLY_EFFECTIVE.name)
             }
         }
 
-        boughtSvc?.let {
+        boughtSvc?.let { svcPort ->
             if (oldBoughtId > 0) {
-                it.getById(oldBoughtId, prefs.simulator)?.let {
+                withContext(Dispatchers.IO) {
+                    svcPort.getById(oldBoughtId, prefs.simulator)
+                }?.let {
                     nameProduct.onValueChange(it.nameItem)
                     valueProduct.onValueChange(NumbersUtil.toString(it.valueItem))
                     monthProduct.onValueChange(it.month.toString())
@@ -509,7 +565,9 @@ class QuoteViewModel(private val codeCreditCard:Int,
             }
 
             if(codeBought > 0) {
-                it.getById(codeBought, prefs.simulator)?.let {
+                withContext(Dispatchers.IO) {
+                    svcPort.getById(codeBought, prefs.simulator)
+                }?.let {
                     bought = it
                     isNew.value = false
 
@@ -533,9 +591,11 @@ class QuoteViewModel(private val codeCreditCard:Int,
 
     }
 
-    private fun loadSettings(){
-        creditCardSettingSvc?.let {
-            it.getAll(codeCreditCard)?.let {
+    private suspend fun loadSettings(){
+        creditCardSettingSvc?.let { svcPort ->
+            withContext(Dispatchers.IO) {
+                svcPort.getAll(codeCreditCard)
+            }?.let {
                 settingList.clear()
                 settingKind.list.clear()
                 settingList.addAll(it)
@@ -547,8 +607,10 @@ class QuoteViewModel(private val codeCreditCard:Int,
             }
         }
 
-        buyCreditCardSettingSvc?.let{
-            it.get(codeBought)?.let{dto->
+        buyCreditCardSettingSvc?.let{ svcPort ->
+            withContext(Dispatchers.IO) {
+                svcPort.get(codeBought)
+            }?.let{dto->
                 buySetting = dto
                 settingKind.onValueChange( settingList.filter { it.id == dto.codeCreditCardSetting }?.map {setting->
                     settingKind.list.first { it?.second == setting.type }
@@ -559,14 +621,18 @@ class QuoteViewModel(private val codeCreditCard:Int,
         }
     }
 
-    private fun loadTags(){
-        tagSvc?.let {
-            it.getAll()?.let {
+    private suspend fun loadTags(){
+        tagSvc?.let { svcPort ->
+            withContext(Dispatchers.IO) {
+                svcPort.getAll()
+            }?.let {
                 tagSelected.list.clear()
                 tagSelected.list.addAll(it)
                 progress.floatValue = 0.7f
             }
-            it.get(codeBought)?.let {
+            withContext(Dispatchers.IO) {
+                svcPort.get(codeBought)
+            }?.let {
                 tagSelected.onValueChange( it )
                 progress.floatValue = 0.75f
             }

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/emailcreditcard/form/EmailCreditCardViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/emailcreditcard/form/EmailCreditCardViewModel.kt
@@ -74,13 +74,13 @@ class EmailCreditCardViewModel @AssistedInject constructor(
 
     fun loadEmailSamples() {
         if (sender.value.isNotEmpty()) {
-            viewModelScope.launch(Dispatchers.IO) {
-                svc?.getEmailList(sender.value, subjectPattern.value, 30)?.let { list ->
-                    withContext(Dispatchers.Main) {
-                        emailSamples.clear()
-                        list.map { Pair(it, false) }.forEach(emailSamples::add)
-                        showEmailDialog.value = true
-                    }
+            viewModelScope.launch {
+                withContext(Dispatchers.IO) {
+                    svc?.getEmailList(sender.value, subjectPattern.value, 30)
+                }?.let { list ->
+                    emailSamples.clear()
+                    list.map { Pair(it, false) }.forEach(emailSamples::add)
+                    showEmailDialog.value = true
                 }
             }
         }
@@ -89,42 +89,36 @@ class EmailCreditCardViewModel @AssistedInject constructor(
     fun generateRegexWithAI() {
         val selectedEmails = emailSamples.filter { it.second }.map { it.first }
         if (selectedEmails.isNotEmpty()) {
-            viewModelScope.launch(Dispatchers.IO) {
-                withContext(Dispatchers.Main) {
-                    load.value = true
-                    progress.floatValue = 0.1f
-                }
+            viewModelScope.launch {
+                load.value = true
+                progress.floatValue = 0.1f
                 val prompt = context?.getString(R.string.promt_email_expreg, selectedEmails.joinToString("\n")) ?: ""
-                withContext(Dispatchers.Main) {
-                    progress.floatValue = 0.3f
-                }
-                llmService?.getAiResponse(prompt, selectedLLMModel.value?.second)?.onSuccess { response ->
-                    withContext(Dispatchers.Main) {
-                        progress.floatValue = 0.6f
-                        val lines = response.trim().lines()
-                        lines.forEach { line ->
-                            if (line.startsWith("SUBJECT:", ignoreCase = true)) {
-                                subjectPattern.value = line.substringAfter("SUBJECT:").trim()
-                            } else if (line.startsWith("BODY:", ignoreCase = true)) {
-                                bodyPattern.value = line.substringAfter("BODY:").trim().removeSurrounding("`").removePrefix("regex").trim()
-                            }
+                progress.floatValue = 0.3f
+                withContext(Dispatchers.IO) {
+                    llmService?.getAiResponse(prompt, selectedLLMModel.value?.second)
+                }?.onSuccess { response ->
+                    progress.floatValue = 0.6f
+                    val lines = response.trim().lines()
+                    lines.forEach { line ->
+                        if (line.startsWith("SUBJECT:", ignoreCase = true)) {
+                            subjectPattern.value = line.substringAfter("SUBJECT:").trim()
+                        } else if (line.startsWith("BODY:", ignoreCase = true)) {
+                            bodyPattern.value = line.substringAfter("BODY:").trim().removeSurrounding("`").removePrefix("regex").trim()
                         }
-                        if (lines.size == 1 && !response.contains("SUBJECT:", ignoreCase = true)) {
-                             bodyPattern.value = response.trim().removeSurrounding("`").removePrefix("regex").trim()
-                        }
-                        progress.floatValue = 1.0f
-                        load.value = false
-                        showEmailDialog.value = false
-                        context?.let { Toast.makeText(it, R.string.ai_response, Toast.LENGTH_SHORT).show() }
                     }
+                    if (lines.size == 1 && !response.contains("SUBJECT:", ignoreCase = true)) {
+                         bodyPattern.value = response.trim().removeSurrounding("`").removePrefix("regex").trim()
+                    }
+                    progress.floatValue = 1.0f
+                    load.value = false
+                    showEmailDialog.value = false
+                    context?.let { Toast.makeText(it, R.string.ai_response, Toast.LENGTH_SHORT).show() }
                 }?.onFailure {
                     Log.e("EmailCCViewModel", "Error: ${it.message}")
-                    withContext(Dispatchers.Main) {
-                        aiFailed.value = true
-                        load.value = false
-                        showEmailDialog.value = false
-                        progress.floatValue = 1.0f
-                    }
+                    aiFailed.value = true
+                    load.value = false
+                    showEmailDialog.value = false
+                    progress.floatValue = 1.0f
                 }
             }
         }
@@ -138,31 +132,27 @@ class EmailCreditCardViewModel @AssistedInject constructor(
         validate()
         emailCreditCard?.let { dto ->
             if (!errorKindInterestRate.value && !errorSender.value && !errorSubjectPattern.value && !errorBodyPattern.value && !errorCreditCard.value) {
-                viewModelScope.launch(Dispatchers.IO) {
+                viewModelScope.launch {
                     if (dto.id == 0) {
-                        val id = svc?.create(dto) ?: 0
+                        val id = withContext(Dispatchers.IO) {
+                            svc?.create(dto) ?: 0
+                        }
                         if (id > 0) {
                             emailCreditCard = dto.copy(id = id)
-                            withContext(Dispatchers.Main) {
-                                context?.let { Toast.makeText(it, R.string.toast_successful_insert, Toast.LENGTH_SHORT).show() }
-                                navController?.popBackStack()
-                            }
+                            context?.let { Toast.makeText(it, R.string.toast_successful_insert, Toast.LENGTH_SHORT).show() }
+                            navController?.popBackStack()
                         } else {
-                            withContext(Dispatchers.Main) {
-                                context?.let { Toast.makeText(it, R.string.toast_unsuccessful_insert, Toast.LENGTH_SHORT).show() }
-                            }
+                            context?.let { Toast.makeText(it, R.string.toast_unsuccessful_insert, Toast.LENGTH_SHORT).show() }
                         }
                     } else {
-                        val result = svc?.update(dto) ?: false
+                        val result = withContext(Dispatchers.IO) {
+                            svc?.update(dto) ?: false
+                        }
                         if (result) {
-                            withContext(Dispatchers.Main) {
-                                context?.let { Toast.makeText(it, R.string.toast_successful_update, Toast.LENGTH_SHORT).show() }
-                                navController?.popBackStack()
-                            }
+                            context?.let { Toast.makeText(it, R.string.toast_successful_update, Toast.LENGTH_SHORT).show() }
+                            navController?.popBackStack()
                         } else {
-                            withContext(Dispatchers.Main) {
-                                context?.let { Toast.makeText(it, R.string.toast_dont_successful_update, Toast.LENGTH_SHORT).show() }
-                            }
+                            context?.let { Toast.makeText(it, R.string.toast_dont_successful_update, Toast.LENGTH_SHORT).show() }
                         }
                     }
                 }
@@ -193,28 +183,24 @@ class EmailCreditCardViewModel @AssistedInject constructor(
     fun validatePatternWithMessages() {
         validate()
         emailCreditCard?.let { dto ->
-            viewModelScope.launch(Dispatchers.IO) {
-                withContext(Dispatchers.Main) {
-                    validating.value = true
-                    showPopup.value = true
-                    validationResults.clear()
-                }
+            viewModelScope.launch {
+                validating.value = true
+                showPopup.value = true
+                validationResults.clear()
                 runCatching {
-                    svc?.validateMessagePattern(dto, 30) ?: emptyList()
-                }.onFailure { e ->
-                    withContext(Dispatchers.Main) {
-                        validating.value = false
-                        validationResult.value = "Error: ${e.message}"
+                    withContext(Dispatchers.IO) {
+                        svc?.validateMessagePattern(dto, 30) ?: emptyList()
                     }
+                }.onFailure { e ->
+                    validating.value = false
+                    validationResult.value = "Error: ${e.message}"
                 }.onSuccess { list ->
-                    withContext(Dispatchers.Main) {
-                        validating.value = false
-                        validationResults.addAll(list)
-                        if (list.isNotEmpty()) {
-                            validationResult.value = "Success"
-                        } else {
-                            validationResult.value = "Not found messages"
-                        }
+                    validating.value = false
+                    validationResults.addAll(list)
+                    if (list.isNotEmpty()) {
+                        validationResult.value = "Success"
+                    } else {
+                        validationResult.value = "Not found messages"
                     }
                 }
             }
@@ -243,63 +229,61 @@ class EmailCreditCardViewModel @AssistedInject constructor(
     }
 
     fun main() {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch {
             progress.floatValue = 0.1f
             execute()
-            withContext(Dispatchers.Main) {
-                progress.floatValue = 1.0f
-                load.value = false
-            }
+            progress.floatValue = 1.0f
+            load.value = false
         }
     }
 
     private suspend fun execute() {
         svc?.let { port ->
             codeEmailCC?.takeIf { it > 0 }?.let { id ->
-                port.getById(id)?.let { dto ->
+                withContext(Dispatchers.IO) {
+                    port.getById(id)
+                }?.let { dto ->
                     emailCreditCard = dto
-                    withContext(Dispatchers.Main) {
-                        kindInterestRate.value = dto.kindInterestRateEnum.let { kind ->
-                            Pair(kind.getCode().toInt(), kind.name)
-                        }
-                        sender.value = dto.sender
-                        subjectPattern.value = dto.subjectPattern
-                        bodyPattern.value = dto.bodyPattern
+                    kindInterestRate.value = dto.kindInterestRateEnum.let { kind ->
+                        Pair(kind.getCode().toInt(), kind.name)
                     }
+                    sender.value = dto.sender
+                    subjectPattern.value = dto.subjectPattern
+                    bodyPattern.value = dto.bodyPattern
                     progress.floatValue = 0.3f
                 }
             }
         }
         creditCardSvc?.let { port ->
-            val list = port.getAll()
-            withContext(Dispatchers.Main) {
-                creditCardList.clear()
-                creditCardLists.clear()
-                list.forEach { cc ->
-                    creditCardLists.add(cc)
-                    creditCardList.add(Pair(cc.id, cc.name))
-                }
-                emailCreditCard?.let { email ->
-                    creditCardLists.firstOrNull { it.id == email.codeCreditCard }?.let { cc ->
-                        creditCard.value = Pair(cc.id, cc.name)
-                    }
+            val list = withContext(Dispatchers.IO) {
+                port.getAll()
+            }
+            creditCardList.clear()
+            creditCardLists.clear()
+            list.forEach { cc ->
+                creditCardLists.add(cc)
+                creditCardList.add(Pair(cc.id, cc.name))
+            }
+            emailCreditCard?.let { email ->
+                creditCardLists.firstOrNull { it.id == email.codeCreditCard }?.let { cc ->
+                    creditCard.value = Pair(cc.id, cc.name)
                 }
             }
             progress.floatValue = 0.6f
         }
 
-        withContext(Dispatchers.Main) {
-            kindInterestRateList.clear()
-            KindInterestRateEnum.entries.map { Pair(it.getCode().toInt(), it.name) }.forEach { kindInterestRateList.add(it) }
+        kindInterestRateList.clear()
+        KindInterestRateEnum.entries.map { Pair(it.getCode().toInt(), it.name) }.forEach { kindInterestRateList.add(it) }
 
-            llmService?.getModels()?.onSuccess { models ->
-                llmModels.clear()
-                models.forEachIndexed { index, name ->
-                    llmModels.add(Pair(index, name))
-                }
-                val model = prefs?.llmModel ?: ""
-                selectedLLMModel.value = llmModels.firstOrNull { it.second == model } ?: llmModels.firstOrNull()
+        withContext(Dispatchers.IO) {
+            llmService?.getModels()
+        }?.onSuccess { models ->
+            llmModels.clear()
+            models.forEachIndexed { index, name ->
+                llmModels.add(Pair(index, name))
             }
+            val model = prefs?.llmModel ?: ""
+            selectedLLMModel.value = llmModels.firstOrNull { it.second == model } ?: llmModels.firstOrNull()
         }
         progress.floatValue = 0.8f
     }

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/emailcreditcard/list/EmailListCreditCardViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/emailcreditcard/list/EmailListCreditCardViewModel.kt
@@ -30,60 +30,45 @@ class EmailListCreditCardViewModel(val svc: IEmailCreditCardPort?, val navContro
     }
 
     fun activate(id:Int,active:Boolean){
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch {
             runCatching {
-                svc?.activate(id, active)?:false
-            }.onFailure { e ->
-                withContext(Dispatchers.Main) {
-
+                withContext(Dispatchers.IO) {
+                    svc?.activate(id, active) ?: false
                 }
+            }.onFailure { e ->
             }.onSuccess { resp ->
-                withContext(Dispatchers.Main) {
-                    if (resp) {
-                        main()
-                    } else {
-
-                    }
+                if (resp) {
+                    main()
                 }
             }
         }
     }
 
     fun delete(id:Int){
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch {
             runCatching {
-                svc?.delete(id)?:false
-            }.onFailure { e ->
-                withContext(Dispatchers.Main) {
-
+                withContext(Dispatchers.IO) {
+                    svc?.delete(id) ?: false
                 }
+            }.onFailure { e ->
             }.onSuccess { resp ->
-                withContext(Dispatchers.Main) {
-                    if (resp) {
-                        main()
-                    } else {
-
-                    }
+                if (resp) {
+                    main()
                 }
             }
         }
     }
 
     fun clone(id:Int){
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch {
             runCatching {
-                svc?.clone(id)?:false
-            }.onFailure { e ->
-                withContext(Dispatchers.Main) {
-
+                withContext(Dispatchers.IO) {
+                    svc?.clone(id) ?: false
                 }
+            }.onFailure { e ->
             }.onSuccess { resp ->
-                withContext(Dispatchers.Main) {
-                    if (resp) {
-
-                    } else {
-
-                    }
+                if (resp) {
+                    main()
                 }
             }
         }

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/simulator/FormViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/simulator/FormViewModel.kt
@@ -23,10 +23,12 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.math.BigDecimal
 import javax.inject.Inject
 import kotlin.compareTo
@@ -146,7 +148,9 @@ class FormViewModel @AssistedInject constructor(
     }
 
     fun calculate() = viewModelScope.launch{
-        simuladorSvc.calculate(_simulator.value)?.let{ calc->
+        withContext(Dispatchers.IO) {
+            simuladorSvc.calculate(_simulator.value)
+        }?.let{ calc->
             _simulator.update {
                 it.copy(
                     capitalValue = calc.capitalValue,
@@ -172,7 +176,9 @@ class FormViewModel @AssistedInject constructor(
     fun save() = viewModelScope.launch{
         if(isValid() && name.validate()) {
             if(_simulator.value.code == 0){
-                simuladorSvc.save(_simulator.value).takeIf { (it ?: (0.toLong())) > 0.toLong() }
+                withContext(Dispatchers.IO) {
+                    simuladorSvc.save(_simulator.value)
+                }.takeIf { (it ?: (0.toLong())) > 0.toLong() }
                     ?.let { code ->
                         _simulator.update {
                             it.copy(code = code.toInt())
@@ -189,7 +195,9 @@ class FormViewModel @AssistedInject constructor(
                         ).show()
                     }
             }else{
-                simuladorSvc.update(_simulator.value,false).takeIf { it == true }
+                withContext(Dispatchers.IO) {
+                    simuladorSvc.update(_simulator.value,false)
+                }.takeIf { it == true }
                     ?.let {
                         snackbar.value
                             .showSnackbar(

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/smscreditcard/form/SmsCreditCardViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/smscreditcard/form/SmsCreditCardViewModel.kt
@@ -69,10 +69,14 @@ class SmsCreditCardViewModel @AssistedInject constructor(@Assisted private val c
 
     fun loadSmsSamples() {
         if (phoneNumber.value.isNotEmpty()) {
-            svc?.getSmsList(phoneNumber.value)?.let { list ->
-                smsSamples.clear()
-                list.map { Pair(it, false) }.forEach(smsSamples::add)
-                showSmsDialog.value = true
+            viewModelScope.launch {
+                withContext(Dispatchers.IO) {
+                    svc?.getSmsList(phoneNumber.value)
+                }?.let { list ->
+                    smsSamples.clear()
+                    list.map { Pair(it, false) }.forEach(smsSamples::add)
+                    showSmsDialog.value = true
+                }
             }
         }
     }
@@ -80,20 +84,20 @@ class SmsCreditCardViewModel @AssistedInject constructor(@Assisted private val c
     fun generateRegexWithAI() {
         val selectedSms = smsSamples.filter { it.second }.map { it.first }
         if (selectedSms.isNotEmpty()) {
-            viewModelScope.launch(Dispatchers.IO) {
+            viewModelScope.launch {
                 load.value = true
                 progress.floatValue = 0.1f
                 val prompt = navController?.context?.getString(R.string.promt_sms_expreg, selectedSms.joinToString("\n"))?:""
                 progress.floatValue = 0.3f
-                llmService?.getAiResponse(prompt, selectedLLMModel.value?.second)?.onSuccess { response ->
+                withContext(Dispatchers.IO) {
+                    llmService?.getAiResponse(prompt, selectedLLMModel.value?.second)
+                }?.onSuccess { response ->
                     progress.floatValue = 0.6f
                     pattern.value = response.trim().removeSurrounding("`").removePrefix("regex").trim()
                     progress.floatValue = 1.0f
                     load.value = false
                     showSmsDialog.value = false
-                    viewModelScope.launch(Dispatchers.Main) {
-                        navController?.let { Toast.makeText(it.context, R.string.ai_response, Toast.LENGTH_SHORT).show() }
-                    }
+                    navController?.let { Toast.makeText(it.context, R.string.ai_response, Toast.LENGTH_SHORT).show() }
                 }?.onFailure {
                     Log.e("SmsCreditCardViewModel", "Error: ${it.message}")
                     aiFaile.value=true
@@ -108,20 +112,26 @@ class SmsCreditCardViewModel @AssistedInject constructor(@Assisted private val c
 
     fun save(){
         if(smsCreditCard != null && !errorKindInterestRate.value && !errorPhoneNumber.value && !errorPattern.value) {
-            smsCreditCard?.takeIf { it.id == 0 }?.let{
-                svc?.create(it)?.takeIf { it > 0 }?.let{
-                    smsCreditCard = smsCreditCard!!.copy(id = it)
-                    navController?.let { Toast.makeText(it.context, R.string.toast_successful_insert, Toast.LENGTH_SHORT).show().also {
-                        navController.popBackStack()
-                    } }
-                }?:navController?.let { Toast.makeText(it.context, R.string.toast_unsuccessful_insert, Toast.LENGTH_SHORT).show() }
-            }
-            smsCreditCard?.takeIf { it.id > 0 }?.let{
-                svc?.update(it)?.takeIf { it }?.let{
-                    navController?.let { Toast.makeText(it.context, R.string.toast_successful_update, Toast.LENGTH_SHORT).show().also {
-                        navController.popBackStack()
-                    }}
-                }?:navController?.let { Toast.makeText(it.context, R.string.toast_dont_successful_update, Toast.LENGTH_SHORT).show() }
+            viewModelScope.launch {
+                smsCreditCard?.takeIf { it.id == 0 }?.let{
+                    withContext(Dispatchers.IO) {
+                        svc?.create(it)
+                    }?.takeIf { it > 0 }?.let{
+                        smsCreditCard = smsCreditCard!!.copy(id = it)
+                        navController?.let { Toast.makeText(it.context, R.string.toast_successful_insert, Toast.LENGTH_SHORT).show().also {
+                            navController.popBackStack()
+                        } }
+                    }?:navController?.let { Toast.makeText(it.context, R.string.toast_unsuccessful_insert, Toast.LENGTH_SHORT).show() }
+                }
+                smsCreditCard?.takeIf { it.id > 0 }?.let{
+                    withContext(Dispatchers.IO) {
+                        svc?.update(it)
+                    }?.takeIf { it }?.let{
+                        navController?.let { Toast.makeText(it.context, R.string.toast_successful_update, Toast.LENGTH_SHORT).show().also {
+                            navController.popBackStack()
+                        }}
+                    }?:navController?.let { Toast.makeText(it.context, R.string.toast_dont_successful_update, Toast.LENGTH_SHORT).show() }
+                }
             }
         }
     }
@@ -149,29 +159,25 @@ class SmsCreditCardViewModel @AssistedInject constructor(@Assisted private val c
     fun validatePatternWithMessages() {
         validate()
         smsCreditCard?.let { dto ->
-            viewModelScope.launch(Dispatchers.IO) {
-                withContext(Dispatchers.Main) {
-                    validating.value = true
-                    showPopup.value = true
-                    validationResults.clear()
-                    validationResult.value = ""
-                }
+            viewModelScope.launch {
+                validating.value = true
+                showPopup.value = true
+                validationResults.clear()
+                validationResult.value = ""
                 runCatching {
-                    svc?.validateMessagePattern(dto) ?: emptyList()
-                }.onFailure { e ->
-                    withContext(Dispatchers.Main) {
-                        validating.value = false
-                        validationResult.value = "Error: ${e.message}"
+                    withContext(Dispatchers.IO) {
+                        svc?.validateMessagePattern(dto) ?: emptyList()
                     }
+                }.onFailure { e ->
+                    validating.value = false
+                    validationResult.value = "Error: ${e.message}"
                 }.onSuccess { list ->
-                    withContext(Dispatchers.Main) {
-                        validating.value = false
-                        validationResults.addAll(list)
-                        if (list.isNotEmpty()) {
-                            validationResult.value = "Success"
-                        } else {
-                            validationResult.value = "Not found sms"
-                        }
+                    validating.value = false
+                    validationResults.addAll(list)
+                    if (list.isNotEmpty()) {
+                        validationResult.value = "Success"
+                    } else {
+                        validationResult.value = "Not found sms"
                     }
                 }
             }
@@ -218,21 +224,19 @@ class SmsCreditCardViewModel @AssistedInject constructor(@Assisted private val c
     }
 
     fun main() {
-        viewModelScope.launch(Dispatchers.IO) {
-            withContext(Dispatchers.Main) {
-                progress.floatValue = 0.1f
-            }
+        viewModelScope.launch {
+            progress.floatValue = 0.1f
             execute()
-            withContext(Dispatchers.Main) {
-                progress.floatValue = 1.0f
-            }
+            progress.floatValue = 1.0f
         }
     }
 
     suspend fun execute(){
         svc?.let{
             codeSMSCC?.let {
-                svc.getById(it)?.let{
+                withContext(Dispatchers.IO) {
+                    svc.getById(it)
+                }?.let{
                     smsCreditCard = it
                     kindInterestRate.value = it.kindInterestRateEnum.let{
                         Pair(it.getCode().toInt(),it.name)
@@ -246,7 +250,9 @@ class SmsCreditCardViewModel @AssistedInject constructor(@Assisted private val c
         creditCardSvc?.let {
             creditCardList.clear()
             creditCardLists.clear()
-            it.getAll()?.takeIf { it.isNotEmpty() }?.forEach {
+            withContext(Dispatchers.IO) {
+                it.getAll()
+            }?.takeIf { it.isNotEmpty() }?.forEach {
                 creditCardLists.add(it)
                 creditCardList.add(Pair(it.id,it.name))
             }
@@ -260,7 +266,9 @@ class SmsCreditCardViewModel @AssistedInject constructor(@Assisted private val c
         KindInterestRateEnum.values().map { Pair(it.getCode().toInt(), it.name)}.forEach(kindInterestRateList::add)
             .also { progress.floatValue = 0.8f }
 
-        llmService?.getModels()?.onSuccess { models ->
+        withContext(Dispatchers.IO) {
+            llmService?.getModels()
+        }?.onSuccess { models ->
             llmModels.clear()
             models.forEachIndexed { index, name ->
                 llmModels.add(Pair(index, name))

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/bought/forms/Quote.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/bought/forms/Quote.kt
@@ -50,8 +50,10 @@ import co.com.japl.ui.components.FieldText
 import co.com.japl.ui.components.FieldView
 import co.com.japl.ui.components.FloatButton
 import co.com.japl.ui.components.IconButton
+import androidx.compose.runtime.rememberCoroutineScope
 import co.com.japl.ui.components.Popup
 import co.com.japl.ui.theme.MaterialThemeComposeUI
+import kotlinx.coroutines.launch
 import co.com.japl.ui.theme.values.Dimensions
 import co.com.japl.ui.theme.values.ModifiersCustom
 import java.time.LocalDateTime
@@ -269,6 +271,7 @@ private fun Body(viewModel: QuoteViewModel,modifier:Modifier){
 @Composable
 private fun PopupTags(tagPopupState:MutableState<Boolean>,viewModel: QuoteViewModel) {
     val tagName = remember {mutableStateOf("")}
+    val coroutineScope = rememberCoroutineScope()
     if(tagPopupState.value){
         Popup(title = R.string.tag,
             state = tagPopupState) {
@@ -291,10 +294,12 @@ private fun PopupTags(tagPopupState:MutableState<Boolean>,viewModel: QuoteViewMo
                             descriptionContent = R.string.add_tag,
                             onClick = {
                                 tagName.value.takeIf { it.isNotBlank() }?.let {
+                                    coroutineScope.launch {
                                     viewModel.createTag(tagName.value)?.let {
                                         viewModel.tagSelected.list.add(it)
                                         viewModel.tagSelected.onValueChange(it)
                                         tagPopupState.value = false
+                                    }
                                     }
                                 }
                             }, modifier = Modifier

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/setting/LLMConnectionViewModel.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/setting/LLMConnectionViewModel.kt
@@ -11,8 +11,10 @@ import co.com.japl.finances.iports.enums.LLMType
 import co.com.japl.finances.iports.inbounds.common.ILLMService
 import co.com.japl.ui.Prefs
 import co.japl.android.myapplication.R
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class LLMConnectionViewModel(private val prefs: Prefs, private val context: Context, private val llmService: ILLMService) : ViewModel() {
     val llmEnabled = mutableStateOf(prefs.llmEnabled)
@@ -34,7 +36,9 @@ class LLMConnectionViewModel(private val prefs: Prefs, private val context: Cont
                 loadProgress.value = 0.1f
                 isLoadingModels.value = true
                 loadProgress.value = 0.3f
-                llmService.getModels().onSuccess { models ->
+                withContext(Dispatchers.IO) {
+                    llmService.getModels()
+                }.onSuccess { models ->
                     loadProgress.value = 0.5f
                     modelsList.clear()
                     models.forEachIndexed { index, s ->

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/simulators/list/ListSimulator.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/simulators/list/ListSimulator.kt
@@ -1,0 +1,77 @@
+package co.japl.android.myapplication.finanzas.controller.simulators.list
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.navigation.NavController
+import co.com.japl.finances.iports.dtos.SimulatorCreditDTO
+import co.com.japl.module.credit.views.simulator.SimulatorList as SimulatorListCredit
+import co.com.japl.module.creditcard.views.simulator.SimulatorList as SimulatorListCreditCard
+
+@Composable
+fun ListSimulator(viewModel: ListSimulatorViewModel, navController: NavController?) {
+    val progress = remember { viewModel.progress }
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) {
+        viewModel.load()
+    }
+
+    if (progress.value) {
+        LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+    } else {
+        if (viewModel.list.isEmpty()) {
+            Text(
+                text = stringResource(co.com.japl.ui.R.string.no_records),
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+        } else {
+            BodyList(viewModel, navController)
+        }
+    }
+}
+
+@Composable
+private fun BodyList(viewModel: ListSimulatorViewModel, navController: NavController?) {
+    val list = remember { viewModel.list.sortedByDescending { it.code } }
+    val context = LocalContext.current
+    Scaffold(
+        modifier = Modifier
+    ) {
+        LazyColumn(
+            state = rememberLazyListState(),
+            modifier = Modifier.padding(it)
+        ) {
+            items(list) { dto ->
+                Body(dto, viewModel, navController)
+                HorizontalDivider(modifier = Modifier.fillMaxWidth())
+            }
+        }
+    }
+}
+
+@Composable
+private fun Body(dto: SimulatorCreditDTO, viewModel: ListSimulatorViewModel, navController: NavController?) {
+    val context = LocalContext.current
+    if (dto.isCreditVariable.not()) {
+        val vm = remember(dto.code) { viewModel.createViewModelQuoteFix(context, dto, navController) }
+        SimulatorListCredit(vm)
+    } else {
+        val vm = remember(dto.code) { viewModel.createViewModelQuoteVariable(context, dto, navController) }
+        SimulatorListCreditCard(vm)
+    }
+}

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/simulators/list/ListSimulatorFragment.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/simulators/list/ListSimulatorFragment.kt
@@ -1,0 +1,34 @@
+package co.japl.android.myapplication.finanzas.controller.simulators.list
+
+import android.os.Build
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.annotation.RequiresApi
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import co.com.japl.ui.theme.MaterialThemeComposeUI
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class ListSimulatorFragment : Fragment() {
+
+    private val viewModel: ListSimulatorViewModel by viewModels()
+
+    @RequiresApi(Build.VERSION_CODES.S)
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setContent {
+                MaterialThemeComposeUI {
+                    ListSimulator(viewModel, findNavController())
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/simulators/list/ListSimulatorViewModel.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/simulators/list/ListSimulatorViewModel.kt
@@ -1,0 +1,59 @@
+package co.japl.android.myapplication.finanzas.controller.simulators.list
+
+import android.content.Context
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.navigation.NavController
+import co.com.japl.finances.iports.dtos.SimulatorCreditDTO
+import co.com.japl.finances.iports.inbounds.credit.ISimulatorCreditFixPort
+import co.com.japl.finances.iports.inbounds.creditcard.ISimulatorCreditVariablePort
+import co.com.japl.module.credit.controllers.simulator.SimulatorListItemViewModel as SimulatorListItemViewModelCredit
+import co.com.japl.module.creditcard.controllers.simulator.SimulatorListItemViewModel as SimulatorListItemViewModelCreditCard
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+@HiltViewModel
+class ListSimulatorViewModel @Inject constructor(
+    private val simulatorVariableSvc: ISimulatorCreditVariablePort?,
+    private val simulatorFixSvc: ISimulatorCreditFixPort?
+) : ViewModel() {
+    val progress = mutableStateOf(false)
+    val list = mutableStateListOf<SimulatorCreditDTO>()
+
+    fun load() = viewModelScope.launch {
+        progress.value = true
+        list.clear()
+        val fixList = withContext(Dispatchers.IO) {
+            simulatorFixSvc?.getList() ?: emptyList()
+        }
+        val variableList = withContext(Dispatchers.IO) {
+            simulatorVariableSvc?.getList() ?: emptyList()
+        }
+        list.addAll(fixList)
+        list.addAll(variableList)
+        progress.value = false
+    }
+
+    fun createViewModelQuoteFix(context: Context, dto: SimulatorCreditDTO, navController: NavController?): SimulatorListItemViewModelCredit {
+        return SimulatorListItemViewModelCredit(
+            context,
+            dto,
+            simulatorFixSvc,
+            navController
+        )
+    }
+
+    fun createViewModelQuoteVariable(context: Context, dto: SimulatorCreditDTO, navController: NavController?): SimulatorListItemViewModelCreditCard {
+        return SimulatorListItemViewModelCreditCard(
+            context,
+            dto,
+            simulatorVariableSvc,
+            navController
+        )
+    }
+}

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -106,7 +106,7 @@
 
     <fragment
         android:id="@+id/item_menu_side_listsave"
-        android:name="co.com.japl.module.credit.fragments.ListSave"
+        android:name="co.japl.android.myapplication.finanzas.controller.simulators.list.ListSimulatorFragment"
         android:label="@string/list_save"
         tools:layout="@layout/fragment_list_save" >
         <action

--- a/credit/src/main/java/co/com/japl/module/credit/controllers/amortization/AmortizationViewModel.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/controllers/amortization/AmortizationViewModel.kt
@@ -9,9 +9,11 @@ import co.com.japl.finances.iports.dtos.AmortizationRowDTO
 import co.com.japl.finances.iports.enums.KindAmortization
 import co.com.japl.finances.iports.inbounds.credit.IAmortizationTablePort
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.time.LocalDate
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
@@ -38,8 +40,9 @@ class AmortizationViewModel @Inject constructor(
     private fun getAmortization() = viewModelScope.launch {
         try {
             _state.value = _state.value.copy(isLoading = true)
-            amortizationSvc?.getAmortization(code, KindAmortization.FIXED_QUOTE_SIMULATOR, true)
-                ?.let {
+            withContext(Dispatchers.IO) {
+                amortizationSvc?.getAmortization(code, KindAmortization.FIXED_QUOTE_SIMULATOR, true)
+            }?.let {
                     _state.value = _state.value.copy(
                         amortization = it,
                         isLoading = false

--- a/credit/src/main/java/co/com/japl/module/credit/controllers/creditamortization/CreditAmortizationViewModel.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/controllers/creditamortization/CreditAmortizationViewModel.kt
@@ -16,6 +16,8 @@ import co.com.japl.module.credit.model.CreditAmortizationState
 import co.com.japl.module.credit.navigations.CreditList
 import co.com.japl.module.credit.navigations.ExtraValueList
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.time.LocalDate
 import androidx.lifecycle.SavedStateHandle
 import javax.inject.Inject
@@ -62,10 +64,10 @@ class CreditAmortizationViewModel @Inject constructor(
 
     suspend fun loadData(){
         _state.value = _state.value.copy(isLoading = true)
-        val credit = creditSvc?.getCredit(creditCode)
-        val additionalList = additionalSvc?.getAdditional(creditCode)
-        val gracePeriodList = gracePeriodSvc?.get(creditCode)
-        val amortizationTable = amortizationSvc?.getAmortization(creditCode, KindAmortization.FIXED_QUOTE, false)
+        val credit = withContext(Dispatchers.IO) { creditSvc?.getCredit(creditCode) }
+        val additionalList = withContext(Dispatchers.IO) { additionalSvc?.getAdditional(creditCode) }
+        val gracePeriodList = withContext(Dispatchers.IO) { gracePeriodSvc?.get(creditCode) }
+        val amortizationTable = withContext(Dispatchers.IO) { amortizationSvc?.getAmortization(creditCode, KindAmortization.FIXED_QUOTE, false) }
         val additional = additionalList?.sumOf { it.value }
         val gracePeriods = gracePeriodList?.filter { it.create > lastDate || it.end < lastDate }?.takeIf { it.isNotEmpty() }?.sumOf{it.periods.toInt()}
         val months = ChronoUnit.MONTHS.between(credit?.date, lastDate)

--- a/credit/src/main/java/co/com/japl/module/credit/controllers/extravalue/ExtraValueListViewModel.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/controllers/extravalue/ExtraValueListViewModel.kt
@@ -5,9 +5,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.com.japl.finances.iports.dtos.ExtraValueAmortizationDTO
 import co.com.japl.finances.iports.inbounds.credit.IExtraValueAmortizationCreditPort
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 //@HiltViewModel
@@ -31,13 +33,18 @@ class ExtraValueListViewModel @Inject constructor(
     }
 
     private suspend fun loadExtraValues(creditId: Int) {
-            extraValueAmortizationCreditSvc?.getAll(creditId)?.let{
+            withContext(Dispatchers.IO) {
+                extraValueAmortizationCreditSvc?.getAll(creditId)
+            }?.let{
                 _extraValues.value = it
             }
     }
 
     fun create( numQuotes: Int, value: Double)= viewModelScope.launch {
-            if((extraValueAmortizationCreditSvc?.save(id, numQuotes.toLong(), value) ?: 0) > 0){
+            val result = withContext(Dispatchers.IO) {
+                extraValueAmortizationCreditSvc?.save(id, numQuotes.toLong(), value) ?: 0
+            }
+            if(result > 0){
                 exec()
             }
         }

--- a/credit/src/main/java/co/com/japl/module/credit/controllers/forms/AdditionalFormViewModel.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/controllers/forms/AdditionalFormViewModel.kt
@@ -2,8 +2,8 @@ package co.com.japl.module.credit.controllers.forms
 
 import android.content.Context
 import android.util.Log
-import androidx.compose.material.SnackbarDuration
-import androidx.compose.material.SnackbarHostState
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
@@ -16,10 +16,11 @@ import co.com.japl.ui.utils.initialFieldState
 import co.com.japl.ui.utils.NumbersUtil
 import co.com.japl.module.credit.params.AdditionalCreditParams
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import java.math.BigDecimal
 import java.time.LocalDate
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -85,13 +86,16 @@ class AdditionalFormViewModel @Inject constructor(
         main()
     }
 
-    fun create(){
-        if(validation()) {
-            additionalSvc?.let {
-                try {
-                    if (_dto.value.id <= 0) {
-                        if (it.create(_dto.value)) {
-                            viewModelScope.launch {
+    fun create() {
+        if (validation()) {
+            viewModelScope.launch {
+                additionalSvc?.let { svcPort ->
+                    try {
+                        if (_dto.value.id <= 0) {
+                            val result = withContext(Dispatchers.IO) {
+                                svcPort.create(_dto.value)
+                            }
+                            if (result) {
                                 hostState.showSnackbar(
                                     message = context.getString(R.string.create_record_success),
                                     actionLabel = context.getString(R.string.close),
@@ -99,19 +103,18 @@ class AdditionalFormViewModel @Inject constructor(
                                 ).also {
                                     navController?.popBackStack()
                                 }
-                            }
-                        } else {
-                            viewModelScope.launch {
+                            } else {
                                 hostState.showSnackbar(
                                     message = context.getString(R.string.error_record_success),
                                     actionLabel = context.getString(R.string.close),
                                     duration = SnackbarDuration.Short
                                 )
                             }
-                        }
-                    } else {
-                        if (it.update(_dto.value)) {
-                            viewModelScope.launch {
+                        } else {
+                            val result = withContext(Dispatchers.IO) {
+                                svcPort.update(_dto.value)
+                            }
+                            if (result) {
                                 hostState.showSnackbar(
                                     message = context.getString(R.string.update_record_success),
                                     actionLabel = context.getString(R.string.close),
@@ -119,9 +122,7 @@ class AdditionalFormViewModel @Inject constructor(
                                 ).also {
                                     navController?.popBackStack()
                                 }
-                            }
-                        } else {
-                            viewModelScope.launch {
+                            } else {
                                 hostState.showSnackbar(
                                     message = context.getString(R.string.error_upd_record_success),
                                     actionLabel = context.getString(R.string.close),
@@ -129,9 +130,7 @@ class AdditionalFormViewModel @Inject constructor(
                                 )
                             }
                         }
-                    }
-                } catch (e: Exception) {
-                    viewModelScope.launch {
+                    } catch (e: Exception) {
                         hostState.showSnackbar(
                             message = "Error: ${e.message}",
                             actionLabel = context.getString(R.string.close),
@@ -162,7 +161,7 @@ class AdditionalFormViewModel @Inject constructor(
         return name.error.value.not() && value.error.value.not() && startDate.error.value.not()
     }
 
-    fun main()= runBlocking {
+    fun main() {
         loading.value = true
         viewModelScope.launch {
             execute()
@@ -170,9 +169,11 @@ class AdditionalFormViewModel @Inject constructor(
     }
 
     suspend fun execute(){
-        additionalSvc?.let{ svc ->
+        additionalSvc?.let{ svcPort ->
             id.takeIf { it > 0 }?.let {
-                svc.get(id)?.let{
+                withContext(Dispatchers.IO) {
+                    svcPort.get(id)
+                }?.let{
                     Log.d(this.javaClass.name,"<<<=== Execute:List $id $codeCredit $it")
                     name.onValueChange(it.name)
                     value.onValueChange(it.value)

--- a/credit/src/main/java/co/com/japl/module/credit/controllers/forms/CreditFormViewModel.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/controllers/forms/CreditFormViewModel.kt
@@ -13,9 +13,11 @@ import co.com.japl.finances.iports.inbounds.credit.ICreditFormPort
 import co.com.japl.module.credit.params.CreditFixParams
 import co.com.japl.ui.utils.initialFieldState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.math.BigDecimal
 import java.time.LocalDate
 import javax.inject.Inject
@@ -136,15 +138,11 @@ class CreditFormViewModel @Inject constructor(
 
     fun executeSave() = viewModelScope.launch {
         showProgress.value = true
-        saveRunning()
-        showProgress.value = false
-    }
-
-    private fun saveRunning() {
-        creditSvc?.let {
-            it.save(_creditDto.value)
-            navController?.popBackStack()
+        withContext(Dispatchers.IO) {
+            creditSvc?.save(_creditDto.value)
         }
+        navController?.popBackStack()
+        showProgress.value = false
     }
 
     fun execute() = viewModelScope.launch {
@@ -153,9 +151,11 @@ class CreditFormViewModel @Inject constructor(
         showProgress.value = false
     }
 
-    private fun running() {
+    private suspend fun running() {
         id?.takeIf { it > 0 }?.let { code ->
-            creditSvc?.findCreditById(code)?.let { dto ->
+            withContext(Dispatchers.IO) {
+                creditSvc?.findCreditById(code)
+            }?.let { dto ->
                 _creditDto.value = dto
                 name.onValueChange(dto.name)
                 value.onValueChange(dto.value.toString())

--- a/credit/src/main/java/co/com/japl/module/credit/controllers/list/AdditionalViewModel.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/controllers/list/AdditionalViewModel.kt
@@ -1,8 +1,8 @@
 package co.com.japl.module.credit.controllers.list
 
 import android.content.Context
-import androidx.compose.material.SnackbarDuration
-import androidx.compose.material.SnackbarHostState
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.mutableStateListOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -12,10 +12,11 @@ import co.com.japl.finances.iports.inbounds.credit.IAdditional
 import co.com.japl.module.credit.R
 import co.com.japl.module.credit.navigations.AdditionalList
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import java.time.LocalDate
 import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -48,26 +49,23 @@ class AdditionalViewModel @Inject constructor(
     }
 
     fun deleteAdditional(idCode:Int){
-        additionalSvc?.let{
-            it.delete(idCode).also{ resp ->
-                viewModelScope.launch {
-                    when(resp) {
-                       true -> hostState.showSnackbar(
-                            message = context.getString(R.string.delete_record),
-                            actionLabel = context.getString(R.string.close),
-                            duration = SnackbarDuration.Short
-                        ).also {
-                            viewModelScope.launch {
-                                main()
-                            }
-                       }
-                        false -> hostState.showSnackbar(
-                            message = context.getString(R.string.error_delete_record),
-                            actionLabel = context.getString(R.string.close),
-                            duration = SnackbarDuration.Short
-                        )
-                    }
-                }
+        viewModelScope.launch {
+            val resp = withContext(Dispatchers.IO) {
+                additionalSvc?.delete(idCode) ?: false
+            }
+            when(resp) {
+               true -> hostState.showSnackbar(
+                    message = context.getString(R.string.delete_record),
+                    actionLabel = context.getString(R.string.close),
+                    duration = SnackbarDuration.Short
+                ).also {
+                    main()
+               }
+                false -> hostState.showSnackbar(
+                    message = context.getString(R.string.error_delete_record),
+                    actionLabel = context.getString(R.string.close),
+                    duration = SnackbarDuration.Short
+                )
             }
         }
     }
@@ -78,7 +76,7 @@ class AdditionalViewModel @Inject constructor(
         }
     }
 
-    fun main()= runBlocking {
+    fun main() {
         _loading.value = true
         viewModelScope.launch {
             execute()
@@ -86,10 +84,9 @@ class AdditionalViewModel @Inject constructor(
     }
 
     suspend fun execute(){
-        additionalSvc?.let{
-            list.clear()
-            it.getAdditional(code).forEach(list::add)
-        }
+        withContext(Dispatchers.IO) {
+            additionalSvc?.getAdditional(code)
+        }?.forEach(list::add)
         _loading.value = false
     }
 }

--- a/credit/src/main/java/co/com/japl/module/credit/controllers/list/PeriodsViewModel.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/controllers/list/PeriodsViewModel.kt
@@ -7,11 +7,12 @@ import co.com.japl.finances.iports.dtos.PeriodCreditDTO
 import co.com.japl.finances.iports.inbounds.credit.IPeriodCreditPort
 import co.com.japl.ui.utils.FormUIState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 
@@ -28,13 +29,17 @@ class PeriodsViewModel @Inject constructor(private val periodSvc: IPeriodCreditP
         }
     }
 
-    fun main()= runBlocking {
-        execute()
+    fun main() {
+        viewModelScope.launch {
+            execute()
+        }
     }
 
     suspend fun execute(){
 
-        periodSvc?.getRecords()?.let(records::addAll)
+        withContext(Dispatchers.IO) {
+            periodSvc?.getRecords()
+        }?.let(records::addAll)
 
         _uiState.value = FormUIState.Current
 

--- a/credit/src/main/java/co/com/japl/module/credit/controllers/simulator/SimulatorFixViewModel.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/controllers/simulator/SimulatorFixViewModel.kt
@@ -17,10 +17,12 @@ import co.com.japl.module.credit.views.simulator.Simulator
 import co.com.japl.ui.utils.initialFieldState
 import co.japl.android.graphs.utils.NumbersUtil
 import dagger.hilt.android.scopes.ViewModelScoped
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.math.BigDecimal
 
 @ViewModelScoped
@@ -130,7 +132,9 @@ class SimulatorFixViewModel(
     }
 
     fun calculate() = viewModelScope.launch{
-        simuladorSvc?.calculate(_simulator.value)?.let{ calc->
+        withContext(Dispatchers.IO) {
+            simuladorSvc?.calculate(_simulator.value)
+        }?.let{ calc->
             _simulator.update {
                 it.copy(
                     capitalValue = calc.capitalValue,
@@ -155,7 +159,9 @@ class SimulatorFixViewModel(
 
     fun save() = viewModelScope.launch{
         if(isValid() && name.validate()) {
-            simuladorSvc?.save(_simulator.value,false)?.takeIf { (it ?: (0.toLong())) > 0.toLong() }
+            withContext(Dispatchers.IO) {
+                simuladorSvc?.save(_simulator.value,false)
+            }?.takeIf { (it ?: (0.toLong())) > 0.toLong() }
                 ?.let { code ->
                     _simulator.update {
                         it.copy(code = code.toInt())

--- a/credit/src/main/java/co/com/japl/module/credit/fragments/SimulatorListViewModel.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/fragments/SimulatorListViewModel.kt
@@ -14,7 +14,9 @@ import co.com.japl.finances.iports.inbounds.creditcard.ISimulatorCreditVariableP
 // Removed: import co.com.japl.module.creditcard.controllers.simulator.SimulatorListItemViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import co.com.japl.module.credit.controllers.simulator.SimulatorListItemViewModel as SimulatorListItemViewModelCredit
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 
 class ListViewModel(@ApplicationContext val context: Context, private val simulatorVariableSvc: ISimulatorCreditVariablePort?=null, private val simulatorFixSvc: ISimulatorCreditFixPort?=null, private val navController: NavController?=null):ViewModel() {
@@ -48,11 +50,15 @@ class ListViewModel(@ApplicationContext val context: Context, private val simula
     }
 
     suspend fun running(){
-        simulatorFixSvc?.let{
-            list.addAll(it.getList())
+        withContext(Dispatchers.IO) {
+            simulatorFixSvc?.getList()
+        }?.let{
+            list.addAll(it)
         }
-        simulatorVariableSvc?.let{
-            list.addAll(it.getList())
+        withContext(Dispatchers.IO) {
+            simulatorVariableSvc?.getList()
+        }?.let{
+            list.addAll(it)
         }
     }
 }

--- a/credit/src/main/java/co/com/japl/module/credit/views/forms/AdditionalForm.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/views/forms/AdditionalForm.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.CleaningServices
 import androidx.compose.material.icons.rounded.Save
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -35,6 +36,9 @@ import java.time.LocalDate
 @Composable
 fun AdditionalForm(viewModel: AdditionalFormViewModel){
     Scaffold (
+        snackbarHost = {
+            SnackbarHost(hostState = viewModel.hostState)
+        },
         floatingActionButton = {
             Buttons(viewModel)
         }

--- a/credit/src/main/java/co/com/japl/module/credit/views/lists/Additional.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/views/lists/Additional.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Scaffold
-import androidx.compose.material.SnackbarHost
+import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Add

--- a/declaracion_renta_dian/src/main/java/co/com/japl/module/dian/controllers/TaxDeclarationViewModel.kt
+++ b/declaracion_renta_dian/src/main/java/co/com/japl/module/dian/controllers/TaxDeclarationViewModel.kt
@@ -5,9 +5,11 @@ import androidx.lifecycle.viewModelScope
 import co.com.japl.finances.iports.dtos.dian.Form210DTO
 import co.com.japl.finances.iports.inbounds.dian.IGetTaxDeclarationUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.time.LocalDate
 import javax.inject.Inject
 
@@ -29,7 +31,9 @@ class TaxDeclarationViewModel @Inject constructor(
     fun loadData() {
         val currentYear = LocalDate.now().year
         viewModelScope.launch {
-            _declarationState.value = getTaxDeclarationUseCase.getTaxDeclaration(currentYear)
+            _declarationState.value = withContext(Dispatchers.IO) {
+                getTaxDeclarationUseCase.getTaxDeclaration(currentYear)
+            }
         }
     }
 

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/emailpaid/form/EmailPaidViewModel.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/emailpaid/form/EmailPaidViewModel.kt
@@ -56,13 +56,13 @@ class EmailPaidViewModel(
 
     fun loadEmailSamples() {
         if (sender.value.isNotEmpty()) {
-            viewModelScope.launch(Dispatchers.IO) {
-                svc?.getEmailList(sender.value, subjectPattern.value, 30)?.let { list ->
-                    withContext(Dispatchers.Main) {
-                        emailSamples.clear()
-                        list.map { Pair(it, false) }.forEach(emailSamples::add)
-                        showEmailDialog.value = true
-                    }
+            viewModelScope.launch {
+                withContext(Dispatchers.IO) {
+                    svc?.getEmailList(sender.value, subjectPattern.value, 30)
+                }?.let { list ->
+                    emailSamples.clear()
+                    list.map { Pair(it, false) }.forEach(emailSamples::add)
+                    showEmailDialog.value = true
                 }
             }
         }
@@ -71,35 +71,31 @@ class EmailPaidViewModel(
     fun generateRegexWithAI() {
         val selectedEmails = emailSamples.filter { it.second }.map { it.first }
         if (selectedEmails.isNotEmpty()) {
-            viewModelScope.launch(Dispatchers.IO) {
-                withContext(Dispatchers.Main) {
-                    load.value = true
-                    progress.floatValue = 0.1f
-                }
+            viewModelScope.launch {
+                load.value = true
+                progress.floatValue = 0.1f
                 val prompt = context?.getString(R.string.promt_email_expreg, selectedEmails.joinToString("\n")) ?: ""
-                llmService?.getAiResponse(prompt, selectedLLMModel.value?.second)?.onSuccess { response ->
-                    withContext(Dispatchers.Main) {
-                        val lines = response.trim().lines()
-                        lines.forEach { line ->
-                            if (line.startsWith("SUBJECT:", ignoreCase = true)) {
-                                subjectPattern.value = line.substringAfter("SUBJECT:").trim()
-                            } else if (line.startsWith("BODY:", ignoreCase = true)) {
-                                bodyPattern.value = line.substringAfter("BODY:").trim().removeSurrounding("`").removePrefix("regex").trim()
-                            }
+                withContext(Dispatchers.IO) {
+                    llmService?.getAiResponse(prompt, selectedLLMModel.value?.second)
+                }?.onSuccess { response ->
+                    val lines = response.trim().lines()
+                    lines.forEach { line ->
+                        if (line.startsWith("SUBJECT:", ignoreCase = true)) {
+                            subjectPattern.value = line.substringAfter("SUBJECT:").trim()
+                        } else if (line.startsWith("BODY:", ignoreCase = true)) {
+                            bodyPattern.value = line.substringAfter("BODY:").trim().removeSurrounding("`").removePrefix("regex").trim()
                         }
-                        if (lines.size == 1 && !response.contains("SUBJECT:", ignoreCase = true)) {
-                            bodyPattern.value = response.trim().removeSurrounding("`").removePrefix("regex").trim()
-                        }
-                        load.value = false
-                        showEmailDialog.value = false
-                        context?.let { Toast.makeText(it, R.string.ai_response, Toast.LENGTH_SHORT).show() }
                     }
+                    if (lines.size == 1 && !response.contains("SUBJECT:", ignoreCase = true)) {
+                        bodyPattern.value = response.trim().removeSurrounding("`").removePrefix("regex").trim()
+                    }
+                    load.value = false
+                    showEmailDialog.value = false
+                    context?.let { Toast.makeText(it, R.string.ai_response, Toast.LENGTH_SHORT).show() }
                 }?.onFailure {
-                    withContext(Dispatchers.Main) {
-                        aiFailed.value = true
-                        load.value = false
-                        showEmailDialog.value = false
-                    }
+                    aiFailed.value = true
+                    load.value = false
+                    showEmailDialog.value = false
                 }
             }
         }
@@ -111,29 +107,26 @@ class EmailPaidViewModel(
         validate()
         emailPaid?.let { dto ->
             if (!errorAccount.value && !errorSender.value && !errorSubjectPattern.value && !errorBodyPattern.value) {
-                viewModelScope.launch(Dispatchers.IO) {
+                viewModelScope.launch {
                     if (dto.id == 0) {
-                        val id = svc?.create(dto) ?: 0
+                        val id = withContext(Dispatchers.IO) {
+                            svc?.create(dto) ?: 0
+                        }
                         if (id > 0) {
-                            withContext(Dispatchers.Main) {
-                                context?.let { Toast.makeText(it, R.string.toast_save_successful, Toast.LENGTH_SHORT).show() }
-                                navController?.popBackStack()
-                            }
+                            context?.let { Toast.makeText(it, R.string.toast_save_successful, Toast.LENGTH_SHORT).show() }
+                            navController?.popBackStack()
                         } else {
-                            withContext(Dispatchers.Main) {
-                                context?.let { Toast.makeText(it, R.string.toast_save_error, Toast.LENGTH_SHORT).show() }
-                            }
+                            context?.let { Toast.makeText(it, R.string.toast_save_error, Toast.LENGTH_SHORT).show() }
                         }
                     } else {
-                        if (svc?.update(dto) == true) {
-                            withContext(Dispatchers.Main) {
-                                context?.let { Toast.makeText(it, R.string.toast_update_successful, Toast.LENGTH_SHORT).show() }
-                                navController?.popBackStack()
-                            }
+                        val result = withContext(Dispatchers.IO) {
+                            svc?.update(dto) == true
+                        }
+                        if (result) {
+                            context?.let { Toast.makeText(it, R.string.toast_update_successful, Toast.LENGTH_SHORT).show() }
+                            navController?.popBackStack()
                         } else {
-                            withContext(Dispatchers.Main) {
-                                context?.let { Toast.makeText(it, R.string.toast_update_error, Toast.LENGTH_SHORT).show() }
-                            }
+                            context?.let { Toast.makeText(it, R.string.toast_update_error, Toast.LENGTH_SHORT).show() }
                         }
                     }
                 }
@@ -156,18 +149,16 @@ class EmailPaidViewModel(
     fun validatePatternWithMessages() {
         validate()
         emailPaid?.let { dto ->
-            viewModelScope.launch(Dispatchers.IO) {
-                withContext(Dispatchers.Main) {
-                    validating.value = true
-                    showPopup.value = true
-                    validationResults.clear()
-                }
-                svc?.validateMessagePattern(dto, 30)?.let { list ->
-                    withContext(Dispatchers.Main) {
-                        validating.value = false
-                        validationResults.addAll(list)
-                        validationResult.value = if (list.isNotEmpty()) "Success" else "Not found messages"
-                    }
+            viewModelScope.launch {
+                validating.value = true
+                showPopup.value = true
+                validationResults.clear()
+                withContext(Dispatchers.IO) {
+                    svc?.validateMessagePattern(dto, 30)
+                }?.let { list ->
+                    validating.value = false
+                    validationResults.addAll(list)
+                    validationResult.value = if (list.isNotEmpty()) "Success" else "Not found messages"
                 }
             }
         }
@@ -193,31 +184,33 @@ class EmailPaidViewModel(
     }
 
     fun main() {
-        viewModelScope.launch(Dispatchers.IO) {
-            accountSvc?.getAll()?.forEach { accountList.add(Pair(it.id, it.name)) }
+        viewModelScope.launch {
+            withContext(Dispatchers.IO) {
+                accountSvc?.getAll()
+            }?.forEach { accountList.add(Pair(it.id, it.name)) }
             codeEmailPaid?.takeIf { it > 0 }?.let { id ->
-                svc?.getById(id)?.let { dto ->
+                withContext(Dispatchers.IO) {
+                    svc?.getById(id)
+                }?.let { dto ->
                     emailPaid = dto
-                    withContext(Dispatchers.Main) {
-                        sender.value = dto.sender
-                        subjectPattern.value = dto.subjectPattern
-                        bodyPattern.value = dto.bodyPattern
-                        account.value = Pair(dto.codeAccount, dto.nameAccount)
-                    }
+                    sender.value = dto.sender
+                    subjectPattern.value = dto.subjectPattern
+                    bodyPattern.value = dto.bodyPattern
+                    account.value = Pair(dto.codeAccount, dto.nameAccount)
                 }
             }
-            withContext(Dispatchers.Main) {
-                llmService?.getModels()?.onSuccess { models ->
-                    llmModels.clear()
-                    models.forEachIndexed { index, name ->
-                        llmModels.add(Pair(index, name))
-                    }
-                    val model = prefs?.llmModel ?: ""
-                    selectedLLMModel.value = llmModels.firstOrNull { it.second == model } ?: llmModels.firstOrNull()
+            withContext(Dispatchers.IO) {
+                llmService?.getModels()
+            }?.onSuccess { models ->
+                llmModels.clear()
+                models.forEachIndexed { index, name ->
+                    llmModels.add(Pair(index, name))
                 }
+                val model = prefs?.llmModel ?: ""
+                selectedLLMModel.value = llmModels.firstOrNull { it.second == model } ?: llmModels.firstOrNull()
+            }
 
-                load.value = false
-            }
+            load.value = false
         }
     }
 }

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/emailpaid/list/EmailListPaidViewModel.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/emailpaid/list/EmailListPaidViewModel.kt
@@ -21,13 +21,13 @@ class EmailListPaidViewModel(
     val list = mutableStateListOf<EmailPaidDTO>()
 
     fun main() {
-        viewModelScope.launch(Dispatchers.IO) {
-            svc?.getAll()?.let {
-                withContext(Dispatchers.Main) {
-                    list.clear()
-                    list.addAll(it)
-                    load.value = false
-                }
+        viewModelScope.launch {
+            withContext(Dispatchers.IO) {
+                svc?.getAll()
+            }?.let {
+                list.clear()
+                list.addAll(it)
+                load.value = false
             }
         }
     }
@@ -41,31 +41,36 @@ class EmailListPaidViewModel(
     }
 
     fun delete(id: Int) {
-        viewModelScope.launch(Dispatchers.IO) {
-            if (svc?.delete(id) == true) {
-                withContext(Dispatchers.Main) {
-                    list.removeIf { it.id == id }
-                }
+        viewModelScope.launch {
+            val result = withContext(Dispatchers.IO) {
+                svc?.delete(id) == true
+            }
+            if (result) {
+                list.removeIf { it.id == id }
             }
         }
     }
 
     fun activate(id: Int, active: Boolean) {
-        viewModelScope.launch(Dispatchers.IO) {
-            if (svc?.activate(id, active) == true) {
-                withContext(Dispatchers.Main) {
-                    val index = list.indexOfFirst { it.id == id }
-                    if (index != -1) {
-                        list[index] = list[index].copy(active = active)
-                    }
+        viewModelScope.launch {
+            val result = withContext(Dispatchers.IO) {
+                svc?.activate(id, active) == true
+            }
+            if (result) {
+                val index = list.indexOfFirst { it.id == id }
+                if (index != -1) {
+                    list[index] = list[index].copy(active = active)
                 }
             }
         }
     }
 
     fun clone(id: Int) {
-        viewModelScope.launch(Dispatchers.IO) {
-            if (svc?.clone(id) == true) {
+        viewModelScope.launch {
+            val result = withContext(Dispatchers.IO) {
+                svc?.clone(id) == true
+            }
+            if (result) {
                 main()
             }
         }

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/paid/list/PaidViewModel.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/paid/list/PaidViewModel.kt
@@ -62,13 +62,15 @@ class PaidViewModel @AssistedInject constructor(@Assisted private val accountCod
         }
     }
 
-    fun delete(id:Int){
-        paidSvc?.let {
-            if(it.delete(id)){
+    fun delete(id:Int) {
+        viewModelScope.launch {
+            val result = withContext(Dispatchers.IO) {
+                paidSvc?.delete(id) ?: false
+            }
+            if(result){
                 navController?.let{
                     Toast.makeText(it.context, R.string.toast_successful_deleted,Toast.LENGTH_LONG).show()
                         .also { loaderState.value = true }
-
                 }
             }else{
                 navController?.let{
@@ -85,8 +87,11 @@ class PaidViewModel @AssistedInject constructor(@Assisted private val accountCod
     }
 
     fun endRecurrent(id:Int){
-        paidSvc?.let{
-            if(it.endRecurrent(id)){
+        viewModelScope.launch {
+            val result = withContext(Dispatchers.IO) {
+                paidSvc?.endRecurrent(id) ?: false
+            }
+            if(result){
                         navController?.let{ Toast.makeText(it.context, R.string.toast_successful_end_recurrent,Toast.LENGTH_LONG).show().also {
                             loaderState.value = true
                         }}
@@ -94,12 +99,14 @@ class PaidViewModel @AssistedInject constructor(@Assisted private val accountCod
                 navController?.let{ Toast.makeText(it.context, R.string.toast_unsuccessful_end_recurrent,Toast.LENGTH_LONG).show() }
             }
         }
-
     }
 
     fun copy(id:Int){
-        paidSvc?.let{
-            if(it.copy(id)){
+        viewModelScope.launch {
+            val result = withContext(Dispatchers.IO) {
+                paidSvc?.copy(id) ?: false
+            }
+            if(result){
                 navController?.let{ Toast.makeText(it.context, R.string.toast_successful_copy,Toast.LENGTH_LONG).show().also {
                     loaderState.value = true
                 }}
@@ -162,16 +169,20 @@ class PaidViewModel @AssistedInject constructor(@Assisted private val accountCod
         return list
     }
 
-    fun main()= runBlocking {
+    fun main() {
         periodOfList.value  = period.format(DateTimeFormatter.ofPattern("MMMM yyyy", Locale("es","CO")))
         progressStatus.value = 0.0f
-        execute()
-        progressStatus.value = 1.0f
+        viewModelScope.launch {
+            execute()
+            progressStatus.value = 1.0f
+        }
     }
 
     suspend fun execute() {
-        paidSvc?.let{
-            it.get(accountCode,period).takeIf { it.isNotEmpty() }?.let{
+        paidSvc?.let{ svcPort ->
+            withContext(Dispatchers.IO) {
+                svcPort.get(accountCode,period)
+            }.takeIf { it.isNotEmpty() }?.let{
                 list.clear()
                 progressStatus.value = 0.3f
 

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/projections/list/ProjectionListViewModel.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/projections/list/ProjectionListViewModel.kt
@@ -15,7 +15,9 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @HiltViewModel(assistedFactory = ProjectionListViewModel.Factory::class)
@@ -51,33 +53,34 @@ class ProjectionListViewModel @AssistedInject constructor(
     }
 
     fun delete(id: Int) {
-        projectionListPort?.let { svc ->
-            svc.delete(id).let {
-                viewModelScope.launch {
-                    if (it) {
-                        snackbarHost.showSnackbar(
-                            message = context.getString(R.string.record_was_remove_success),
-                            actionLabel = context.getString(R.string.close),
-                            duration = SnackbarDuration.Short
-                        ).also {
-                            load()
-                        }
-                    } else {
-                        snackbarHost.showSnackbar(
-                            message = context.getString(R.string.record_was_remove_error),
-                            actionLabel = context.getString(R.string.close),
-                            duration = SnackbarDuration.Short
-                        )
-                    }
+        viewModelScope.launch {
+            val result = withContext(Dispatchers.IO) {
+                projectionListPort?.delete(id) ?: false
+            }
+            if (result) {
+                snackbarHost.showSnackbar(
+                    message = context.getString(R.string.record_was_remove_success),
+                    actionLabel = context.getString(R.string.close),
+                    duration = SnackbarDuration.Short
+                ).also {
+                    load()
                 }
+            } else {
+                snackbarHost.showSnackbar(
+                    message = context.getString(R.string.record_was_remove_error),
+                    actionLabel = context.getString(R.string.close),
+                    duration = SnackbarDuration.Short
+                )
             }
         }
     }
 
     private fun load() = viewModelScope.launch {
         loader.value = true
-        projectionListPort?.let {
-            it.getProjections().let {
+        projectionListPort?.let { svcPort ->
+            withContext(Dispatchers.IO) {
+                svcPort.getProjections()
+            }.let {
                 _list.clear()
                 _list.addAll(it)
             }

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/projections/list/ProjectionsViewModel.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/projections/list/ProjectionsViewModel.kt
@@ -14,8 +14,9 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import java.math.BigDecimal
 import java.util.logging.Handler
 import javax.inject.Inject
@@ -60,14 +61,16 @@ class ProjectionsViewModel @AssistedInject constructor(@Assisted private val sav
         }
     }
 
-    fun main() = runBlocking {
+    fun main() = viewModelScope.launch {
         loadingStatus.value = true
         execute()
     }
 
     suspend fun execute(){
-        projectionSvc?.let{
-            it.getProjectionRecap().let{
+        projectionSvc?.let{ svcPort ->
+            withContext(Dispatchers.IO) {
+                svcPort.getProjectionRecap()
+            }.let{
                 it.first.let(totalCount::onValueChange)
                 it.second.let(totalSaved::onValueChange)
                 it.third.let{

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/sms/form/SmsViewModel.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/sms/form/SmsViewModel.kt
@@ -53,10 +53,14 @@ class SmsViewModel(private val codeSMS:Int?, private val svc:ISMSPaidPort?, priv
 
     fun loadSmsSamples() {
         if (phoneNumber.value.isNotEmpty()) {
-            svc?.getSmsList(phoneNumber.value)?.let { list ->
-                smsSamples.clear()
-                list.map { Pair(it, false) }.forEach(smsSamples::add)
-                showSmsDialog.value = true
+            viewModelScope.launch {
+                withContext(Dispatchers.IO) {
+                    svc?.getSmsList(phoneNumber.value)
+                }?.let { list ->
+                    smsSamples.clear()
+                    list.map { Pair(it, false) }.forEach(smsSamples::add)
+                    showSmsDialog.value = true
+                }
             }
         }
     }
@@ -67,17 +71,17 @@ class SmsViewModel(private val codeSMS:Int?, private val svc:ISMSPaidPort?, priv
     fun generateRegexWithAI() {
         val selectedSms = smsSamples.filter { it.second }.map { it.first }
         if (selectedSms.isNotEmpty()) {
-            viewModelScope.launch(Dispatchers.IO) {
+            viewModelScope.launch {
                 load.value = true
                 progress.floatValue = 0.1f
                 val prompt = navController?.context?.getString(R.string.promt_sms_expreg,selectedSms.joinToString("\n"))?:""
-                llmService?.getAiResponse(prompt, selectedLLMModel.value?.second)?.onSuccess { response ->
+                withContext(Dispatchers.IO) {
+                    llmService?.getAiResponse(prompt, selectedLLMModel.value?.second)
+                }?.onSuccess { response ->
                     progress.floatValue = 0.5f
                     pattern.value = response.trim().removeSurrounding("`").removePrefix("regex").trim()
                     progress.floatValue = 0.8f
-                    viewModelScope.launch(Dispatchers.Main) {
-                        navController?.let { Toast.makeText(it.context, R.string.ai_response, Toast.LENGTH_SHORT).show() }
-                    }
+                    navController?.let { Toast.makeText(it.context, R.string.ai_response, Toast.LENGTH_SHORT).show() }
                     progress.floatValue = 1.0f
                     load.value = false
                     showSmsDialog.value = false
@@ -94,20 +98,26 @@ class SmsViewModel(private val codeSMS:Int?, private val svc:ISMSPaidPort?, priv
 
     fun save(){
         if(smsPaid != null && !errorPhoneNumber.value && !errorPattern.value) {
-            smsPaid?.takeIf { it.id == 0 }?.let{
-                svc?.create(it)?.takeIf { it > 0 }?.let{
-                    smsPaid = smsPaid!!.copy(id = it)
-                    navController?.let { Toast.makeText(it.context, R.string.toast_save_successful, Toast.LENGTH_SHORT).show().also {
-                        navController.popBackStack()
-                    } }
-                }?:navController?.let { Toast.makeText(it.context, R.string.toast_save_error, Toast.LENGTH_SHORT).show() }
-            }
-            smsPaid?.takeIf { it.id > 0 }?.let{
-                svc?.update(it)?.takeIf { it }?.let{
-                    navController?.let { Toast.makeText(it.context, R.string.toast_update_successful, Toast.LENGTH_SHORT).show().also {
-                        navController.popBackStack()
-                    }}
-                }?:navController?.let { Toast.makeText(it.context, R.string.toast_update_error, Toast.LENGTH_SHORT).show() }
+            viewModelScope.launch {
+                smsPaid?.takeIf { it.id == 0 }?.let{
+                    withContext(Dispatchers.IO) {
+                        svc?.create(it)
+                    }?.takeIf { it > 0 }?.let{
+                        smsPaid = smsPaid!!.copy(id = it)
+                        navController?.let { Toast.makeText(it.context, R.string.toast_save_successful, Toast.LENGTH_SHORT).show().also {
+                            navController.popBackStack()
+                        } }
+                    }?:navController?.let { Toast.makeText(it.context, R.string.toast_save_error, Toast.LENGTH_SHORT).show() }
+                }
+                smsPaid?.takeIf { it.id > 0 }?.let{
+                    withContext(Dispatchers.IO) {
+                        svc?.update(it)
+                    }?.takeIf { it }?.let{
+                        navController?.let { Toast.makeText(it.context, R.string.toast_update_successful, Toast.LENGTH_SHORT).show().also {
+                            navController.popBackStack()
+                        }}
+                    }?:navController?.let { Toast.makeText(it.context, R.string.toast_update_error, Toast.LENGTH_SHORT).show() }
+                }
             }
         }
     }
@@ -129,29 +139,25 @@ class SmsViewModel(private val codeSMS:Int?, private val svc:ISMSPaidPort?, priv
     fun validatePatternWithMessages(){
         validate()
         smsPaid?.let {dto->
-            viewModelScope.launch(Dispatchers.IO) {
-                withContext(Dispatchers.Main) {
-                    validating.value = true
-                    showPopup.value = true
-                    validationResults.clear()
-                    validationResult.value = ""
-                }
+            viewModelScope.launch {
+                validating.value = true
+                showPopup.value = true
+                validationResults.clear()
+                validationResult.value = ""
                 runCatching {
-                    svc?.validateMessagePattern(dto) ?: emptyList()
-                }.onFailure { e ->
-                    withContext(Dispatchers.Main) {
-                        validating.value = false
-                        validationResult.value = "Error: ${e.message}"
+                    withContext(Dispatchers.IO) {
+                        svc?.validateMessagePattern(dto) ?: emptyList()
                     }
+                }.onFailure { e ->
+                    validating.value = false
+                    validationResult.value = "Error: ${e.message}"
                 }.onSuccess { list ->
-                    withContext(Dispatchers.Main) {
-                        validating.value = false
-                        validationResults.addAll(list)
-                        if (list.isNotEmpty()) {
-                            validationResult.value = "Success"
-                        } else {
-                            validationResult.value = "Not found sms"
-                        }
+                    validating.value = false
+                    validationResults.addAll(list)
+                    if (list.isNotEmpty()) {
+                        validationResult.value = "Success"
+                    } else {
+                        validationResult.value = "Not found sms"
                     }
                 }
             }
@@ -191,21 +197,19 @@ class SmsViewModel(private val codeSMS:Int?, private val svc:ISMSPaidPort?, priv
     }
 
     fun main() {
-        viewModelScope.launch(Dispatchers.IO) {
-            withContext(Dispatchers.Main) {
-                progress.floatValue = 0.1f
-            }
+        viewModelScope.launch {
+            progress.floatValue = 0.1f
             execute()
-            withContext(Dispatchers.Main) {
-                progress.floatValue = 1.0f
-            }
+            progress.floatValue = 1.0f
         }
     }
 
     suspend fun execute(){
         svc?.let{
             codeSMS?.let {
-                svc.getById(it)?.let{
+                withContext(Dispatchers.IO) {
+                    svc.getById(it)
+                }?.let{
                     smsPaid = it
                     phoneNumber.value = it.phoneNumber
                     pattern.value = it.pattern
@@ -216,7 +220,9 @@ class SmsViewModel(private val codeSMS:Int?, private val svc:ISMSPaidPort?, priv
         accountSvc?.let {
             accountList.clear()
             accountLists.clear()
-            it.getAll()?.takeIf { it.isNotEmpty() }?.forEach {
+            withContext(Dispatchers.IO) {
+                it.getAll()
+            }?.takeIf { it.isNotEmpty() }?.forEach {
                 accountLists.add(it)
                 accountList.add(Pair(it.id,it.name))
             }
@@ -230,7 +236,9 @@ class SmsViewModel(private val codeSMS:Int?, private val svc:ISMSPaidPort?, priv
         KindInterestRateEnum.values().map { Pair(it.getCode().toInt(), it.name)}.forEach(kindInterestRateList::add)
             .also { progress.floatValue = 0.8f }
 
-        llmService?.getModels()?.onSuccess { models ->
+        withContext(Dispatchers.IO) {
+            llmService?.getModels()
+        }?.onSuccess { models ->
             llmModels.clear()
             models.forEachIndexed { index, name ->
                 llmModels.add(Pair(index, name))


### PR DESCRIPTION
This PR addresses three main tasks:
1. **Threading Improvements:** Numerous ViewModels across multiple modules (`CreditCardModule`, `credit`, `paid-module`, `app`, `declaracion_renta_dian`) were updated. Service/port calls inside `viewModelScope.launch` are now wrapped in `withContext(Dispatchers.IO)` to ensure they run off the main thread, as requested.
2. **Material 3 Migration:** The `credit` module was updated to use Material 3 `SnackbarHostState` and `SnackbarHost`. The `Scaffold` components in `Additional.kt` and `AdditionalForm.kt` were updated to correctly show snackbars from the ViewModel.
3. **Combined Simulator List:** A new combined simulator list was implemented in the `app` module. It features a new ViewModel, Composable, and Fragment that aggregate simulation records from both fixed-rate credits and variable-rate credit cards. The navigation graph was updated to point the simulator list destination to this new combined view.

Additionally, code review feedback was addressed by:
- Removing hundreds of build artifacts accidentally included in initial staging.
- Optimizing list item ViewModel creation in Compose using `remember`.
- Replacing `runBlocking` with proper coroutine usage.
- Including the `ProjectionFormViewModel.kt` example file in the threading updates.

---
*PR created automatically by Jules for task [2839256471876300001](https://jules.google.com/task/2839256471876300001) started by @nano871022*