### PR TITLE
Update Google Drive scopes to DRIVE_APPDATA

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,8 +18,8 @@ android {
         applicationId "co.japl.android.myapplication"
         minSdk 26
         targetSdk 36
-        versionCode 4_09_02_187
-        versionName "V 4.09.02 build 187 Added request permisison for gmail and drive when is record or one by one"
+        versionCode 4_09_02_188
+        versionName "V 4.09.02 build 188 Added request permisison for gmail and drive when is record or one by one"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/japl-android-finances-services/src/main/java/co/japl/android/finances/services/implement/GoogleDriveServiceImpl.kt
+++ b/japl-android-finances-services/src/main/java/co/japl/android/finances/services/implement/GoogleDriveServiceImpl.kt
@@ -31,7 +31,7 @@ import javax.inject.Inject
 class GoogleDriveServiceImpl @Inject constructor(private val context:Context, private val dbConnect: ConnectDB) : IGoogleDriveService {
     companion object {
         const val PARAMETER_FOLDER = "appDataFolder"
-        private val SCOPES = listOf(DriveScopes.DRIVE_FILE, DriveScopes.DRIVE_APPDATA)
+        private val SCOPES = listOf(DriveScopes.DRIVE_APPDATA)
     }
 
     override suspend fun stats(): List<Pair<String, Long>> {

--- a/japl-android-finances-services/src/main/java/co/japl/android/finances/services/implement/GoogleLoginService.kt
+++ b/japl-android-finances-services/src/main/java/co/japl/android/finances/services/implement/GoogleLoginService.kt
@@ -19,7 +19,6 @@ class GoogleLoginService(private val activity:Activity, override val RC_SIGN_IN:
         .requestEmail()
         .requestScopes(
             Scope(GmailScopes.GMAIL_READONLY),
-            Scope(DriveScopes.DRIVE_FILE),
             Scope(DriveScopes.DRIVE_APPDATA)
         )
         .build()
@@ -45,7 +44,6 @@ class GoogleLoginService(private val activity:Activity, override val RC_SIGN_IN:
     override fun getConnection(): Any? = getIntent()
     override fun requestPermissions(activity: Activity) {
         val scopes = arrayOf(
-            Scope(DriveScopes.DRIVE_FILE),
             Scope(DriveScopes.DRIVE_APPDATA),
             Scope(GmailScopes.GMAIL_READONLY)
         )


### PR DESCRIPTION
Changed requested scopes in Google Login and Google Drive services to use DRIVE_APPDATA instead of DRIVE_FILE to avoid restricted scope verification processes.

---
*PR created automatically by Jules for task [15143341749153614512](https://jules.google.com/task/15143341749153614512) started by @nano871022*