### PR TITLE
Fix app startup WorkDatabase crash under AGP 9

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -76,3 +76,24 @@
 -keep class **.R$*
 
 -keep class com.fasterxml.** {*;}
+
+# WorkManager and Room database implementation protection for AGP 9
+-keep class androidx.work.impl.** { *; }
+-keep class androidx.room.MultiInstanceInvalidationService { *; }
+-dontwarn androidx.work.impl.**
+
+# Specific implementation classes and Worker persistence
+-keep class androidx.work.impl.WorkDatabase_Impl { *; }
+-keep class androidx.work.impl.background.systemjob.SystemJobService { *; }
+-keep class * extends androidx.work.Worker { *; }
+-keep class * extends androidx.work.ListenableWorker { *; }
+
+# App Startup persistence to prevent obfuscation breaks on start
+-keep class androidx.startup.** { *; }
+-keep class androidx.startup.InitializationProvider
+-keep class * implements androidx.startup.Initializer
+
+# Room/SQLite internal database implementation (Android 15 and AGP 9 compatibility)
+-keep class * extends androidx.room.RoomDatabase { *; }
+-keep class androidx.work.impl.db.WorkDatabase_Impl { *; }
+-keep class androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory


### PR DESCRIPTION
Fixed a fatal app startup crash during initialization of WorkManager/WorkDatabase. When R8 optimization is enabled (such as under AGP 9 in release builds), Room's reflection-based lookup of generated database implementations (WorkDatabase_Impl) fails because classes are obfuscated or stripped.

We resolved this by adding the recommended keep rules for:
- `androidx.work.impl.**`
- `androidx.room.MultiInstanceInvalidationService`
- `androidx.work.impl.WorkDatabase_Impl`
- `androidx.work.impl.background.systemjob.SystemJobService`
- Classes extending `androidx.work.Worker` or `androidx.work.ListenableWorker`
- `androidx.startup.**`
- Classes extending `androidx.room.RoomDatabase`
- `androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory`

---
*PR created automatically by Jules for task [14422465383204069532](https://jules.google.com/task/14422465383204069532) started by @nano871022*