### PR TITLE
Fix LayoutNode Attached to Owner Crash

### DIFF
--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/account/CreditCardListViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/account/CreditCardListViewModel.kt
@@ -12,7 +12,10 @@ import co.com.japl.module.creditcard.R
 import co.com.japl.module.creditcard.navigations.CreditCard
 import co.com.japl.module.creditcard.navigations.ListCreditCardSettings
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.runBlocking
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @HiltViewModel
@@ -52,17 +55,22 @@ class CreditCardListViewModel @Inject constructor(private val creditCardSvc:ICre
         }
     }
 
-    fun main() = runBlocking {
-        progress.floatValue = 0.1f
-        execute()
-        progress.floatValue = 1f
+    fun main() {
+        viewModelScope.launch {
+            progress.floatValue = 0.1f
+            execute()
+            progress.floatValue = 1f
+        }
     }
 
-    suspend fun execute(){
+    suspend fun execute() {
         progress.floatValue = 0.4f
-        creditCardSvc?.let{
+        creditCardSvc?.let { svc ->
+            val result = withContext(Dispatchers.IO) {
+                svc.getAll()
+            }
             list.clear()
-            it.getAll()?.let(list::addAll)
+            result?.let(list::addAll)
             showProgress.value = false
         }
         progress.floatValue = 0.8f

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/account/CreditCardViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/account/CreditCardViewModel.kt
@@ -13,7 +13,10 @@ import co.com.japl.module.creditcard.navigations.ListCreditCardSettings
 import co.com.japl.ui.utils.NumbersUtil
 import co.com.japl.module.creditcard.params.CreditCardParams
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.runBlocking
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.math.BigDecimal
 import java.time.LocalDateTime
 import androidx.lifecycle.SavedStateHandle
@@ -119,27 +122,31 @@ class CreditCardViewModel @Inject constructor(
         }
     }
 
-    fun main() = runBlocking {
-        progress.floatValue = 0.1f
+    fun main() {
+        viewModelScope.launch {
+            progress.floatValue = 0.1f
 
-        execute()
+            execute()
 
-        progress.floatValue = 1f
+            progress.floatValue = 1f
+        }
     }
 
-    suspend fun execute(){
+    suspend fun execute() {
         progress.floatValue = 0.3f
-        codeCreditCard?.let {
-            creditCardSvc.getCreditCard(codeCreditCard)?.let{
+        codeCreditCard?.let { code ->
+            withContext(Dispatchers.IO) {
+                creditCardSvc.getCreditCard(code)
+            }?.let {
                 _creditCardDto = it
                 showButtonUpdate.value = it.id > 0
 
                 name.value = it.name
                 maxQuotes.value = it.maxQuotes.toString()
                 cutOffDay.value = it.cutOffDay.toString()
-                warningValue.value = if(it.warningValue > BigDecimal.ZERO) {
+                warningValue.value = if (it.warningValue > BigDecimal.ZERO) {
                     NumbersUtil.toString(it.warningValue.toDouble())
-                }else{
+                } else {
                     ""
                 }
                 state.value = it.status

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/bought/lists/BoughtMonthlyViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/bought/lists/BoughtMonthlyViewModel.kt
@@ -21,7 +21,10 @@ import co.com.japl.module.creditcard.navigations.Bought
 import co.com.japl.module.creditcard.navigations.ListCreditRate
 import co.com.japl.ui.Prefs
 import co.com.japl.ui.utils.DateUtils
-import kotlinx.coroutines.runBlocking
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.Period
@@ -123,16 +126,20 @@ class BoughtMonthlyViewModel(
         showCreditRate.value = false
     }
 
-    fun mainCreditCard()= runBlocking {
-        executeCreditCard()
+    fun mainCreditCard() {
+        viewModelScope.launch {
+            executeCreditCard()
+        }
     }
 
     suspend fun executeCreditCard() {
-        creditCardSvc?.getAll()?.let {
+        withContext(Dispatchers.IO) {
+            creditCardSvc?.getAll()
+        }?.let {
             listCreditCard = it
             creditCardList.clear()
             creditCardList.addAll(it.map { Pair<Int, String>(it.id, it.name) })
-            if(it.size == 1 && creditCard.value.isBlank()){
+            if (it.size == 1 && creditCard.value.isBlank()) {
                 creditCardCode.intValue = it.first().id
                 creditCard.value = it.first().name
                 main()
@@ -140,34 +147,38 @@ class BoughtMonthlyViewModel(
         }
     }
 
-    fun main()= runBlocking {
-        loader.value = false
-        progress.floatValue = 1f
-        execute()
-        progress.floatValue = 100f
-        loader.value = true
-        readSms()
-    }
-
-
-    suspend fun readSms(){
-        try {
-            msmSvc?.read(prefs.creditCardSMSDaysRead)
-        }catch (e:Exception){
-            Log.e(javaClass.name,e.message,e)
+    fun main() {
+        viewModelScope.launch {
+            loader.value = false
+            progress.floatValue = 1f
+            execute()
+            progress.floatValue = 100f
+            loader.value = true
+            readSms()
         }
     }
 
-    suspend fun execute(){
+
+    suspend fun readSms() {
+        try {
+            withContext(Dispatchers.IO) {
+                msmSvc?.read(prefs.creditCardSMSDaysRead)
+            }
+        } catch (e: Exception) {
+            Log.e(javaClass.name, e.message, e)
+        }
+    }
+
+    suspend fun execute() {
         if (creditCardCode.intValue != 0) {
             clear()
-            listCreditCard?.first { it.id == creditCardCode.intValue }?.let {creditCard->
+            listCreditCard?.first { it.id == creditCardCode.intValue }?.let { creditCard ->
                 progress.floatValue = 0.2f
                 creditCardSelected = creditCard
                 DateUtils.cutOff(creditCard.cutOffDay, LocalDate.now())?.let {
                     cutOff.value = it
                 }
-                daysLeftCutOff.value = Period.between(LocalDate.now(),cutOff.value.toLocalDate()).days
+                daysLeftCutOff.value = Period.between(LocalDate.now(), cutOff.value.toLocalDate()).days
                 progress.floatValue = 0.3f
                 DateUtils.cutOffLastMonth(creditCard.cutOffDay, cutOff.value)?.let {
                     lastMonthPaid.value = it
@@ -175,7 +186,10 @@ class BoughtMonthlyViewModel(
                 progress.floatValue = 0.4f
                 warningValue.value = creditCard.warningValue.toDouble()
                 progress.floatValue = 0.5f
-                boughtCreditCardSvc?.getRecap(creditCard, cutOff.value,cache.value)?.let {
+
+                withContext(Dispatchers.IO) {
+                    boughtCreditCardSvc?.getRecap(creditCard, cutOff.value, cache.value)
+                }?.let {
                     it.current?.let {
                         progress.floatValue = 0.6f
                         capitalValue.value = it.capitalValue
@@ -197,29 +211,52 @@ class BoughtMonthlyViewModel(
                     }
                 }
 
-                boughtCreditCardSvc?.getBoughtCurrentPeriodList(creditCard,cutOff.value,cache.value)?.let{
+                withContext(Dispatchers.IO) {
+                    boughtCreditCardSvc?.getBoughtCurrentPeriodList(creditCard, cutOff.value, cache.value)
+                }?.let {
                     graphListPeriod.addAll(it)
                     progress.floatValue = 0.8f
                 }
 
-                creditRate?.let {
+                creditRate?.let { svc ->
 
-                    it.get(creditCard.id,cutOff.value.monthValue,cutOff.value.year,KindInterestRateEnum.CREDIT_CARD)?.let{
+                    withContext(Dispatchers.IO) {
+                        svc.get(
+                            creditCard.id,
+                            cutOff.value.monthValue,
+                            cutOff.value.year,
+                            KindInterestRateEnum.CREDIT_CARD
+                        )
+                    }?.let {
                         showBought.value = true
                         showList.value = true
                         progress.floatValue = 0.85f
                     }
 
-                    it.get(creditCard.id,cutOff.value.monthValue,cutOff.value.year,KindInterestRateEnum.CASH_ADVANCE)?.let{
+                    withContext(Dispatchers.IO) {
+                        svc.get(
+                            creditCard.id,
+                            cutOff.value.monthValue,
+                            cutOff.value.year,
+                            KindInterestRateEnum.CASH_ADVANCE
+                        )
+                    }?.let {
                         showAdvance.value = true
                         progress.floatValue = 0.9f
                     }
 
-                    it.get(creditCard.id,cutOff.value.monthValue,cutOff.value.year,KindInterestRateEnum.WALLET_BUY)?.let{
+                    withContext(Dispatchers.IO) {
+                        svc.get(
+                            creditCard.id,
+                            cutOff.value.monthValue,
+                            cutOff.value.year,
+                            KindInterestRateEnum.WALLET_BUY
+                        )
+                    }?.let {
                         showWallet.value = true
                         progress.floatValue = 0.95f
                     }
-                    if(showWallet.value.not() and showAdvance.value.not() and showBought.value.not()){
+                    if (showWallet.value.not() and showAdvance.value.not() and showBought.value.not()) {
                         showCreditRate.value = true
                     }
                     progress.floatValue = 100f

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/creditrate/forms/CreateRateViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/creditrate/forms/CreateRateViewModel.kt
@@ -14,7 +14,10 @@ import co.com.japl.finances.iports.inbounds.creditcard.ICreditCardPort
 import co.com.japl.finances.iports.inbounds.creditcard.ITaxPort
 import co.com.japl.module.creditcard.R
 import co.com.japl.ui.utils.NumbersUtil
-import kotlinx.coroutines.runBlocking
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.YearMonth
@@ -129,60 +132,70 @@ class CreateRateViewModel(private val codeCreditCard:Int?, private val codeCredi
 
 
 
-    fun main() = runBlocking {
-        progress.floatValue = 0.1f
-        execute()
-        progress.floatValue = 1.0f
+    fun main() {
+        viewModelScope.launch {
+            progress.floatValue = 0.1f
+            execute()
+            progress.floatValue = 1.0f
+        }
     }
 
-    suspend fun execute(){
-        codeCreditCard?.let {
-            creditCardSvc?.let {
-                it.getCreditCard(codeCreditCard)?.let {
+    suspend fun execute() {
+        codeCreditCard?.let { code ->
+            withContext(Dispatchers.IO) {
+                creditCardSvc?.getCreditCard(code)
+            }?.let {
                 _creditCardDto = it
-
-                    creditCard.value = it.id.toString()
-
-                progress.floatValue = 0.3f
+                creditCard.value = it.id.toString()
             }
-            }
+            progress.floatValue = 0.3f
         }
-        creditCardSvc?.let {
-           _listCreditCards = it.getAll()
-            progress.floatValue = 0.6f
-            loader.value = false
+
+        withContext(Dispatchers.IO) {
+            creditCardSvc?.getAll()
+        }?.let {
+            _listCreditCards = it
         }
+        progress.floatValue = 0.6f
+        loader.value = false
 
         year.value = LocalDate.now().year.toString()
         month.value = LocalDate.now().monthValue.toString()
         creditRateKind.value = KindOfTaxEnum.ANUAL_EFFECTIVE.getName()
         creditCardKind.value = KindInterestRateEnum.CREDIT_CARD.getCode().toString()
 
-        creditRateSvc?.let{svc->
-            codeCreditCard?.let {
+        creditRateSvc?.let { svc ->
+            codeCreditCard?.let { code ->
                 val yearMonth = YearMonth.of(year.value.toInt(), month.value.toInt()).minusMonths(1)
-                svc.get(
-                    codeCreditCard,
-                    yearMonth.monthValue,
-                    yearMonth.year,
-                    kind = KindInterestRateEnum.findByOrdinal(creditCardKind.value?.toShort()?:0))?.let {
-                        rate.value = it.value.toString()
-                    }
+                withContext(Dispatchers.IO) {
+                    svc.get(
+                        code,
+                        yearMonth.monthValue,
+                        yearMonth.year,
+                        kind = KindInterestRateEnum.findByOrdinal(
+                            creditCardKind.value?.toShort() ?: 0
+                        )
+                    )
+                }?.let {
+                    rate.value = it.value.toString()
+                }
             }
-            codeCreditRate?.let {
-                svc.getById(it)?.let {
+            codeCreditRate?.let { codeRate ->
+                withContext(Dispatchers.IO) {
+                    svc.getById(codeRate)
+                }?.let {
                     _creditRateDto = it
                     year.value = it.year.toString()
                     month.value = it.month.toString()
                     rate.value = it.value.toString()
                     creditCardKind.value = it.kind.getCode().toString()
-                    creditRateKind.value = it.kindOfTax?.getName()?:KindOfTaxEnum.ANUAL_EFFECTIVE.getName()
+                    creditRateKind.value =
+                        it.kindOfTax?.getName() ?: KindOfTaxEnum.ANUAL_EFFECTIVE.getName()
                     period.value = it.period.toString()
-                    status.value = it.status>0
+                    status.value = it.status > 0
                 }
             }
         }
-
     }
 
 }

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/creditrate/lists/CreditRateListViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/creditrate/lists/CreditRateListViewModel.kt
@@ -12,7 +12,10 @@ import co.com.japl.finances.iports.inbounds.creditcard.ICreditCardPort
 import co.com.japl.finances.iports.inbounds.creditcard.ITaxPort
 import co.com.japl.module.creditcard.R
 import co.com.japl.module.creditcard.navigations.ListCreditRate
-import kotlinx.coroutines.runBlocking
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class CreditRateListViewModel(private val context:Context?, private val creditCardSvc:ICreditCardPort?, private val creditRateSvc:ITaxPort?, private val navController: NavController?):ViewModel() {
 
@@ -98,30 +101,33 @@ class CreditRateListViewModel(private val context:Context?, private val creditCa
         navController?.let { ListCreditRate.navigate(codeCreditCard,codeCreditRate,navigate = navController)}
     }
 
-    fun main() = runBlocking {
-        progress.floatValue = 0.1f
-        execute()
-        progress.floatValue = 1f
+    fun main() {
+        viewModelScope.launch {
+            progress.floatValue = 0.1f
+            execute()
+            progress.floatValue = 1f
+        }
     }
 
-    suspend fun execute(){
-        creditCardSvc?.let {
-            creditCardSvc.getAll()?.let { list ->
-                progress.floatValue = 0.5f
-                list.flatMap {
-                    creditRateSvc?.let{svc->
-                        svc.getByCreditCard(it.id)?.sortedByDescending { it.create }
-                    }?: listOf()
-                }.groupBy { rate ->
-                    list.find {
-                        it.id == rate.codCreditCard
+    suspend fun execute() {
+        creditCardSvc?.let { svc ->
+            val result = withContext(Dispatchers.IO) {
+                svc.getAll()?.let { list ->
+                    progress.floatValue = 0.5f
+                    list.flatMap {
+                        creditRateSvc?.let { svcTax ->
+                            svcTax.getByCreditCard(it.id)?.sortedByDescending { it.create }
+                        } ?: listOf()
+                    }.groupBy { rate ->
+                        list.find {
+                            it.id == rate.codCreditCard
+                        }
                     }
                 }
-            }.let {
-                progress.floatValue = 0.8f
-                creditCard = it?.toMutableMap()
-                showProgress.value = false
             }
+            progress.floatValue = 0.8f
+            creditCard = result?.toMutableMap()
+            showProgress.value = false
         }
     }
 

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/account/forms/CreditCard.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/account/forms/CreditCard.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material.icons.rounded.Update
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -35,7 +36,7 @@ fun CreditCard(viewModel: CreditCardViewModel){
     remember { viewModel.showButtons }
     val buttonUpdateState = remember { viewModel.showButtonUpdate}
 
-    CoroutineScope(Dispatchers.IO).launch {
+    LaunchedEffect(Unit) {
         viewModel.main()
     }
 

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/account/lists/CreditCardList.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/account/lists/CreditCardList.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -63,7 +64,7 @@ fun CreditCardList(creditCardViewModel:CreditCardListViewModel){
         creditCardViewModel.showProgress
     }
 
-    CoroutineScope(Dispatchers.IO).launch {
+    LaunchedEffect(Unit) {
         creditCardViewModel.main()
     }
 

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/bought/BoughtMonthly.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/bought/BoughtMonthly.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -80,7 +81,7 @@ fun BoughtMonthly(viewModel:BoughtMonthlyViewModel?=null) {
     var loaderStatus by remember {viewModel!!.loader}
     var progressStatus by remember {viewModel!!.progress}
 
-    CoroutineScope(Dispatchers.IO).launch{
+    LaunchedEffect(Unit) {
         viewModel?.mainCreditCard()
     }
 

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/creditrate/forms/CreditRate.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/creditrate/forms/CreditRate.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.FloatingActionButtonDefaults
 import androidx.compose.material.icons.rounded.Cancel
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringArrayResource
@@ -48,7 +49,7 @@ fun CreditRate(viewModel:CreateRateViewModel){
     var progress = remember {
         viewModel.progress
     }
-    CoroutineScope(Dispatchers.IO).launch {
+    LaunchedEffect(Unit) {
         viewModel.main()
     }
 

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/creditrate/lists/CreditRateList.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/creditrate/lists/CreditRateList.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -68,7 +69,7 @@ fun CreditRateList(viewModel: CreditRateListViewModel){
     val progress = remember {
         viewModel.progress
     }
-    CoroutineScope(Dispatchers.IO).launch {
+    LaunchedEffect(Unit) {
         viewModel.main()
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,8 +18,8 @@ android {
         applicationId "co.japl.android.myapplication"
         minSdk 26
         targetSdk 36
-        versionCode 4_09_02_185
-        versionName "V 4.09.02 build 185 Added request permisison for gmail and drive when is record or one by one"
+        versionCode 4_09_02_186
+        versionName "V 4.09.02 build 186 Added request permisison for gmail and drive when is record or one by one"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/co/japl/android/myapplication/finanzas/view/google/StatsSpace.kt
+++ b/app/src/main/java/co/japl/android/myapplication/finanzas/view/google/StatsSpace.kt
@@ -34,16 +34,16 @@ import co.com.japl.ui.theme.MaterialThemeComposeUI
 import co.com.japl.ui.theme.values.Dimensions
 import co.japl.android.myapplication.R
 import co.com.japl.ui.utils.NumbersUtil
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
+import androidx.compose.runtime.LaunchedEffect
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Locale.getDefault
 
 @Composable
 fun StatsSpace(viewModel: GoogleAuthBackupRestoreViewModel) {
-    viewModel.onload()
+    LaunchedEffect(Unit) {
+        viewModel.onload()
+    }
     val isProcessing by remember { viewModel.isProcessing }
     val isLogged by remember { viewModel.isLogged }
     val email = remember { viewModel.loginValue }
@@ -133,9 +133,7 @@ fun StatsSpace(viewModel: GoogleAuthBackupRestoreViewModel) {
         AlertBackup(
             status = statusBackupDialog,
             action = {
-                CoroutineScope(Dispatchers.IO).launch {
-                    viewModel.backup()
-                }
+                viewModel.backup()
             })
     }
 }

--- a/credit/src/main/java/co/com/japl/module/credit/controllers/list/ListViewModel.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/controllers/list/ListViewModel.kt
@@ -12,9 +12,10 @@ import co.com.japl.module.credit.R
 import co.com.japl.module.credit.navigations.CreditList
 import co.com.japl.module.credit.pojo.CreditPeriodGraceDTO
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.CoroutineScope
+import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.time.LocalDate
 import java.time.YearMonth
 import androidx.lifecycle.SavedStateHandle
@@ -105,17 +106,21 @@ class ListViewModel @Inject constructor(
     }
 
     fun execute() {
-        CoroutineScope(Dispatchers.IO).launch {
+        viewModelScope.launch {
             load()
         }
     }
 
-    suspend fun load(){
+    suspend fun load() {
         progress.value = true
-        creditsSvc?.getCreditEnable(period)?.takeIf { it.isNotEmpty() }?.let{
+        withContext(Dispatchers.IO) {
+            creditsSvc?.getCreditEnable(period)
+        }?.takeIf { it.isNotEmpty() }?.let {
             list.clear()
             val credits = it.map {
-                CreditPeriodGraceDTO(it, periodGraceSvc?.hasGracePeriod(it.id) ?: false)
+                CreditPeriodGraceDTO(
+                    it,
+                    withContext(Dispatchers.IO) { periodGraceSvc?.hasGracePeriod(it.id) } ?: false)
             }.sortedByDescending { it.credit.date }
             list.addAll(credits)
         }

--- a/credit/src/main/java/co/com/japl/module/credit/controllers/recap/RecapViewModel.kt
+++ b/credit/src/main/java/co/com/japl/module/credit/controllers/recap/RecapViewModel.kt
@@ -8,9 +8,10 @@ import co.com.japl.finances.iports.dtos.RecapCreditDTO
 import co.com.japl.finances.iports.inbounds.credit.ICreditPort
 import co.com.japl.module.credit.navigations.CreditList
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.CoroutineScope
+import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.time.YearMonth
 import androidx.lifecycle.SavedStateHandle
 import javax.inject.Inject
@@ -40,16 +41,18 @@ class RecapViewModel @Inject constructor(
         navController?.let(CreditList::periodCredits)
     }
 
-    fun execute() = CoroutineScope(Dispatchers.IO).launch {
+    fun execute() = viewModelScope.launch {
         progress.floatValue = 0.1f
         load()
         progress.floatValue = 1f
     }
 
-    suspend fun load(){
-        creditsSvc?.let{
+    suspend fun load() {
+        creditsSvc?.let { svc ->
             progress.floatValue = 0.2f
-            it.getCreditsEnables(yearMonth).takeIf { it.isNotEmpty() }?.let{
+            withContext(Dispatchers.IO) {
+                svc.getCreditsEnables(yearMonth)
+            }.takeIf { it.isNotEmpty() }?.let {
                 progress.floatValue = 0.7f
                 listCredits.clear()
                 progress.floatValue = 0.8f

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/Inputs/form/InputViewModel.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/Inputs/form/InputViewModel.kt
@@ -16,7 +16,10 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.runBlocking
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.time.LocalDate
 
 @HiltViewModel(assistedFactory = InputViewModel.Factory::class)
@@ -87,17 +90,23 @@ class InputViewModel @AssistedInject constructor(@Assisted private val codeAccou
         }
     }
 
-    fun main()= runBlocking  {
-        progress.value = 0.1f
-        execution()
-        progress.value = 1f
+    fun main() {
+        viewModelScope.launch {
+            progress.value = 0.1f
+            execution()
+            progress.value = 1f
+        }
     }
 
-    suspend fun execution(){
+    suspend fun execution() {
         date.value = DateUtils.localDateToStringDate(LocalDate.now())
-        kindOfPayment.value = navController.context.getString(MoreOptionsKindPaymentInput.MONTHLY.getName())
-        codeInput?.takeIf { it > 0 }?.let {
-            inputSvc.getById(codeInput)?.let {
+        kindOfPayment.value =
+            navController.context.getString(MoreOptionsKindPaymentInput.MONTHLY.getName())
+        codeInput?.takeIf { it > 0 }?.let { code ->
+            val result = withContext(Dispatchers.IO) {
+                inputSvc.getById(code)
+            }
+            result?.let {
                 _input = it
                 date.value = DateUtils.localDateToStringDate(it.date)
                 kindOfPayment.value = it.kindOf
@@ -107,7 +116,7 @@ class InputViewModel @AssistedInject constructor(@Assisted private val codeAccou
             }
         }
 
-            loader.value = false
+        loader.value = false
 
     }
 

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/Inputs/list/InputListModelView.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/Inputs/list/InputListModelView.kt
@@ -17,8 +17,9 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 
 @HiltViewModel(assistedFactory = InputListModelView.Factory::class)
 class InputListModelView @AssistedInject constructor(@Assisted private val context:Context, @Assisted val accountCode:Int, @Assisted private val navController: NavController?,private val inputSvc:IInputPort?) : ViewModel() {
@@ -72,22 +73,24 @@ class InputListModelView @AssistedInject constructor(@Assisted private val conte
         navController?.let{Input.navigate(accountCode,code,navController)}
     }
 
-    fun main()= runBlocking  {
-        progress.value = 0.1f
-        getItems()
-        progress.value = 1f
+    fun main() {
+        viewModelScope.launch {
+            progress.value = 0.1f
+            getItems()
+            progress.value = 1f
+        }
     }
 
     suspend fun getItems() {
         progress.value = 0.2f
-        inputSvc?.let{
-            _items.clear()
-            it.getInputs(accountCode).let {
-                _items.addAll(it.sortedByDescending { it.date })
-                progress.value = 0.7f
-                stateLoader.value = false
+        inputSvc?.let { svc ->
+            val result = withContext(Dispatchers.IO) {
+                svc.getInputs(accountCode)
             }
-
+            _items.clear()
+            _items.addAll(result.sortedByDescending { it.date })
+            progress.value = 0.7f
+            stateLoader.value = false
         }
         progress.value = 0.8f
     }

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/accounts/form/AccountViewModel.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/accounts/form/AccountViewModel.kt
@@ -12,7 +12,10 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.runBlocking
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.time.LocalDate
 
 @HiltViewModel(assistedFactory = AccountViewModel.Factory::class)
@@ -69,16 +72,21 @@ class AccountViewModel @AssistedInject constructor(@Assisted private val codeAcc
         }
     }
 
-    fun main() = runBlocking {
-        progress.value = 0.1f
-        execution()
-        progress.value = 1f
+    fun main() {
+        viewModelScope.launch {
+            progress.value = 0.1f
+            execution()
+            progress.value = 1f
+        }
     }
 
-    suspend fun execution(){
+    suspend fun execution() {
         progress.value = 0.2f
-        codeAccount?.takeIf { it > 0 }?.let{
-            accountSvc.getById(codeAccount)?.let{
+        codeAccount?.takeIf { it > 0 }?.let { code ->
+            val result = withContext(Dispatchers.IO) {
+                accountSvc.getById(code)
+            }
+            result?.let {
                 progress.value = 0.6f
                 _item = it
                 name.value = it.name

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/accounts/list/AccountViewModel.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/accounts/list/AccountViewModel.kt
@@ -10,7 +10,10 @@ import co.com.japl.finances.iports.inbounds.inputs.IAccountPort
 import co.com.japl.finances.iports.inbounds.inputs.IInputPort
 import co.com.japl.module.paid.navigations.Account
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.runBlocking
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @HiltViewModel
@@ -43,16 +46,21 @@ class AccountViewModel @Inject constructor(private val accountSvc:IAccountPort?,
     }
 
 
-    fun main() = runBlocking {
-        progress.value = 0.1f
-        services()
-        progress.value = 1f
+    fun main() {
+        viewModelScope.launch {
+            progress.value = 0.1f
+            services()
+            progress.value = 1f
+        }
     }
 
-    suspend fun services(){
+    suspend fun services() {
         progress.value = 0.2f
-        accountSvc?.let {
-            accountSvc.getAll()?.takeIf { it.isNotEmpty() }?.let {
+        accountSvc?.let { svc ->
+            val result = withContext(Dispatchers.IO) {
+                svc.getAll()
+            }
+            result?.takeIf { it.isNotEmpty() }?.let {
                 list.clear()
                 list.addAll(it)
                 loading.value = false

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/monthly/list/MonthlyViewModel.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/monthly/list/MonthlyViewModel.kt
@@ -28,7 +28,6 @@ import co.com.japl.ui.utils.DateUtils
 import co.com.japl.ui.utils.NumbersUtil
 import kotlinx.coroutines.Dispatchers
 
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.time.YearMonth
@@ -87,49 +86,63 @@ class MonthlyViewModel(private val period:YearMonth, private val paidSvc: IPaidP
     }
 
 
-    fun main()= runBlocking {
-        progressStatus.value = 0.0f
-        execute()
-        progressStatus.value = 0.6f
-        readSms()
-        progressStatus.value = 0.8f
+    fun main() {
+        viewModelScope.launch {
+            progressStatus.value = 0.0f
+            execute()
+            progressStatus.value = 0.6f
+            readSms()
+            progressStatus.value = 0.8f
 
-        progressStatus.value = 1.0f
+            progressStatus.value = 1.0f
+        }
     }
 
     suspend fun execute() {
-        periodState.value = "${period?.month?.getDisplayName(TextStyle.FULL, Locale("es","CO"))} ${period?.year}"
-        accountSvc?.let {
-            it.getAllActive().takeIf { it.isNotEmpty() }?.let { list ->
+        periodState.value =
+            "${period?.month?.getDisplayName(TextStyle.FULL, Locale("es", "CO"))} ${period?.year}"
+        accountSvc?.let { svc ->
+            val list = withContext(Dispatchers.IO) {
+                svc.getAllActive()
+            }
+            list.takeIf { it.isNotEmpty() }?.let { activeList ->
                 accountList.clear()
-                _accounts = list
-                list.forEach {
-                    accountList.add(Pair(it.id,it.name))
+                _accounts = activeList
+                activeList.forEach {
+                    accountList.add(Pair(it.id, it.name))
                 }
-                list.takeIf { it.isNotEmpty() && it.size == 1 }?.let {
+                activeList.takeIf { it.isNotEmpty() && it.size == 1 }?.let {
                     accountState.value = it.first()
                 }
                 progressStatus.value = 0.3f
             }
         }
 
-        accountState.value?.let {account->
-            paidSvc?.let {
-               period?.let {_period->
-                   it.getRecap(codeAccount = account.id, period = _period)?.let { recap ->
-                       countState.value = recap.count
-                       paidTotalState.value = recap.totalPaid
+        accountState.value?.let { account ->
+            paidSvc?.let { svc ->
+                period?.let { _period ->
+                    val recap = withContext(Dispatchers.IO) {
+                        svc.getRecap(codeAccount = account.id, period = _period)
+                    }
+                    recap?.let {
+                        countState.value = it.count
+                        paidTotalState.value = it.totalPaid
 
-                       progressStatus.value = 0.6f
-                   }
-                   it.getListGraph(codeAccount = account.id, period = _period).takeIf{it.isNotEmpty()}?.forEach (listGraph::add)
-               }
+                        progressStatus.value = 0.6f
+                    }
+                    withContext(Dispatchers.IO) {
+                        svc.getListGraph(codeAccount = account.id, period = _period)
+                    }.takeIf { it.isNotEmpty() }?.forEach(listGraph::add)
+                }
 
             }
-            incomesSvc?.let {
+            incomesSvc?.let { svc ->
                 period?.let { _period ->
-                    it.getTotalInputs(account.id, _period)?.let { total ->
-                        incomesTotalState.value = total
+                    val total = withContext(Dispatchers.IO) {
+                        svc.getTotalInputs(account.id, _period)
+                    }
+                    total?.let {
+                        incomesTotalState.value = it
                         progressStatus.value = 0.7f
                     }
                 }
@@ -139,11 +152,13 @@ class MonthlyViewModel(private val period:YearMonth, private val paidSvc: IPaidP
         loaderState.value = false
     }
 
-    suspend fun readSms(){
+    suspend fun readSms() {
         try {
-            smsSvc?.read(prefs?.paidSMSDaysRead?:0)
-        }catch (e:Exception){
-            Log.e(javaClass.name,e.message,e)
+            withContext(Dispatchers.IO) {
+                smsSvc?.read(prefs?.paidSMSDaysRead ?: 0)
+            }
+        } catch (e: Exception) {
+            Log.e(javaClass.name, e.message, e)
         }
     }
 }

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/paid/list/PaidViewModel.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/paid/list/PaidViewModel.kt
@@ -25,7 +25,6 @@ import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import java.time.LocalDateTime
 import java.time.YearMonth
@@ -170,7 +169,7 @@ class PaidViewModel @AssistedInject constructor(@Assisted private val accountCod
     }
 
     fun main() {
-        periodOfList.value  = period.format(DateTimeFormatter.ofPattern("MMMM yyyy", Locale("es","CO")))
+        periodOfList.value = period.format(DateTimeFormatter.ofPattern("MMMM yyyy", Locale("es", "CO")))
         progressStatus.value = 0.0f
         viewModelScope.launch {
             execute()

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/checkpaids/CheckList.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/checkpaids/CheckList.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -58,7 +59,7 @@ fun CheckList(viewModel:CheckListViewModel){
     val loaderProgressStatus = remember { viewModel.loaderProgressStatus }
     val progressState = remember { viewModel.progression }
 
-    CoroutineScope(Dispatchers.IO).launch {
+    LaunchedEffect(Unit) {
         viewModel.main()
     }
 

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/monthly/list/Monthly.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/monthly/list/Monthly.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -53,7 +54,7 @@ fun Monthly(viewModel:MonthlyViewModel) {
         viewModel.progressStatus
     }
 
-    CoroutineScope(Dispatchers.IO).launch{
+    LaunchedEffect(Unit) {
         viewModel.main()
     }
 

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/paid/form/Paid.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/paid/form/Paid.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.Cancel
 import androidx.compose.material.icons.rounded.CleaningServices
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -39,7 +40,7 @@ fun Paid(viewModel:PaidViewModel) {
     val progresStatus  = remember{viewModel.progressStatus}
     val loaderState = remember {viewModel.loading}
 
-    CoroutineScope(Dispatchers.IO).launch {
+    LaunchedEffect(Unit) {
         viewModel.main()
     }
 

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/paid/list/Paid.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/paid/list/Paid.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.rounded.MoreVert
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -68,7 +69,7 @@ fun Paid(viewModel:PaidViewModel) {
         viewModel.loaderState
     }
 
-    CoroutineScope(Dispatchers.IO).launch{
+    LaunchedEffect(Unit) {
         viewModel.main()
     }
 

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/periods/list/Period.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/periods/list/Period.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.rounded.MoreVert
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshots.SnapshotStateMap
@@ -55,7 +56,7 @@ fun Period(viewModel:PeriodsViewModel){
         viewModel.loader
     }
 
-    CoroutineScope(Dispatchers.IO).launch{
+    LaunchedEffect(Unit) {
         viewModel.main()
     }
 

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/sms/list/SMS.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/sms/list/SMS.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.MoreVert
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -53,7 +54,7 @@ fun SMS(viewModel:SmsViewModel) {
     val loader = remember {viewModel.load}
     val progress = remember {viewModel.progress}
 
-    CoroutineScope(Dispatchers.IO).launch {
+    LaunchedEffect(Unit) {
         viewModel.main()
     }
 


### PR DESCRIPTION
Resolved the fatal `java.lang.IllegalStateException: LayoutNode should be attached to an owner` crash by correcting coroutine management and threading in Jetpack Compose.

Key changes:
- Replaced manual coroutine launches in Composable bodies with `LaunchedEffect`.
- Migrated ViewModels from `runBlocking` to `viewModelScope.launch`.
- Ensured proper use of `withContext(Dispatchers.IO)` for repository calls.
- Removed compiler-generated artifacts.
- Verified fixes with unit tests across multiple modules.

---
*PR created automatically by Jules for task [16944415027314385533](https://jules.google.com/task/16944415027314385533) started by @nano871022*