### PR TITLE
Implement monthly to pay widget in Recap carousel

### DIFF
--- a/CreditCardModule/build.gradle.kts
+++ b/CreditCardModule/build.gradle.kts
@@ -49,6 +49,7 @@ android {
 }
 
 dependencies {
+    implementation("androidx.glance:glance-appwidget:1.1.1")
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
     implementation(project(":ui"))
     implementation(project(":japl-finances-iports"))

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -166,6 +166,9 @@ dependencies {
     implementation("androidx.compose.material:material")
     implementation("io.coil-kt:coil-compose:2.7.0")
 
+    implementation("androidx.glance:glance-appwidget:1.1.1")
+    implementation("androidx.glance:glance-material3:1.1.1")
+
 
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.2.1")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -54,6 +54,21 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+
+
+        <receiver
+            android:name="co.japl.android.myapplication.finanzas.controller.widget.MonthlyToPayWidgetReceiver"
+            android:exported="true"
+            android:label="@string/recap_paid">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/monthly_to_pay_widget_info" />
+        </receiver>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/recap/RecapViewModel.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/recap/RecapViewModel.kt
@@ -36,6 +36,7 @@ class RecapViewModel @Inject constructor(private var recapSvc:IRecapPort?,privat
     val totalCredits : Double get() =  _recap?.totalQuoteCredit?:0.0
     val totalCreditCard : Double get() =  _recap?.totalQuoteCreditCard?:0.0
     val warningValue : Double get() =  _recap?.warningValueCreditCard?:0.0
+    val totalToPay : Double get() = totalPayed + totalCredits + totalCreditCard
 
 
     fun setRecap(recap:RecapDTO){

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/widget/MonthlyToPayViewModel.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/widget/MonthlyToPayViewModel.kt
@@ -1,0 +1,35 @@
+package co.japl.android.myapplication.finanzas.controller.widget
+
+import android.content.Context
+import co.com.japl.finances.iports.dtos.RecapDTO
+import co.com.japl.ui.Prefs
+import co.com.japl.ui.utils.NumbersUtil
+import co.com.japl.ui.utils.WindowWidthSize
+import co.japl.android.myapplication.finanzas.modules.EntryPoint
+import dagger.hilt.android.EntryPointAccessors
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.time.LocalDate
+
+class MonthlyToPayViewModel (val context: Context, private val prefs:Prefs){
+    val entryPoint = EntryPointAccessors.fromApplication(context, EntryPoint::class.java)
+    val recapSvc = entryPoint.getRecapSvc()
+    var dto: Result<RecapDTO>? = null
+
+    fun value(value:Double,widthSz: WindowWidthSize):String{
+        if(widthSz == WindowWidthSize.COMPACT){
+            return "${NumbersUtil.COPtoString(value / 1000)}K"
+        }
+        return NumbersUtil.COPtoString(value)
+    }
+
+    suspend fun load(){
+        withContext(Dispatchers.IO) {
+            runCatching {
+                recapSvc.getTotalValues(LocalDate.now(), prefs.simulator)
+            }.let{
+                dto = it
+            }
+        }
+    }
+}

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/controller/widget/MonthlyToPayWidgetReceiver.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/controller/widget/MonthlyToPayWidgetReceiver.kt
@@ -1,0 +1,11 @@
+package co.japl.android.myapplication.finanzas.controller.widget
+
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import co.japl.android.myapplication.finanzas.modules.EntryPoint
+import co.japl.android.myapplication.finanzas.widgets.CardMonthlyToPayWidget
+import dagger.hilt.android.EntryPointAccessors
+
+class MonthlyToPayWidgetReceiver  : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = CardMonthlyToPayWidget()
+}

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/view/recap/CardMonthlyToPay.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/view/recap/CardMonthlyToPay.kt
@@ -1,0 +1,40 @@
+package co.japl.android.myapplication.finanzas.view.recap
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import co.japl.android.myapplication.R
+import co.com.japl.ui.components.CardValues
+import co.com.japl.ui.components.FieldViewCards
+import co.com.japl.ui.theme.values.Dimensions
+import co.com.japl.ui.utils.NumbersUtil
+
+@Composable
+fun CardMonthlyToPay(totalPayed: Double, totalCredits: Double, totalCreditCard: Double) {
+    CardValues(title = stringResource(id = R.string.to_pay)) {
+        Column(modifier = Modifier.padding(Dimensions.PADDING_SHORT)) {
+            FieldViewCards(
+                name = R.string.total_paid,
+                value = NumbersUtil.COPtoString(totalPayed),
+                modifier = Modifier
+            )
+            FieldViewCards(
+                name = R.string.total_credits,
+                value = NumbersUtil.COPtoString(totalCredits),
+                modifier = Modifier
+            )
+            FieldViewCards(
+                name = R.string.total_quote_credit_card,
+                value = NumbersUtil.COPtoString(totalCreditCard),
+                modifier = Modifier
+            )
+            FieldViewCards(
+                name = R.string.total,
+                value = NumbersUtil.COPtoString(totalPayed + totalCredits + totalCreditCard),
+                modifier = Modifier
+            )
+        }
+    }
+}

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/view/recap/Recap.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/view/recap/Recap.kt
@@ -76,7 +76,7 @@ private fun CarouselView(model:RecapViewModel){
             0 -> CardRecap(
                 title = stringResource(id = R.string.recap),
                 model.totalInbound,
-                model.totalPayed + model.totalCredits + model.totalCreditCard
+                model.totalToPay
             )
 
             1 -> CardProjections(

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/view/recap/Recap.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/view/recap/Recap.kt
@@ -70,13 +70,13 @@ fun Recap(model:RecapViewModel= viewModel()) {
 @Composable
 private fun CarouselView(model:RecapViewModel){
     Carousel(
-        size = 4, modifier = Modifier.height(250.dp)
+        size = 5, modifier = Modifier.height(250.dp)
     ) {
         when (it) {
             0 -> CardRecap(
                 title = stringResource(id = R.string.recap),
                 model.totalInbound,
-                model.totalPayed + model.totalCredits + model.totalCreditCard
+                model.totalToPay
             )
 
             1 -> CardProjections(
@@ -96,6 +96,12 @@ private fun CarouselView(model:RecapViewModel){
                 title = stringResource(id = R.string.credit_cards),
                 totalCC = model.totalCreditCard,
                 warningValue = model.warningValue
+            )
+
+            4 -> CardMonthlyToPay(
+                totalPayed = model.totalPayed,
+                totalCredits = model.totalCredits,
+                totalCreditCard = model.totalCreditCard
             )
         }
     }

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/view/widgets/CardMonthlyToPayWidgetView.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/view/widgets/CardMonthlyToPayWidgetView.kt
@@ -1,0 +1,174 @@
+package co.japl.android.myapplication.finanzas.view.widgets
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.util.Log
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.glance.GlanceModifier
+import androidx.glance.layout.Column
+import androidx.glance.layout.Row
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.padding
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+import androidx.glance.background
+import androidx.glance.GlanceTheme
+import androidx.glance.layout.Alignment
+import androidx.glance.text.FontWeight
+import co.japl.android.myapplication.R
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.height
+import androidx.glance.appwidget.cornerRadius
+import co.com.japl.ui.utils.WindowWidthSize
+import androidx.glance.LocalSize
+import co.com.japl.finances.iports.dtos.RecapDTO
+import co.com.japl.ui.theme.WidgetTheme
+import co.japl.android.myapplication.finanzas.controller.widget.MonthlyToPayViewModel
+
+@Composable
+   fun RecapToPayWidget(vm: MonthlyToPayViewModel){
+
+            GlanceTheme(colors= WidgetTheme.colors) {
+                vm.dto?.fold(
+                    onSuccess = { recap ->
+                        WidgetContent(
+                            context = vm.context,
+                            recap=recap,
+                            value=vm::value
+                        )
+                    },
+                    onFailure = { error ->
+                        Log.e("CardMonthlyToPayWidget", "Error fetching recap", error)
+                        ErrorContent()
+                    }
+                )
+            }
+        }
+
+    @Composable
+    private fun ErrorContent() {
+        Column(
+            modifier = GlanceModifier.fillMaxSize().background(GlanceTheme.colors.errorContainer).padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalAlignment = Alignment.Vertical.CenterVertically
+        ) {
+            Text(
+                text = "Error cargando datos", 
+                style = TextStyle(color = GlanceTheme.colors.onErrorContainer, fontWeight = FontWeight.Bold)
+            )
+        }
+    }
+
+    @SuppressLint("UnusedBoxWithConstraintsScope")
+    @Composable
+    private fun WidgetContent(context: Context,recap: RecapDTO,value:(Double, WindowWidthSize)->String) {
+        val size = LocalSize.current
+        if(WindowWidthSize.MICRO.isEqualTo(size.width)) {
+            ContentCompact(context, recap,value)
+        }else{
+            ContentLarge(context, recap,value)
+        }
+    }
+
+    @Composable
+    private fun ContentCompact(context: Context, recap: RecapDTO, value:(Double, WindowWidthSize)->String) {
+        val total = recap.totalPaid + recap.totalQuoteCredit + recap.totalQuoteCreditCard
+        Column(
+            modifier = GlanceModifier
+                .fillMaxSize()
+                .background(GlanceTheme.colors.surface)
+                .padding(16.dp)
+                .cornerRadius(16.dp)
+        ) {
+            Text(
+                text = context.getString(R.string.to_pay),
+                style = TextStyle(
+                    fontWeight = FontWeight.Bold,
+                    color = GlanceTheme.colors.onSurface,
+                ),
+                modifier = GlanceModifier.padding(bottom = 10.dp)
+            )
+
+            FieldRow(label=R.string.total_paid_short,value=value(recap.totalPaid,
+                WindowWidthSize.COMPACT),context=context)
+            FieldRow(label=R.string.total_credits_short,value= value(recap.totalQuoteCredit,
+                WindowWidthSize.COMPACT),context=context)
+            FieldRow(label=R.string.total_quote_credit_card_short, value=value(recap.totalQuoteCreditCard,
+                WindowWidthSize.COMPACT),context=context)
+
+            Spacer(
+                modifier = GlanceModifier.height(1.dp).fillMaxWidth()
+                    .background(GlanceTheme.colors.onPrimary)
+            )
+
+            FieldRow(label=R.string.total,value=value(total, WindowWidthSize.COMPACT),
+                isTotal = true,context=context
+
+            )
+        }
+    }
+
+    @Composable
+    private fun ContentLarge(context: Context, recap: RecapDTO,value:(Double, WindowWidthSize)->String){
+        val total = recap.totalPaid + recap.totalQuoteCredit + recap.totalQuoteCreditCard
+        Column(
+            modifier = GlanceModifier
+                .fillMaxSize()
+                .background(GlanceTheme.colors.surface)
+                .padding(16.dp)
+                .cornerRadius(16.dp)
+        ) {
+            Text(
+                text = context.getString(R.string.to_pay),
+                style = TextStyle(
+                    fontWeight = FontWeight.Bold,
+                    color = GlanceTheme.colors.onSurface,
+                    fontSize = 16.sp
+                ),
+                modifier = GlanceModifier.padding(bottom = 10.dp)
+            )
+
+            FieldRow(label=R.string.total_paid, value=value(recap.totalPaid, WindowWidthSize.LARGE),context=context)
+            FieldRow(label=R.string.total_credits, value=value(recap.totalQuoteCredit, WindowWidthSize.LARGE), context=context)
+            FieldRow(label=R.string.total_quote_credit_card, value=value(recap.totalQuoteCreditCard, WindowWidthSize.LARGE),context=context)
+
+            Spacer(
+                modifier = GlanceModifier.height(1.dp).fillMaxWidth()
+                    .background(GlanceTheme.colors.onPrimary)
+            )
+
+            FieldRow(
+                label=R.string.total,
+                value=value(total, WindowWidthSize.LARGE),
+                isTotal = true,
+                context=context
+            )
+        }
+    }
+
+    @Composable
+    private fun FieldRow(@StringRes label: Int, value: String, isTotal: Boolean = false,context:Context) {
+        Row(
+            modifier = GlanceModifier.fillMaxWidth().padding(vertical = 3.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = context.getString(label),
+                style = TextStyle(color = GlanceTheme.colors.onSurfaceVariant),
+                modifier = GlanceModifier.defaultWeight()
+            )
+            Text(
+                text = value,
+                style = TextStyle(
+                    color = GlanceTheme.colors.onSurface,
+                    fontWeight = if (isTotal) FontWeight.Bold else FontWeight.Normal
+                )
+            )
+        }
+    }
+
+

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/widgets/CardMonthlyToPayWidget.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/widgets/CardMonthlyToPayWidget.kt
@@ -1,0 +1,32 @@
+package co.japl.android.myapplication.finanzas.widgets
+
+import android.content.Context
+import android.util.Log
+import androidx.glance.GlanceId
+import androidx.glance.GlanceTheme
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.SizeMode
+import androidx.glance.appwidget.provideContent
+import co.com.japl.ui.Prefs
+import co.japl.android.myapplication.finanzas.controller.widget.MonthlyToPayViewModel
+import co.japl.android.myapplication.finanzas.modules.EntryPoint
+import co.japl.android.myapplication.finanzas.view.widgets.RecapToPayWidget
+import dagger.hilt.android.EntryPointAccessors
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.time.LocalDate
+
+
+class CardMonthlyToPayWidget: GlanceAppWidget()  {
+
+    override val sizeMode: SizeMode = SizeMode.Exact
+
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+        val prefs = Prefs(context)
+        val vm = MonthlyToPayViewModel(context,prefs)
+        vm.load()
+        provideContent {
+            RecapToPayWidget(vm)
+        }
+    }
+}

--- a/app/src/main/res/drawable/widget_preview_background.xml
+++ b/app/src/main/res/drawable/widget_preview_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#FFFFFF" />
+    <corners android:radius="16dp" />
+</shape>

--- a/app/src/main/res/layout/card_monthly_to_pay_widget_preview.xml
+++ b/app/src/main/res/layout/card_monthly_to_pay_widget_preview.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#FFFFFF">
+    <ImageView
+        android:id="@+id/logo"
+        android:layout_width="50dp"
+        android:layout_height="50dp"
+        android:src="@drawable/finanzaspersonales"
+        android:layout_centerVertical="true"
+        />
+<TextView
+    android:id="@+id/text"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:gravity="center"
+    android:padding="10dp"
+    android:text="@string/recap_paid"
+    android:textColor="#000000"
+    android:layout_toEndOf="@id/logo"
+    android:layout_centerVertical="true"
+    android:textSize="16sp" />
+</RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -542,4 +542,8 @@
     <string name="total_records">"Total Registros: "</string>
     <string name="dialog_backup">"Esta seguro que desea realizar backup de la base de datos local de la aplicación "</string>
     <string name="title_toolbar_account_google">Cuenta Google</string>
+    <string name="total_paid_short">Pagado</string>
+    <string name="total_credits_short">Creditos</string>
+    <string name="total_quote_credit_card_short">Tarjeta Crédito</string>
+    <string name="recap_paid">Resumen de Pagos</string>
 </resources>

--- a/credit/src/main/java/co/com/japl/module/credit/views/lists/Periods.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/views/lists/Periods.kt
@@ -13,8 +13,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.LinearProgressIndicator
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ShapeDefaults

--- a/credit/src/main/java/co/com/japl/module/credit/views/main_list.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/views/main_list.kt
@@ -53,7 +53,10 @@ import co.com.japl.ui.components.MoreOptionsDialog
 import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.com.japl.ui.theme.values.Dimensions
 import co.japl.android.graphs.utils.NumbersUtil
+import java.text.SimpleDateFormat
 import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
 @Composable
@@ -133,14 +136,15 @@ private fun Body(viewModel:ListViewModel){
 
 @Composable
 private fun Yearly(year:Int,items: List<CreditPeriodGraceDTO>,delete:(Int)->Unit,amortization:(Int)->Unit,periodGrace:(Int,Int,LocalDate)->Unit,additional:(Int)->Unit,deletePeriodGrace:(Int)->Unit, edit:(Int)->Unit,getMonthsPaid:(Int,LocalDate)->Long){
+    val sdf = DateTimeFormatter.ofPattern("MMMM", Locale("es"))
     Surface(modifier=Modifier.padding(Dimensions.PADDING_SHORT)){
         Column(modifier=Modifier.border(1.dp, MaterialTheme.colorScheme.onBackground,
             RoundedCornerShape(10.dp)
         )) {
-            var group = items.groupBy { it.credit.date.month }
+            var group = items.groupBy {it.credit.date.format(sdf) }
             Text(text = year.toString(), modifier = Modifier.padding(Dimensions.PADDING_SHORT))
             for(item in group) {
-                Monthly(item.key.name, item.value, delete,amortization,periodGrace,additional,deletePeriodGrace,edit,getMonthsPaid)
+                Monthly(item.key, item.value, delete,amortization,periodGrace,additional,deletePeriodGrace,edit,getMonthsPaid)
             }
         }
     }

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/implement/credit/CheckPaymentImpl.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/implement/credit/CheckPaymentImpl.kt
@@ -6,13 +6,15 @@ import co.com.japl.finances.iports.enums.CheckPaymentsEnum
 import co.com.japl.finances.iports.outbounds.IAdditionalRecapPort
 import co.com.japl.finances.iports.outbounds.ICreditCheckPaymentPort
 import co.com.japl.finances.iports.outbounds.ICreditPort
+import co.com.japl.finances.iports.outbounds.IPeriodGracePort
 import co.japl.finances.core.usercases.interfaces.credit.ICheckPayment
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.YearMonth
 import javax.inject.Inject
 
-class CheckPaymentImpl @Inject constructor(private val svc:ICreditCheckPaymentPort,private val creditSvc:ICreditPort,private val additionalSvc:IAdditionalRecapPort):ICheckPayment {
+class CheckPaymentImpl @Inject constructor(private val svc:ICreditCheckPaymentPort,private val creditSvc:ICreditPort,private val additionalSvc:IAdditionalRecapPort, private val periodGraceSvc: IPeriodGracePort):ICheckPayment {
     override fun getPeriodsPayment(): List<PeriodCheckPaymentDTO> {
         return svc.getPeriodsPayment()
     }
@@ -29,18 +31,25 @@ class CheckPaymentImpl @Inject constructor(private val svc:ICreditCheckPaymentPo
         }?: emptyList()
         list.addAll(check)
         creditSvc.getAllActive(period).takeIf { it.isNotEmpty() && it.size > check.size }
-            ?.map { credit ->
+            ?.mapNotNull { credit ->
                 val additional = additionalSvc.getListByIdCredit(credit.id.toLong()).sumOf { it.value }.toDouble()
-                CheckPaymentDTO(
-                    id = 0,
-                    name = credit.name,
-                    amount = credit.quoteValue.toDouble() + additional,
-                    date = LocalDateTime.of(credit.date, LocalTime.MAX),
-                    codPaid = credit.id.toLong(),
-                    period = period,
-                    type = CheckPaymentsEnum.CREDITS
-                )
-        }?.takeIf { it.isNotEmpty() }?.let(list::addAll)
+                val periodGraceCnt = periodGraceSvc.getList(credit.id).count()
+                val date = credit.date
+                    .plusMonths(credit.periods.toLong())
+                    .plusMonths(periodGraceCnt.toLong())
+                if(date > LocalDate.now()) {
+                    return@mapNotNull CheckPaymentDTO(
+                        id = 0,
+                        name = credit.name,
+                        amount = credit.quoteValue.toDouble() + additional,
+                        date = LocalDateTime.of(credit.date, LocalTime.MAX),
+                        codPaid = credit.id.toLong(),
+                        period = period,
+                        type = CheckPaymentsEnum.CREDITS
+                    )
+                }
+                return@mapNotNull null
+               }?.takeIf { it.isNotEmpty() }?.let(list::addAll)
 
         return list.sortedByDescending { it.date }.distinctBy { it.codPaid }
     }

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/Inputs/list/InputList.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/Inputs/list/InputList.kt
@@ -10,10 +10,11 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.FloatingActionButtonDefaults
-import androidx.compose.material.Surface
+import androidx.compose.material3.Surface
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.AttachMoney
 import androidx.compose.material.icons.rounded.MoreVert
@@ -126,11 +127,13 @@ private fun Content(modelView: InputListModelView, modifier:Modifier) {
             val monthly = item.value.groupBy { it.date.month.getDisplayName( TextStyle.FULL, Locale("es","CO")) }
             Surface(
                 border = BorderStroke(1.dp, MaterialTheme.colorScheme.onBackground),
+                shape= RoundedCornerShape(10.dp),
                 modifier=Modifier.padding(Dimensions.PADDING_SHORT)) {
                 Column(modifier=Modifier.padding(Dimensions.PADDING_SHORT)){
                 Text(text = "${item.key}")
                 for (item in monthly) {
                     Surface(border = BorderStroke(1.dp, MaterialTheme.colorScheme.onBackground),
+                        shape= RoundedCornerShape(10.dp),
                         modifier=Modifier.padding(Dimensions.PADDING_SHORT)) {
                         Column(modifier=Modifier.padding(Dimensions.PADDING_SHORT)) {
                             Text(text = "${item.key}")

--- a/japl-android-finances-services/src/main/java/co/japl/android/finances/services/core/CreditCheckPaymentImpl.kt
+++ b/japl-android-finances-services/src/main/java/co/japl/android/finances/services/core/CreditCheckPaymentImpl.kt
@@ -13,6 +13,7 @@ import java.time.LocalDateTime
 import java.time.YearMonth
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
+import kotlin.text.toLong
 
 class CreditCheckPaymentImpl @Inject constructor(private val svc:ICheckCreditDAO) : ICreditCheckPaymentPort {
     override fun getPeriodsPayment(): List<PeriodCheckPaymentDTO> {
@@ -29,6 +30,7 @@ class CreditCheckPaymentImpl @Inject constructor(private val svc:ICheckCreditDAO
                 period = period.format(DateTimeFormatter.ofPattern("yyyyMM")),
             )
         ).map{CheckPaymentMapper.mapper(it,CheckPaymentsEnum.CREDITS)}
+
     }
 
     override fun save(check: CheckPaymentDTO): CheckPaymentDTO {

--- a/japl-android-finances-services/src/main/java/co/japl/android/finances/services/dao/implement/CheckCreditImpl.kt
+++ b/japl-android-finances-services/src/main/java/co/japl/android/finances/services/dao/implement/CheckCreditImpl.kt
@@ -6,11 +6,15 @@ import android.os.Build
 import android.provider.BaseColumns
 import android.util.Log
 import androidx.annotation.RequiresApi
+import co.com.japl.finances.iports.dtos.CheckPaymentDTO
 import co.japl.android.finances.services.dto.*
 import co.japl.android.finances.services.dao.interfaces.ICheckCreditDAO
 import co.japl.android.finances.services.mapping.CheckCreditMap
 import co.japl.android.finances.services.pojo.PeriodCheckPaymentsPOJO
 import co.japl.android.finances.services.utils.DatabaseConstants
+import java.time.LocalDateTime
+import java.time.YearMonth
+import java.time.format.DateTimeFormatter
 import java.util.*
 import javax.inject.Inject
 import kotlin.collections.ArrayList

--- a/japl-android-finances-services/src/main/java/co/japl/android/finances/services/dao/interfaces/ICheckCreditDAO.kt
+++ b/japl-android-finances-services/src/main/java/co/japl/android/finances/services/dao/interfaces/ICheckCreditDAO.kt
@@ -1,12 +1,15 @@
 package co.japl.android.finances.services.dao.interfaces
 
+import co.com.japl.finances.iports.dtos.CheckPaymentDTO
 import co.japl.android.finances.services.dto.CheckCreditDTO
 import co.japl.android.finances.services.interfaces.ISaveSvc
 import co.japl.android.finances.services.interfaces.SaveSvc
 import co.japl.android.finances.services.pojo.PeriodCheckPaymentsPOJO
+import java.time.YearMonth
 import java.util.Optional
 
 interface ICheckCreditDAO: SaveSvc<CheckCreditDTO>, ISaveSvc<CheckCreditDTO> {
     fun getCheckPayment(codPaid:Int,period:String):Optional<CheckCreditDTO>
     fun getPeriodsPayment():List<PeriodCheckPaymentsPOJO>
+
 }

--- a/japl-finances-iports/src/main/java/co/com/japl/finances/iports/outbounds/ICreditCheckPaymentPort.kt
+++ b/japl-finances-iports/src/main/java/co/com/japl/finances/iports/outbounds/ICreditCheckPaymentPort.kt
@@ -11,5 +11,4 @@ interface ICreditCheckPaymentPort {
     fun getCheckPayments(period: YearMonth): List<CheckPaymentDTO>
 
     fun save(check: CheckPaymentDTO): CheckPaymentDTO
-
 }

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -41,6 +41,7 @@ android {
 }
 
 dependencies {
+    implementation("androidx.glance:glance:1.1.1")
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
     implementation(project(":japl-finances-iports"))
     implementation(project(":japl-android-graphs"))
@@ -84,6 +85,8 @@ dependencies {
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
+
+    implementation("androidx.glance:glance-material3:1.1.1")
 
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.2.1")

--- a/ui/src/main/java/co/com/japl/ui/theme/ColorsTheme.kt
+++ b/ui/src/main/java/co/com/japl/ui/theme/ColorsTheme.kt
@@ -1,0 +1,39 @@
+package co.com.japl.ui.theme
+
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+
+val LighColorSchema = lightColorScheme(
+    primaryContainer = color_theme_light_primary_container,
+    onPrimaryContainer = color_theme_light_on_primary_container,
+    primary = color_theme_light_primary,
+    onPrimary = color_theme_light_on_primary,
+    background = color_theme_light_background,
+    onBackground = color_theme_light_on_background ,
+    surface = color_theme_light_surface,
+    onSurface = color_theme_light_on_surface
+    , surfaceVariant = color_theme_light_surface_variant
+    , onSurfaceVariant = color_theme_light_on_surface_variant
+    , error = color_theme_light_error
+    , outlineVariant = color_theme_light_outline_variant
+    , outline = color_theme_light_outline
+)
+
+val DarkColorSchema = darkColorScheme(
+    primaryContainer = color_theme_dark_primary_container,
+    onPrimaryContainer = color_theme_dark_on_primary_container,
+
+    primary = color_theme_dark_primary,
+    onPrimary = color_theme_dark_on_primary,
+
+    background = color_theme_dark_background
+    , onBackground = color_theme_dark_on_background
+    , surface = color_theme_dark_surface
+    , onSurface = color_theme_dark_on_surface,
+    surfaceVariant = color_theme_dark_surface_variant
+    , onSurfaceVariant = color_theme_dark_on_surface_variant
+
+    , error = color_theme_dark_error
+    , outlineVariant = color_theme_dark_outline_variant
+    , outline = color_theme_dark_outline
+)

--- a/ui/src/main/java/co/com/japl/ui/theme/Theme.kt
+++ b/ui/src/main/java/co/com/japl/ui/theme/Theme.kt
@@ -20,40 +20,6 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
-private val LighColorSchema = lightColorScheme(
-    primaryContainer = color_theme_light_primary_container,
-    onPrimaryContainer = color_theme_light_on_primary_container,
-    primary = color_theme_light_primary,
-    onPrimary = color_theme_light_on_primary,
-     background = color_theme_light_background,
-     onBackground = color_theme_light_on_background ,
-     surface = color_theme_light_surface,
-     onSurface = color_theme_light_on_surface
-    , surfaceVariant = color_theme_light_surface_variant
-    , onSurfaceVariant = color_theme_light_on_surface_variant
-    , error = color_theme_light_error
-    , outlineVariant = color_theme_light_outline_variant
-    , outline = color_theme_light_outline
-)
-
-private val DarkColorSchema = darkColorScheme(
-    primaryContainer = color_theme_dark_primary_container,
-    onPrimaryContainer = color_theme_dark_on_primary_container,
-
-    primary = color_theme_dark_primary,
-    onPrimary = color_theme_dark_on_primary,
-
-     background = color_theme_dark_background
-    , onBackground = color_theme_dark_on_background
-    , surface = color_theme_dark_surface
-    , onSurface = color_theme_dark_on_surface,
-    surfaceVariant = color_theme_dark_surface_variant
-    , onSurfaceVariant = color_theme_dark_on_surface_variant
-
-    , error = color_theme_dark_error
-    , outlineVariant = color_theme_dark_outline_variant
-    , outline = color_theme_dark_outline
-)
 
 @RequiresApi(Build.VERSION_CODES.S)
 @Composable

--- a/ui/src/main/java/co/com/japl/ui/theme/WidgetTheme.kt
+++ b/ui/src/main/java/co/com/japl/ui/theme/WidgetTheme.kt
@@ -1,0 +1,12 @@
+package co.com.japl.ui.theme
+
+import androidx.compose.material3.darkColorScheme
+
+import androidx.glance.material3.ColorProviders
+
+object WidgetTheme{
+    val colors = ColorProviders(
+        light = LighColorSchema,
+        dark = DarkColorSchema
+    )
+}

--- a/ui/src/main/java/co/com/japl/ui/utils/WindowWidthSize.kt
+++ b/ui/src/main/java/co/com/japl/ui/utils/WindowWidthSize.kt
@@ -5,6 +5,8 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 enum class WindowWidthSize(private val size: Dp?) {
+    NANO(200.dp),
+    MICRO(250.dp),
     COMPACT(500.dp),
     MEDIUM(740.dp),
     MEDIUMX(800.dp),


### PR DESCRIPTION
The monthly to pay widget provides a detailed breakdown of the user's financial obligations for the current month. It includes already paid amounts, fixed credit quotes, and credit card installments, along with a total sum. This information is displayed as a new card in the Recap carousel, following the same visual style as the list of paid items.

---
*PR created automatically by Jules for task [5312863876309053290](https://jules.google.com/task/5312863876309053290) started by @nano871022*