### PR TITLE
Delegate Gmail permission checks to ports and adapters layer

### DIFF
--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/emailcreditcard/list/EmailListCreditCardViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/emailcreditcard/list/EmailListCreditCardViewModel.kt
@@ -17,9 +17,8 @@ class EmailListCreditCardViewModel(val svc: IEmailCreditCardPort?, val navContro
 
     val load = mutableStateOf(true)
 
-    fun hasGmailPermission(context: android.content.Context): Boolean {
-        val account = com.google.android.gms.auth.api.signin.GoogleSignIn.getLastSignedInAccount(context)
-        return account?.grantedScopes?.any { it.scopeUri.contains("gmail") } ?: false
+    fun hasGmailPermission(): Boolean {
+        return svc?.hasGmailPermission() ?: false
     }
 
     fun navigateToLogin() {

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/emailcreditcard/list/EmailListCreditCardViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/emailcreditcard/list/EmailListCreditCardViewModel.kt
@@ -16,6 +16,17 @@ import kotlinx.coroutines.withContext
 class EmailListCreditCardViewModel(val svc: IEmailCreditCardPort?, val navController: NavController?) : ViewModel(){
 
     val load = mutableStateOf(true)
+
+    fun hasGmailPermission(context: android.content.Context): Boolean {
+        val account = com.google.android.gms.auth.api.signin.GoogleSignIn.getLastSignedInAccount(context)
+        return account?.grantedScopes?.any { it.scopeUri.contains("gmail") } ?: false
+    }
+
+    fun navigateToLogin() {
+        navController?.let {
+            co.com.japl.module.creditcard.navigations.LoginNavigation.navigateToLogin(it)
+        }
+    }
     val list = mutableListOf<EmailCreditCardDTO>()
 
     fun create(){

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/emailcreditcard/list/EmailListCreditCardViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/controllers/emailcreditcard/list/EmailListCreditCardViewModel.kt
@@ -18,8 +18,7 @@ class EmailListCreditCardViewModel(val svc: IEmailCreditCardPort?, val navContro
     val load = mutableStateOf(true)
 
     fun hasGmailPermission(context: android.content.Context): Boolean {
-        val account = com.google.android.gms.auth.api.signin.GoogleSignIn.getLastSignedInAccount(context)
-        return account?.grantedScopes?.any { it.scopeUri.contains("gmail") } ?: false
+        return svc?.isEmailAccessGranted() ?: false
     }
 
     fun navigateToLogin() {

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/navigations/LoginNavigation.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/navigations/LoginNavigation.kt
@@ -1,0 +1,15 @@
+package co.com.japl.module.creditcard.navigations
+
+import androidx.core.net.toUri
+import androidx.navigation.NavController
+import androidx.navigation.NavDeepLinkRequest
+import co.com.japl.module.creditcard.R
+
+object LoginNavigation {
+    fun navigateToLogin(navController: NavController) {
+        val request = NavDeepLinkRequest.Builder
+            .fromUri(navController.context.getString(R.string.navigate_to_login).toUri())
+            .build()
+        navController.navigate(request)
+    }
+}

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/bought/PopUpView.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/bought/PopUpView.kt
@@ -213,7 +213,7 @@ fun PopupSetting(viewModel: SettingsViewModel,state: MutableState<Boolean>) {
     val daysEmailRead = remember { viewModel.daysEmailRead }
     val errorDaysEmailRead = remember { viewModel.errorDaysEmailRead }
     val context = LocalContext.current
-    val hasGmailPermission = remember { viewModel.hasGmailPermission(context) }
+    val hasGmailPermission = remember { viewModel.hasGmailPermission() }
 
     Popup(title = R.string.settings_credit_card_boughts, state = state) {
         Scaffold(

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/bought/PopUpView.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/bought/PopUpView.kt
@@ -213,8 +213,7 @@ fun PopupSetting(viewModel: SettingsViewModel,state: MutableState<Boolean>) {
     val daysEmailRead = remember { viewModel.daysEmailRead }
     val errorDaysEmailRead = remember { viewModel.errorDaysEmailRead }
     val context = LocalContext.current
-    val account = remember { com.google.android.gms.auth.api.signin.GoogleSignIn.getLastSignedInAccount(context) }
-    val hasGmailPermission = remember { account?.grantedScopes?.any { it.scopeUri.contains("gmail") } ?: false }
+    val hasGmailPermission = remember { viewModel.hasGmailPermission(context) }
 
     Popup(title = R.string.settings_credit_card_boughts, state = state) {
         Scaffold(

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/bought/PopUpView.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/bought/PopUpView.kt
@@ -213,13 +213,18 @@ fun PopupSetting(viewModel: SettingsViewModel,state: MutableState<Boolean>) {
     val daysEmailRead = remember { viewModel.daysEmailRead }
     val errorDaysEmailRead = remember { viewModel.errorDaysEmailRead }
     val context = LocalContext.current
+    val account = remember { com.google.android.gms.auth.api.signin.GoogleSignIn.getLastSignedInAccount(context) }
+    val hasGmailPermission = remember { account?.grantedScopes?.any { it.scopeUri.contains("gmail") } ?: false }
+
     Popup(title = R.string.settings_credit_card_boughts, state = state) {
         Scaffold(
             floatingActionButton = {
                 Row {
-                    FloatButton(imageVector = Icons.Rounded.ForwardToInbox, descriptionIcon = R.string.read_email) {
-                        viewModel.readEmail(context)
-                        state.value = false
+                    if (hasGmailPermission) {
+                        FloatButton(imageVector = Icons.Rounded.ForwardToInbox, descriptionIcon = R.string.read_email) {
+                            viewModel.readEmail(context)
+                            state.value = false
+                        }
                     }
                     FloatButton(imageVector = Icons.Rounded.Save, descriptionIcon = R.string.save) {
                         viewModel.save(context)
@@ -257,15 +262,17 @@ fun PopupSetting(viewModel: SettingsViewModel,state: MutableState<Boolean>) {
                         daysSmsRead.value = it
                     },modifier= Modifier.padding(top=Dimensions.PADDING_SHORT).fillMaxWidth())
 
-                FieldText(title = stringResource(id = R.string.days_email_read),
-                    value = "${daysEmailRead.value}",
-                    hasErrorState = errorDaysEmailRead,
-                    keyboardType = KeyboardOptions(keyboardType = KeyboardType.Number),
-                    icon = Icons.Rounded.Cancel,
-                    validation = {viewModel.validation()},
-                    callback = {
-                        daysEmailRead.value = it
-                    },modifier= Modifier.padding(top=Dimensions.PADDING_SHORT).fillMaxWidth())
+                if (hasGmailPermission) {
+                    FieldText(title = stringResource(id = R.string.days_email_read),
+                        value = "${daysEmailRead.value}",
+                        hasErrorState = errorDaysEmailRead,
+                        keyboardType = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        icon = Icons.Rounded.Cancel,
+                        validation = {viewModel.validation()},
+                        callback = {
+                            daysEmailRead.value = it
+                        },modifier= Modifier.padding(top=Dimensions.PADDING_SHORT).fillMaxWidth())
+                }
             }
         }
     }

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/bought/SettingViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/bought/SettingViewModel.kt
@@ -17,9 +17,8 @@ class SettingsViewModel(private val prefs: Prefs,private val emailCCSvc: IEmailC
 
     val state = mutableStateOf(false)
 
-    fun hasGmailPermission(context: android.content.Context): Boolean {
-        val account = com.google.android.gms.auth.api.signin.GoogleSignIn.getLastSignedInAccount(context)
-        return account?.grantedScopes?.any { it.scopeUri.contains("gmail") } ?: false
+    fun hasGmailPermission(): Boolean {
+        return emailCCSvc.hasGmailPermission()
     }
 
     val daysSmsRead = mutableStateOf("${prefs.creditCardSMSDaysRead}")

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/bought/SettingViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/bought/SettingViewModel.kt
@@ -17,6 +17,11 @@ class SettingsViewModel(private val prefs: Prefs,private val emailCCSvc: IEmailC
 
     val state = mutableStateOf(false)
 
+    fun hasGmailPermission(context: android.content.Context): Boolean {
+        val account = com.google.android.gms.auth.api.signin.GoogleSignIn.getLastSignedInAccount(context)
+        return account?.grantedScopes?.any { it.scopeUri.contains("gmail") } ?: false
+    }
+
     val daysSmsRead = mutableStateOf("${prefs.creditCardSMSDaysRead}")
     val errorDaysSmsRead = mutableStateOf(false)
     val daysEmailRead = mutableStateOf("${prefs.creditCardEmailDaysRead}")

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/bought/SettingViewModel.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/bought/SettingViewModel.kt
@@ -18,8 +18,7 @@ class SettingsViewModel(private val prefs: Prefs,private val emailCCSvc: IEmailC
     val state = mutableStateOf(false)
 
     fun hasGmailPermission(context: android.content.Context): Boolean {
-        val account = com.google.android.gms.auth.api.signin.GoogleSignIn.getLastSignedInAccount(context)
-        return account?.grantedScopes?.any { it.scopeUri.contains("gmail") } ?: false
+        return emailCCSvc.isEmailAccessGranted()
     }
 
     val daysSmsRead = mutableStateOf("${prefs.creditCardSMSDaysRead}")

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/email/list/EmailList.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/email/list/EmailList.kt
@@ -6,6 +6,14 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.text.style.TextAlign
+import androidx.navigation.NavDeepLinkRequest
+import androidx.core.net.toUri
+import com.google.android.gms.auth.api.signin.GoogleSignIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.Button
 import androidx.compose.material3.Card
@@ -24,7 +32,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.res.stringResource
@@ -49,15 +56,45 @@ import co.com.japl.ui.theme.values.Dimensions
 @Composable
 fun EmailList(viewModel: EmailListCreditCardViewModel){
     val load = remember { viewModel.load}
+    val context = LocalContext.current
+    val account = remember { GoogleSignIn.getLastSignedInAccount(context) }
+    val hasGmailPermission = remember { account?.grantedScopes?.any { it.scopeUri.contains("gmail") } ?: false }
 
-    LoadingProgress(
-        message = R.string.loading_data,
-        showProgress = load,
-        execute = viewModel::execution
-    ) {
-        BodyMain(viewModel)
+    if (!hasGmailPermission) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "No tienes permisos para usar esta funcionalidad activala en la interface de inicio de sesion",
+                style = MaterialTheme.typography.bodyLarge,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(bottom = 16.dp),
+                color = MaterialTheme.colorScheme.onBackground
+            )
+            Button(onClick = {
+                viewModel.navController?.let { nav ->
+                    val request = NavDeepLinkRequest.Builder
+                        .fromUri("android-app://co.com.japl.finanzas.module.app/google_login".toUri())
+                        .build()
+                    nav.navigate(request)
+                }
+            }) {
+                Text(text = "Ir a Inicio de Sesión")
+            }
+        }
+    } else {
+        LoadingProgress(
+            message = R.string.loading_data,
+            showProgress = load,
+            execute = viewModel::execution
+        ) {
+            BodyMain(viewModel)
+        }
     }
-
 }
 
 @Composable

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/email/list/EmailList.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/email/list/EmailList.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.text.style.TextAlign
 import androidx.navigation.NavDeepLinkRequest
 import androidx.core.net.toUri
-import com.google.android.gms.auth.api.signin.GoogleSignIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.Button
 import androidx.compose.material3.Card
@@ -56,8 +55,7 @@ import co.com.japl.ui.theme.values.Dimensions
 @Composable
 fun EmailList(viewModel: EmailListCreditCardViewModel){
     val load = remember { viewModel.load}
-    val context = LocalContext.current
-    val hasGmailPermission = remember { viewModel.hasGmailPermission(context) }
+    val hasGmailPermission = remember { viewModel.hasGmailPermission() }
 
     if (!hasGmailPermission) {
         Column(

--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/email/list/EmailList.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/email/list/EmailList.kt
@@ -57,8 +57,7 @@ import co.com.japl.ui.theme.values.Dimensions
 fun EmailList(viewModel: EmailListCreditCardViewModel){
     val load = remember { viewModel.load}
     val context = LocalContext.current
-    val account = remember { GoogleSignIn.getLastSignedInAccount(context) }
-    val hasGmailPermission = remember { account?.grantedScopes?.any { it.scopeUri.contains("gmail") } ?: false }
+    val hasGmailPermission = remember { viewModel.hasGmailPermission(context) }
 
     if (!hasGmailPermission) {
         Column(
@@ -69,21 +68,16 @@ fun EmailList(viewModel: EmailListCreditCardViewModel){
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Text(
-                text = "No tienes permisos para usar esta funcionalidad activala en la interface de inicio de sesion",
+                text = stringResource(id = R.string.no_gmail_permission_error),
                 style = MaterialTheme.typography.bodyLarge,
                 textAlign = TextAlign.Center,
                 modifier = Modifier.padding(bottom = 16.dp),
                 color = MaterialTheme.colorScheme.onBackground
             )
             Button(onClick = {
-                viewModel.navController?.let { nav ->
-                    val request = NavDeepLinkRequest.Builder
-                        .fromUri("android-app://co.com.japl.finanzas.module.app/google_login".toUri())
-                        .build()
-                    nav.navigate(request)
-                }
+                viewModel.navigateToLogin()
             }) {
-                Text(text = "Ir a Inicio de Sesión")
+                Text(text = stringResource(id = R.string.go_to_login_button))
             }
         }
     } else {

--- a/CreditCardModule/src/main/res/values/strings.xml
+++ b/CreditCardModule/src/main/res/values/strings.xml
@@ -180,4 +180,7 @@ Messages:
     <string name="description_simulator">Permite realizar simulaciones de cambios de cuotras sin que afecte los registros esto queda en memoria y se eliminan cuando se cambie el boton o se cierre la aplicación</string>
     <string name="days_sms_read">Dias leer SMS</string>
     <string name="days_email_read">Dias leer Correo Electrónico</string>
+    <string name="navigate_to_login">android-app://co.com.japl.finanzas.module.app/google_login</string>
+    <string name="no_gmail_permission_error">No tienes permisos para usar esta funcionalidad activala en la interface de inicio de sesion</string>
+    <string name="go_to_login_button">Ir a Inicio de Sesión</string>
 </resources>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -191,7 +191,9 @@
         android:id="@+id/item_menu_setting_google_login"
         android:name="co.japl.android.myapplication.finanzas.fragment.GDriveConnectFragment"
         android:label="@string/title_toolbar_account_google"
-        tools:layout="@layout/fragment_g_drive_connect" />
+        tools:layout="@layout/fragment_g_drive_connect" >
+        <deepLink app:uri="android-app://co.com.japl.finanzas.module.app/google_login" />
+    </fragment>
     <fragment
         android:id="@+id/creditCardSettingFragment"
         android:name="co.com.japl.module.creditcard.fragments.CreditCardSettingFragment"

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/adapters/inbound/implement/creditcard/EmailCreditCard.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/adapters/inbound/implement/creditcard/EmailCreditCard.kt
@@ -8,6 +8,8 @@ import javax.inject.Inject
 
 class EmailCreditCard @Inject constructor(val svc: IEmailCreditCard) : IEmailCreditCardPort {
 
+    override fun hasGmailPermission(): Boolean = svc.hasGmailPermission()
+
     override fun validateMessagePattern(dto: EmailCreditCardDTO, numDaysRead: Int): List<EmailValidationDTO> {
         require(dto.bodyPattern.isNotEmpty()){"Need pattern for find in message"}
         require(dto.subjectPattern.isNotEmpty()){"Need pattern for find in email"}

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/adapters/inbound/implement/creditcard/EmailCreditCard.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/adapters/inbound/implement/creditcard/EmailCreditCard.kt
@@ -64,4 +64,8 @@ class EmailCreditCard @Inject constructor(val svc: IEmailCreditCard) : IEmailCre
     override fun read(numDaysRead: Int) {
         svc.read(numDaysRead)
     }
+
+    override fun isEmailAccessGranted(): Boolean {
+        return svc.isEmailAccessGranted()
+    }
 }

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/adapters/inbound/implement/paid/EmailPaid.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/adapters/inbound/implement/paid/EmailPaid.kt
@@ -7,6 +7,8 @@ import co.japl.finances.core.usercases.interfaces.paid.IEmailPaid
 import javax.inject.Inject
 
 class EmailPaid @Inject constructor(val svc: IEmailPaid) : IEmailPaidPort {
+    override fun hasGmailPermission(): Boolean = svc.hasGmailPermission()
+
     override fun create(dto: EmailPaidDTO): Int = svc.create(dto)
 
     override fun update(dto: EmailPaidDTO): Boolean = svc.update(dto)

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/adapters/inbound/implement/paid/EmailPaid.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/adapters/inbound/implement/paid/EmailPaid.kt
@@ -28,4 +28,8 @@ class EmailPaid @Inject constructor(val svc: IEmailPaid) : IEmailPaidPort {
     override fun read(numDaysRead: Int) {
         svc.read(numDaysRead)
     }
+
+    override fun isEmailAccessGranted(): Boolean {
+        return svc.isEmailAccessGranted()
+    }
 }

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/implement/creditcard/EmailCreditCardImpl.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/implement/creditcard/EmailCreditCardImpl.kt
@@ -13,6 +13,8 @@ import java.time.LocalDateTime
 import javax.inject.Inject
 
 class EmailCreditCardImpl @Inject constructor(val svc: IEmailCreditCardPort, val messageSvc: IEmailCreditCardPattern, val boughtSmsSvc: IBoughtSms) : IEmailCreditCard {
+    override fun hasGmailPermission(): Boolean = messageSvc.hasGmailPermission()
+
     override fun create(dto: EmailCreditCardDTO): Int = svc.create(dto)
 
     override fun update(dto: EmailCreditCardDTO): Boolean =svc.update(dto)

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/implement/creditcard/EmailCreditCardImpl.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/implement/creditcard/EmailCreditCardImpl.kt
@@ -31,6 +31,10 @@ class EmailCreditCardImpl @Inject constructor(val svc: IEmailCreditCardPort, val
 
     override fun getEmailList(sender: String, subject: String, numDaysRead: Int): List<Pair<String, LocalDateTime>> = messageSvc.getEmailList(sender, subject, numDaysRead)
 
+    override fun isEmailAccessGranted(): Boolean {
+        return messageSvc.isEmailAccessGranted()
+    }
+
     override fun read(numDaysRead: Int) {
         val startDate = LocalDate.now().minusDays(numDaysRead.toLong())
         svc.getAll().filter { it.active }.forEach { emailConfig ->

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/implement/paid/EmailPaidImpl.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/implement/paid/EmailPaidImpl.kt
@@ -12,6 +12,8 @@ import java.time.LocalDateTime
 import javax.inject.Inject
 
 class EmailPaidImpl @Inject constructor(val svc: IEmailPaidPort, val messageSvc: IEmailPaidPattern, val paidSmsSvc: ISms2) : IEmailPaid {
+    override fun hasGmailPermission(): Boolean = messageSvc.hasGmailPermission()
+
     override fun create(dto: EmailPaidDTO): Int = svc.create(dto)
 
     override fun update(dto: EmailPaidDTO): Boolean = svc.update(dto)

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/implement/paid/EmailPaidImpl.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/implement/paid/EmailPaidImpl.kt
@@ -30,6 +30,10 @@ class EmailPaidImpl @Inject constructor(val svc: IEmailPaidPort, val messageSvc:
 
     override fun getEmailList(sender: String, subject: String, numDaysRead: Int): List<Pair<String, LocalDateTime>> = messageSvc.getEmailList(sender, subject, numDaysRead)
 
+    override fun isEmailAccessGranted(): Boolean {
+        return messageSvc.isEmailAccessGranted()
+    }
+
     override fun read(numDaysRead: Int) {
         svc.getAll().filter { it.active }.forEach { emailConfig ->
             messageSvc.validateMessagePattern(emailConfig, numDaysRead).filter { it.matched }.forEach { validation ->

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/interfaces/creditcard/IEmailCreditCard.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/interfaces/creditcard/IEmailCreditCard.kt
@@ -6,6 +6,8 @@ import java.time.LocalDateTime
 
 interface IEmailCreditCard {
 
+    fun hasGmailPermission(): Boolean
+
     fun validateMessagePattern(dto: EmailCreditCardDTO, numDaysRead: Int): List<EmailValidationDTO>
 
     fun getEmailList(sender: String, subject: String, numDaysRead: Int): List<Pair<String, LocalDateTime>>

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/interfaces/creditcard/IEmailCreditCard.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/interfaces/creditcard/IEmailCreditCard.kt
@@ -25,4 +25,6 @@ interface IEmailCreditCard {
     fun clone(id: Int): Boolean
 
     fun read(numDaysRead: Int)
+
+    fun isEmailAccessGranted(): Boolean
 }

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/interfaces/paid/IEmailPaid.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/interfaces/paid/IEmailPaid.kt
@@ -16,4 +16,5 @@ interface IEmailPaid {
     fun getEmailList(sender: String, subject: String, numDaysRead: Int): List<Pair<String, LocalDateTime>>
 
     fun read(numDaysRead: Int)
+    fun isEmailAccessGranted(): Boolean
 }

--- a/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/interfaces/paid/IEmailPaid.kt
+++ b/japl-android-finances-core/src/main/java/co/japl/finances/core/usercases/interfaces/paid/IEmailPaid.kt
@@ -5,6 +5,7 @@ import co.com.japl.finances.iports.dtos.EmailValidationDTO
 import java.time.LocalDateTime
 
 interface IEmailPaid {
+    fun hasGmailPermission(): Boolean
     fun create(dto: EmailPaidDTO): Int
     fun update(dto: EmailPaidDTO): Boolean
     fun getById(id: Int): EmailPaidDTO?

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/emailpaid/list/EmailListPaidViewModel.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/emailpaid/list/EmailListPaidViewModel.kt
@@ -22,8 +22,7 @@ class EmailListPaidViewModel(
     fun getNavController(): NavController? = navController
 
     fun hasGmailPermission(context: android.content.Context): Boolean {
-        val account = com.google.android.gms.auth.api.signin.GoogleSignIn.getLastSignedInAccount(context)
-        return account?.grantedScopes?.any { it.scopeUri.contains("gmail") } ?: false
+        return svc?.isEmailAccessGranted() ?: false
     }
 
     fun navigateToLogin() {

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/emailpaid/list/EmailListPaidViewModel.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/emailpaid/list/EmailListPaidViewModel.kt
@@ -18,6 +18,8 @@ class EmailListPaidViewModel(
 ) : ViewModel() {
 
     val load = mutableStateOf(true)
+
+    fun getNavController(): NavController? = navController
     val list = mutableStateListOf<EmailPaidDTO>()
 
     fun main() {

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/emailpaid/list/EmailListPaidViewModel.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/emailpaid/list/EmailListPaidViewModel.kt
@@ -20,6 +20,17 @@ class EmailListPaidViewModel(
     val load = mutableStateOf(true)
 
     fun getNavController(): NavController? = navController
+
+    fun hasGmailPermission(context: android.content.Context): Boolean {
+        val account = com.google.android.gms.auth.api.signin.GoogleSignIn.getLastSignedInAccount(context)
+        return account?.grantedScopes?.any { it.scopeUri.contains("gmail") } ?: false
+    }
+
+    fun navigateToLogin() {
+        navController?.let {
+            co.com.japl.module.paid.navigations.LoginNavigation.navigateToLogin(it)
+        }
+    }
     val list = mutableStateListOf<EmailPaidDTO>()
 
     fun main() {

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/emailpaid/list/EmailListPaidViewModel.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/emailpaid/list/EmailListPaidViewModel.kt
@@ -21,9 +21,8 @@ class EmailListPaidViewModel(
 
     fun getNavController(): NavController? = navController
 
-    fun hasGmailPermission(context: android.content.Context): Boolean {
-        val account = com.google.android.gms.auth.api.signin.GoogleSignIn.getLastSignedInAccount(context)
-        return account?.grantedScopes?.any { it.scopeUri.contains("gmail") } ?: false
+    fun hasGmailPermission(): Boolean {
+        return svc?.hasGmailPermission() ?: false
     }
 
     fun navigateToLogin() {

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/paid/list/PaidViewModel.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/paid/list/PaidViewModel.kt
@@ -54,9 +54,8 @@ class PaidViewModel @AssistedInject constructor(@Assisted private val accountCod
 
     val settingState = mutableStateOf(false)
 
-    fun hasGmailPermission(context: android.content.Context): Boolean {
-        val account = com.google.android.gms.auth.api.signin.GoogleSignIn.getLastSignedInAccount(context)
-        return account?.grantedScopes?.any { it.scopeUri.contains("gmail") } ?: false
+    fun hasGmailPermission(): Boolean {
+        return emailSvc?.hasGmailPermission() ?: false
     }
 
     fun newOne(){

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/paid/list/PaidViewModel.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/paid/list/PaidViewModel.kt
@@ -55,8 +55,7 @@ class PaidViewModel @AssistedInject constructor(@Assisted private val accountCod
     val settingState = mutableStateOf(false)
 
     fun hasGmailPermission(context: android.content.Context): Boolean {
-        val account = com.google.android.gms.auth.api.signin.GoogleSignIn.getLastSignedInAccount(context)
-        return account?.grantedScopes?.any { it.scopeUri.contains("gmail") } ?: false
+        return emailSvc?.isEmailAccessGranted() ?: false
     }
 
     fun newOne(){

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/paid/list/PaidViewModel.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/paid/list/PaidViewModel.kt
@@ -54,6 +54,10 @@ class PaidViewModel @AssistedInject constructor(@Assisted private val accountCod
 
     val settingState = mutableStateOf(false)
 
+    fun hasGmailPermission(context: android.content.Context): Boolean {
+        val account = com.google.android.gms.auth.api.signin.GoogleSignIn.getLastSignedInAccount(context)
+        return account?.grantedScopes?.any { it.scopeUri.contains("gmail") } ?: false
+    }
 
     fun newOne(){
         navController?.let {

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/navigations/LoginNavigation.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/navigations/LoginNavigation.kt
@@ -1,0 +1,15 @@
+package co.com.japl.module.paid.navigations
+
+import androidx.core.net.toUri
+import androidx.navigation.NavController
+import androidx.navigation.NavDeepLinkRequest
+import co.com.japl.module.paid.R
+
+object LoginNavigation {
+    fun navigateToLogin(navController: NavController) {
+        val request = NavDeepLinkRequest.Builder
+            .fromUri(navController.context.getString(R.string.navigate_to_login).toUri())
+            .build()
+        navController.navigate(request)
+    }
+}

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/email/list/EmailListPaid.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/email/list/EmailListPaid.kt
@@ -42,8 +42,7 @@ import co.com.japl.ui.theme.values.Dimensions
 fun EmailListPaid(viewModel: EmailListPaidViewModel) {
     val load by viewModel.load
     val context = LocalContext.current
-    val account = remember { GoogleSignIn.getLastSignedInAccount(context) }
-    val hasGmailPermission = remember { account?.grantedScopes?.any { it.scopeUri.contains("gmail") } ?: false }
+    val hasGmailPermission = remember { viewModel.hasGmailPermission(context) }
 
     if (!hasGmailPermission) {
         Column(
@@ -54,21 +53,16 @@ fun EmailListPaid(viewModel: EmailListPaidViewModel) {
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Text(
-                text = "No tienes permisos para usar esta funcionalidad activala en la interface de inicio de sesion",
+                text = stringResource(id = R.string.no_gmail_permission_error),
                 style = MaterialTheme.typography.bodyLarge,
                 textAlign = TextAlign.Center,
                 modifier = Modifier.padding(bottom = 16.dp),
                 color = MaterialTheme.colorScheme.onBackground
             )
             Button(onClick = {
-                viewModel.getNavController()?.let { nav ->
-                    val request = NavDeepLinkRequest.Builder
-                        .fromUri("android-app://co.com.japl.finanzas.module.app/google_login".toUri())
-                        .build()
-                    nav.navigate(request)
-                }
+                viewModel.navigateToLogin()
             }) {
-                Text(text = "Ir a Inicio de Sesión")
+                Text(text = stringResource(id = R.string.go_to_login_button))
             }
         }
     } else {

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/email/list/EmailListPaid.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/email/list/EmailListPaid.kt
@@ -3,6 +3,11 @@ package co.com.japl.module.paid.views.email.list
 import android.content.res.Configuration
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.*
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
+import androidx.navigation.NavDeepLinkRequest
+import androidx.core.net.toUri
+import com.google.android.gms.auth.api.signin.GoogleSignIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -36,16 +41,47 @@ import co.com.japl.ui.theme.values.Dimensions
 @Composable
 fun EmailListPaid(viewModel: EmailListPaidViewModel) {
     val load by viewModel.load
+    val context = LocalContext.current
+    val account = remember { GoogleSignIn.getLastSignedInAccount(context) }
+    val hasGmailPermission = remember { account?.grantedScopes?.any { it.scopeUri.contains("gmail") } ?: false }
 
-    LaunchedEffect(Unit) {
-        viewModel.main()
-    }
-    Column{
-        if (load) {
-            LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
-            Text(text=stringResource(R.string.loading_data))
-        } else {
-            Body(viewModel)
+    if (!hasGmailPermission) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "No tienes permisos para usar esta funcionalidad activala en la interface de inicio de sesion",
+                style = MaterialTheme.typography.bodyLarge,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(bottom = 16.dp),
+                color = MaterialTheme.colorScheme.onBackground
+            )
+            Button(onClick = {
+                viewModel.getNavController()?.let { nav ->
+                    val request = NavDeepLinkRequest.Builder
+                        .fromUri("android-app://co.com.japl.finanzas.module.app/google_login".toUri())
+                        .build()
+                    nav.navigate(request)
+                }
+            }) {
+                Text(text = "Ir a Inicio de Sesión")
+            }
+        }
+    } else {
+        LaunchedEffect(Unit) {
+            viewModel.main()
+        }
+        Column{
+            if (load) {
+                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                Text(text=stringResource(R.string.loading_data))
+            } else {
+                Body(viewModel)
+            }
         }
     }
 }

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/email/list/EmailListPaid.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/email/list/EmailListPaid.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.navigation.NavDeepLinkRequest
 import androidx.core.net.toUri
-import com.google.android.gms.auth.api.signin.GoogleSignIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -41,8 +40,7 @@ import co.com.japl.ui.theme.values.Dimensions
 @Composable
 fun EmailListPaid(viewModel: EmailListPaidViewModel) {
     val load by viewModel.load
-    val context = LocalContext.current
-    val hasGmailPermission = remember { viewModel.hasGmailPermission(context) }
+    val hasGmailPermission = remember { viewModel.hasGmailPermission() }
 
     if (!hasGmailPermission) {
         Column(

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/paid/list/PopUpView.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/paid/list/PopUpView.kt
@@ -34,7 +34,7 @@ fun PopupSetting(viewModel: PaidViewModel, state: MutableState<Boolean>) {
     val paidSMSDaysRead = remember { viewModel.paidSMSDaysRead }
     val errorPaidSMSDaysRead = remember { viewModel.errorPaidSMSDaysRead }
     val context = LocalContext.current
-    val hasGmailPermission = remember { viewModel.hasGmailPermission(context) }
+    val hasGmailPermission = remember { viewModel.hasGmailPermission() }
 
     Popup(title = R.string.setting, state = state) {
         Scaffold(

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/paid/list/PopUpView.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/paid/list/PopUpView.kt
@@ -34,13 +34,17 @@ fun PopupSetting(viewModel: PaidViewModel, state: MutableState<Boolean>) {
     val paidSMSDaysRead = remember { viewModel.paidSMSDaysRead }
     val errorPaidSMSDaysRead = remember { viewModel.errorPaidSMSDaysRead }
     val context = LocalContext.current
+    val account = remember { com.google.android.gms.auth.api.signin.GoogleSignIn.getLastSignedInAccount(context) }
+    val hasGmailPermission = remember { account?.grantedScopes?.any { it.scopeUri.contains("gmail") } ?: false }
 
     Popup(title = R.string.setting, state = state) {
         Scaffold(
             floatingActionButton = {
                 Row {
-                    FloatButton(imageVector = Icons.AutoMirrored.Rounded.ForwardToInbox, descriptionIcon = R.string.email_read) {
-                        viewModel.readEmail(context)
+                    if (hasGmailPermission) {
+                        FloatButton(imageVector = Icons.AutoMirrored.Rounded.ForwardToInbox, descriptionIcon = R.string.email_read) {
+                            viewModel.readEmail(context)
+                        }
                     }
                     FloatButton(imageVector = Icons.Rounded.Save, descriptionIcon = R.string.save) {
                         viewModel.saveSettings(context)
@@ -60,15 +64,17 @@ fun PopupSetting(viewModel: PaidViewModel, state: MutableState<Boolean>) {
                         paidSMSDaysRead.value = it
                     }, modifier = Modifier.padding(top = Dimensions.PADDING_SHORT).fillMaxWidth())
 
-                FieldText(title = stringResource(id = R.string.email_read_num),
-                    value = paidEmailDaysRead.value,
-                    hasErrorState = errorPaidEmailDaysRead,
-                    keyboardType = KeyboardOptions(keyboardType = KeyboardType.Number),
-                    icon = Icons.Rounded.Cancel,
-                    validation = { viewModel.validation() },
-                    callback = {
-                        paidEmailDaysRead.value = it
-                    }, modifier = Modifier.padding(top = Dimensions.PADDING_SHORT).fillMaxWidth())
+                if (hasGmailPermission) {
+                    FieldText(title = stringResource(id = R.string.email_read_num),
+                        value = paidEmailDaysRead.value,
+                        hasErrorState = errorPaidEmailDaysRead,
+                        keyboardType = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        icon = Icons.Rounded.Cancel,
+                        validation = { viewModel.validation() },
+                        callback = {
+                            paidEmailDaysRead.value = it
+                        }, modifier = Modifier.padding(top = Dimensions.PADDING_SHORT).fillMaxWidth())
+                }
             }
         }
     }

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/paid/list/PopUpView.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/paid/list/PopUpView.kt
@@ -34,8 +34,7 @@ fun PopupSetting(viewModel: PaidViewModel, state: MutableState<Boolean>) {
     val paidSMSDaysRead = remember { viewModel.paidSMSDaysRead }
     val errorPaidSMSDaysRead = remember { viewModel.errorPaidSMSDaysRead }
     val context = LocalContext.current
-    val account = remember { com.google.android.gms.auth.api.signin.GoogleSignIn.getLastSignedInAccount(context) }
-    val hasGmailPermission = remember { account?.grantedScopes?.any { it.scopeUri.contains("gmail") } ?: false }
+    val hasGmailPermission = remember { viewModel.hasGmailPermission(context) }
 
     Popup(title = R.string.setting, state = state) {
         Scaffold(

--- a/japl-android-finances-paid-module/src/main/res/values/strings.xml
+++ b/japl-android-finances-paid-module/src/main/res/values/strings.xml
@@ -139,4 +139,7 @@ Email Samples:
     <string name="num_paids">#</string>
     <string name="quote_value_short">Cuota</string>
     <string name="subject_email">Asunto</string>
+    <string name="navigate_to_login">android-app://co.com.japl.finanzas.module.app/google_login</string>
+    <string name="no_gmail_permission_error">No tienes permisos para usar esta funcionalidad activala en la interface de inicio de sesion</string>
+    <string name="go_to_login_button">Ir a Inicio de Sesión</string>
 </resources>

--- a/japl-android-finances-services/src/main/java/co/japl/android/finances/services/implement/EmailCreditCardPatternImpl.kt
+++ b/japl-android-finances-services/src/main/java/co/japl/android/finances/services/implement/EmailCreditCardPatternImpl.kt
@@ -35,4 +35,8 @@ class EmailCreditCardPatternImpl @Inject constructor(private val emailRead: IEma
     override fun getEmailList(sender: String, subject: String, numDaysRead: Int): List<Pair<String, LocalDateTime>> {
         return emailRead.getEmails(sender, subject, numDaysRead)
     }
+
+    override fun isEmailAccessGranted(): Boolean {
+        return emailRead.isEmailAccessGranted()
+    }
 }

--- a/japl-android-finances-services/src/main/java/co/japl/android/finances/services/implement/EmailCreditCardPatternImpl.kt
+++ b/japl-android-finances-services/src/main/java/co/japl/android/finances/services/implement/EmailCreditCardPatternImpl.kt
@@ -13,6 +13,8 @@ import javax.inject.Inject
 
 class EmailCreditCardPatternImpl @Inject constructor(private val emailRead: IEmailRead) : IEmailCreditCardPattern {
 
+    override fun hasGmailPermission(): Boolean = emailRead.hasGmailPermission()
+
     override fun validateMessagePattern(dto: EmailCreditCardDTO, numDaysRead: Int): List<EmailValidationDTO> {
         val emails = emailRead.getEmails(dto.sender, dto.subjectPattern, numDaysRead)
         return emails.map { body ->

--- a/japl-android-finances-services/src/main/java/co/japl/android/finances/services/implement/EmailPaidPatternImpl.kt
+++ b/japl-android-finances-services/src/main/java/co/japl/android/finances/services/implement/EmailPaidPatternImpl.kt
@@ -46,4 +46,8 @@ class EmailPaidPatternImpl @Inject constructor(private val emailRead: IEmailRead
     override fun getEmailList(sender: String, subject: String, numDaysRead: Int): List<Pair<String, LocalDateTime>> {
         return emailRead.getEmails(sender, subject, numDaysRead)
     }
+
+    override fun isEmailAccessGranted(): Boolean {
+        return emailRead.isEmailAccessGranted()
+    }
 }

--- a/japl-android-finances-services/src/main/java/co/japl/android/finances/services/implement/EmailPaidPatternImpl.kt
+++ b/japl-android-finances-services/src/main/java/co/japl/android/finances/services/implement/EmailPaidPatternImpl.kt
@@ -13,6 +13,8 @@ import javax.inject.Inject
 
 class EmailPaidPatternImpl @Inject constructor(private val emailRead: IEmailRead) : IEmailPaidPattern {
 
+    override fun hasGmailPermission(): Boolean = emailRead.hasGmailPermission()
+
     override fun validateMessagePattern(dto: EmailPaidDTO, numDaysRead: Int): List<EmailValidationDTO> {
         try {
             val emails = emailRead.getEmails(dto.sender, dto.subjectPattern, numDaysRead)

--- a/japl-android-finances-services/src/main/java/co/japl/android/finances/services/implement/GmailReadImpl.kt
+++ b/japl-android-finances-services/src/main/java/co/japl/android/finances/services/implement/GmailReadImpl.kt
@@ -24,6 +24,11 @@ class GmailReadImpl @Inject constructor(
     private val jsonFactory = GsonFactory.getDefaultInstance()
     private val httpTransport = NetHttpTransport()
 
+    override fun hasGmailPermission(): Boolean {
+        val account = GoogleSignIn.getLastSignedInAccount(context)
+        return account?.grantedScopes?.any { it.scopeUri.contains("gmail") } ?: false
+    }
+
     override fun getEmails(sender: String, subject: String, numDaysRead: Int): List<Pair<String, LocalDateTime>> {
         val account = GoogleSignIn.getLastSignedInAccount(context) ?: return emptyList()
         val credential =

--- a/japl-android-finances-services/src/main/java/co/japl/android/finances/services/implement/GmailReadImpl.kt
+++ b/japl-android-finances-services/src/main/java/co/japl/android/finances/services/implement/GmailReadImpl.kt
@@ -21,6 +21,11 @@ class GmailReadImpl @Inject constructor(
     private val context: Context
 ) : IEmailRead {
 
+    override fun isEmailAccessGranted(): Boolean {
+        val account = GoogleSignIn.getLastSignedInAccount(context)
+        return account?.grantedScopes?.any { it.scopeUri.contains("gmail") } ?: false
+    }
+
     private val jsonFactory = GsonFactory.getDefaultInstance()
     private val httpTransport = NetHttpTransport()
 

--- a/japl-android-finances-services/src/main/java/co/japl/android/finances/services/implement/GoogleLoginService.kt
+++ b/japl-android-finances-services/src/main/java/co/japl/android/finances/services/implement/GoogleLoginService.kt
@@ -18,7 +18,6 @@ class GoogleLoginService(private val activity:Activity, override val RC_SIGN_IN:
         .Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
         .requestEmail()
         .requestScopes(
-            Scope(GmailScopes.GMAIL_READONLY),
             Scope(DriveScopes.DRIVE_APPDATA)
         )
         .build()

--- a/japl-finances-iports/src/main/java/co/com/japl/finances/iports/inbounds/common/IEmailRead.kt
+++ b/japl-finances-iports/src/main/java/co/com/japl/finances/iports/inbounds/common/IEmailRead.kt
@@ -4,4 +4,5 @@ import java.time.LocalDateTime
 
 interface IEmailRead {
     fun getEmails(sender: String, subject: String, numDaysRead: Int): List<Pair<String, LocalDateTime>>
+    fun hasGmailPermission(): Boolean
 }

--- a/japl-finances-iports/src/main/java/co/com/japl/finances/iports/inbounds/common/IEmailRead.kt
+++ b/japl-finances-iports/src/main/java/co/com/japl/finances/iports/inbounds/common/IEmailRead.kt
@@ -4,4 +4,5 @@ import java.time.LocalDateTime
 
 interface IEmailRead {
     fun getEmails(sender: String, subject: String, numDaysRead: Int): List<Pair<String, LocalDateTime>>
+    fun isEmailAccessGranted(): Boolean
 }

--- a/japl-finances-iports/src/main/java/co/com/japl/finances/iports/inbounds/creditcard/IEmailCreditCardPort.kt
+++ b/japl-finances-iports/src/main/java/co/com/japl/finances/iports/inbounds/creditcard/IEmailCreditCardPort.kt
@@ -5,6 +5,8 @@ import co.com.japl.finances.iports.dtos.EmailValidationDTO
 
 interface IEmailCreditCardPort{
 
+    fun hasGmailPermission(): Boolean
+
     fun validateMessagePattern(dto: EmailCreditCardDTO, numDaysRead: Int):List<EmailValidationDTO>
 
     fun create(dto: EmailCreditCardDTO): Int

--- a/japl-finances-iports/src/main/java/co/com/japl/finances/iports/inbounds/creditcard/IEmailCreditCardPort.kt
+++ b/japl-finances-iports/src/main/java/co/com/japl/finances/iports/inbounds/creditcard/IEmailCreditCardPort.kt
@@ -24,4 +24,6 @@ interface IEmailCreditCardPort{
     fun getEmailList(sender: String, subject: String, numDaysRead: Int): List<String>
 
     fun read(numDaysRead: Int)
+
+    fun isEmailAccessGranted(): Boolean
 }

--- a/japl-finances-iports/src/main/java/co/com/japl/finances/iports/inbounds/paid/IEmailPaidPort.kt
+++ b/japl-finances-iports/src/main/java/co/com/japl/finances/iports/inbounds/paid/IEmailPaidPort.kt
@@ -24,4 +24,6 @@ interface IEmailPaidPort {
     fun getEmailList(sender: String, subject: String, numDaysRead: Int): List<String>
 
     fun read(numDaysRead: Int)
+
+    fun isEmailAccessGranted(): Boolean
 }

--- a/japl-finances-iports/src/main/java/co/com/japl/finances/iports/inbounds/paid/IEmailPaidPort.kt
+++ b/japl-finances-iports/src/main/java/co/com/japl/finances/iports/inbounds/paid/IEmailPaidPort.kt
@@ -5,6 +5,8 @@ import co.com.japl.finances.iports.dtos.EmailValidationDTO
 
 interface IEmailPaidPort {
 
+    fun hasGmailPermission(): Boolean
+
     fun validateMessagePattern(dto: EmailPaidDTO, numDaysRead: Int): List<EmailValidationDTO>
 
     fun create(dto: EmailPaidDTO): Int

--- a/japl-finances-iports/src/main/java/co/com/japl/finances/iports/outbounds/IEmailCreditCardPattern.kt
+++ b/japl-finances-iports/src/main/java/co/com/japl/finances/iports/outbounds/IEmailCreditCardPattern.kt
@@ -10,4 +10,6 @@ interface IEmailCreditCardPattern {
     fun validateMessagePattern(dto: EmailCreditCardDTO, numDaysRead: Int): List<EmailValidationDTO>
 
     fun getEmailList(sender: String, subject: String, numDaysRead: Int): List<Pair<String, LocalDateTime>>
+
+    fun isEmailAccessGranted(): Boolean
 }

--- a/japl-finances-iports/src/main/java/co/com/japl/finances/iports/outbounds/IEmailCreditCardPattern.kt
+++ b/japl-finances-iports/src/main/java/co/com/japl/finances/iports/outbounds/IEmailCreditCardPattern.kt
@@ -7,6 +7,8 @@ import java.time.LocalDateTime
 
 interface IEmailCreditCardPattern {
 
+    fun hasGmailPermission(): Boolean
+
     fun validateMessagePattern(dto: EmailCreditCardDTO, numDaysRead: Int): List<EmailValidationDTO>
 
     fun getEmailList(sender: String, subject: String, numDaysRead: Int): List<Pair<String, LocalDateTime>>

--- a/japl-finances-iports/src/main/java/co/com/japl/finances/iports/outbounds/IEmailPaidPattern.kt
+++ b/japl-finances-iports/src/main/java/co/com/japl/finances/iports/outbounds/IEmailPaidPattern.kt
@@ -9,4 +9,6 @@ interface IEmailPaidPattern {
     fun validateMessagePattern(dto: EmailPaidDTO, numDaysRead: Int): List<EmailValidationDTO>
 
     fun getEmailList(sender: String, subject: String, numDaysRead: Int): List<Pair<String, LocalDateTime>>
+
+    fun isEmailAccessGranted(): Boolean
 }

--- a/japl-finances-iports/src/main/java/co/com/japl/finances/iports/outbounds/IEmailPaidPattern.kt
+++ b/japl-finances-iports/src/main/java/co/com/japl/finances/iports/outbounds/IEmailPaidPattern.kt
@@ -6,6 +6,8 @@ import java.time.LocalDateTime
 
 interface IEmailPaidPattern {
 
+    fun hasGmailPermission(): Boolean
+
     fun validateMessagePattern(dto: EmailPaidDTO, numDaysRead: Int): List<EmailValidationDTO>
 
     fun getEmailList(sender: String, subject: String, numDaysRead: Int): List<Pair<String, LocalDateTime>>


### PR DESCRIPTION
Delegated Gmail permission checking through the hexagonal ports and adapters architecture, eliminating direct GoogleSignIn API and Android Context dependencies from ViewModels and Compose views.

---
*PR created automatically by Jules for task [9578132215328805497](https://jules.google.com/task/9578132215328805497) started by @nano871022*