### PR TITLE
Add configurable validation days to Email Credit Card validation popup

### DIFF
--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/emailcreditcard/form/EmailCreditCardViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/emailcreditcard/form/EmailCreditCardViewModel.kt
@@ -65,6 +65,9 @@ class EmailCreditCardViewModel @AssistedInject constructor(
     val showPopup = mutableStateOf(false)
     val validating = mutableStateOf(false)
     val validationResults = mutableStateListOf<EmailValidationDTO>()
+    val numDaysRead = mutableStateOf("30")
+    val errorNumDaysRead = mutableStateOf(false)
+    val showDaysField = mutableStateOf(false)
 
     val aiFailed = mutableStateOf(false)
     val emailSamples = mutableStateListOf<Pair<String, Boolean>>()
@@ -76,7 +79,7 @@ class EmailCreditCardViewModel @AssistedInject constructor(
         if (sender.value.isNotEmpty()) {
             viewModelScope.launch {
                 withContext(Dispatchers.IO) {
-                    svc?.getEmailList(sender.value, subjectPattern.value, 30)
+                    svc?.getEmailList(sender.value, subjectPattern.value, numDaysRead.value.toIntOrNull() ?: 30)
                 }?.let { list ->
                     emailSamples.clear()
                     list.map { Pair(it, false) }.forEach(emailSamples::add)
@@ -178,9 +181,15 @@ class EmailCreditCardViewModel @AssistedInject constructor(
         showPopup.value = false
         validating.value = false
         validationResults.clear()
+        numDaysRead.value = "30"
+        errorNumDaysRead.value = false
+        showDaysField.value = false
     }
 
     fun validatePatternWithMessages() {
+        errorNumDaysRead.value = numDaysRead.value.toIntOrNull() == null
+        if (errorNumDaysRead.value) return
+
         validate()
         emailCreditCard?.let { dto ->
             viewModelScope.launch {
@@ -189,7 +198,7 @@ class EmailCreditCardViewModel @AssistedInject constructor(
                 validationResults.clear()
                 runCatching {
                     withContext(Dispatchers.IO) {
-                        svc?.validateMessagePattern(dto, 30) ?: emptyList()
+                        svc?.validateMessagePattern(dto, numDaysRead.value.toIntOrNull() ?: 30) ?: emptyList()
                     }
                 }.onFailure { e ->
                     validating.value = false

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/email/form/EmailBought.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/email/form/EmailBought.kt
@@ -1,12 +1,15 @@
 package co.com.japl.module.creditcard.views.email.form
 
 import android.content.res.Configuration
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.DirectionsRun
 import androidx.compose.material.icons.rounded.Add
@@ -21,6 +24,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -37,6 +41,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -282,6 +287,9 @@ private fun ValidationPopup(viewModel: EmailCreditCardViewModel) {
     val showPopup = viewModel.showPopup
     val validating = viewModel.validating.value
     val validationResults = viewModel.validationResults
+    val numDaysRead = viewModel.numDaysRead
+    val errorNumDaysRead = viewModel.errorNumDaysRead
+    val showDaysField = viewModel.showDaysField
 
     Popup(title = R.string.validation_results_title, state = showPopup) {
         Column(
@@ -302,10 +310,53 @@ private fun ValidationPopup(viewModel: EmailCreditCardViewModel) {
                     )
                 }
             } else {
-                Text(text=viewModel.bodyPattern.value,
-                    color = MaterialTheme.colorScheme.onPrimary,
-                    fontSize = MaterialTheme.typography.bodySmall.fontSize,
-                    modifier = Modifier.fillMaxWidth())
+                Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.clickable { showDaysField.value = !showDaysField.value }) {
+                    Text(text=viewModel.bodyPattern.value,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                        fontSize = MaterialTheme.typography.bodySmall.fontSize,
+                        modifier = Modifier.weight(1f))
+
+                    Box(modifier = Modifier
+                        .padding(horizontal = Dimensions.PADDING_SHORT)
+                        .width(Dimensions.DIVIDER_THICKNESS)
+                        .height(Dimensions.ICON_SIZE_MEDIUM)
+                        .background(MaterialTheme.colorScheme.onPrimary)
+                    )
+
+                    Icon(imageVector = Icons.Rounded.ArrowDownward, contentDescription = null, tint = MaterialTheme.colorScheme.onPrimary)
+                }
+
+                if (showDaysField.value) {
+                    FieldText(
+                        title = stringResource(R.string.days_email_read),
+                        value = numDaysRead.value,
+                        hasErrorState = errorNumDaysRead,
+                        keyboardType = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        modifier = Modifier.fillMaxWidth().padding(top = Dimensions.PADDING_SHORT)
+                    ) {
+                        numDaysRead.value = it
+                    }
+
+                    OutlinedButton(
+                        onClick = { viewModel.validatePatternWithMessages() },
+                        modifier = Modifier
+                            .align(alignment = Alignment.End)
+                            .padding(top = Dimensions.PADDING_TOP)
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Rounded.DirectionsRun,
+                            contentDescription = stringResource(id = R.string.validate),
+                            tint = MaterialTheme.colorScheme.onPrimary
+                        )
+
+                        Text(
+                            text = stringResource(id = R.string.validate),
+                            color = MaterialTheme.colorScheme.onPrimary,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
+                }
 
                 Carousel(
                     size = validationResults.size,

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,8 +18,8 @@ android {
         applicationId "co.japl.android.myapplication"
         minSdk 26
         targetSdk 36
-        versionCode 4_09_02_186
-        versionName "V 4.09.02 build 186 Added request permisison for gmail and drive when is record or one by one"
+        versionCode 4_09_02_187
+        versionName "V 4.09.02 build 187 Added request permisison for gmail and drive when is record or one by one"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
This change adds a configurable field to the validation popup in the Email Credit Card form, allowing users to specify the number of days to look back when validating email patterns. Previously, this value was hardcoded to 30 days. The new field is hidden by default and can be toggled using a clickable row with a vertical separator and an arrow icon, matching existing UI patterns in the app (like AI model selection). A dedicated validation button was also added within the expanded area to allow for immediate re-validation after changing the number of days.

---
*PR created automatically by Jules for task [113913527733023843](https://jules.google.com/task/113913527733023843) started by @nano871022*