### PR TITLE
Fix runtime dialog NoSuchMethodError and NumberFormatExceptions

### DIFF
--- a/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/bought/Dialogs.kt
+++ b/CreditCardModule/src/main/java/co/com/japl/module/creditcard/views/bought/Dialogs.kt
@@ -12,7 +12,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Cancel
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.BasicAlertDialog
+import androidx.compose.ui.window.Dialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -130,7 +130,7 @@ fun MoreOptionsDialog(valueToPay:Double,isRecurrent:Boolean, creditRate:Double,l
                 })
         }
     }
-    BasicAlertDialog(onDismissRequest = onDismiss) {
+    Dialog(onDismissRequest = onDismiss) {
         Surface {
             Column(
                 modifier = Modifier.fillMaxWidth(),
@@ -206,7 +206,7 @@ private fun DifferInstallmentDialog(value:Double,creditRate: Double,onDismiss: (
     val stateInstallment = remember { mutableStateOf("") }
     val newValueInstallment = remember { mutableDoubleStateOf(0.0) }
     val interest = remember {mutableDoubleStateOf(0.0)}
-    BasicAlertDialog(onDismissRequest = onDismiss) {
+    Dialog(onDismissRequest = onDismiss) {
         Surface {
             Column(
                 modifier = Modifier.fillMaxWidth(),

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/projections/forms/ProjectionFormViewModel.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/controllers/projections/forms/ProjectionFormViewModel.kt
@@ -103,7 +103,7 @@ class ProjectionFormViewModel @AssistedInject constructor(
         saveStateHandler!!,
         "FORM_VALUE",
         initialValue = projection.value.value,
-        formatter = { if(NumbersUtil.isNumber(it)) BigDecimal(it) else BigDecimal.ZERO },
+        formatter = { if(NumbersUtil.isNumber(it)) NumbersUtil.toBigDecimal(it) else BigDecimal.ZERO },
         validator = { it > BigDecimal.ZERO },
         onValueChangeCallBack = { newValue ->
             projection.update{
@@ -117,7 +117,7 @@ class ProjectionFormViewModel @AssistedInject constructor(
         saveStateHandler!!,
         "FORM_QUOTE",
         initialValue = projection.value.quote,
-        formatter = { if(NumbersUtil.isNumber(it)) BigDecimal(it) else BigDecimal.ZERO },
+        formatter = { if(NumbersUtil.isNumber(it)) NumbersUtil.toBigDecimal(it) else BigDecimal.ZERO },
         validator = { it > BigDecimal.ZERO },
         onValueChangeCallBack = { newValue ->
             projection.update{

--- a/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/Inputs/list/Dialog.kt
+++ b/japl-android-finances-paid-module/src/main/java/co/com/japl/module/paid/views/Inputs/list/Dialog.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Cancel
-import androidx.compose.material3.BasicAlertDialog
+import androidx.compose.ui.window.Dialog
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -97,7 +97,7 @@ private fun DeleteConfirm(stateDeleteDialog:MutableState<Boolean>,onDismiss:()->
 @Composable
 private fun UpdateValueDialog(onDismiss: () -> Unit, onClick: (Double) -> Unit) {
     var text by remember { mutableStateOf("") }
-    BasicAlertDialog(onDismissRequest = onDismiss) {
+    Dialog(onDismissRequest = onDismiss) {
         Surface {
             Column(
                 modifier = Modifier.fillMaxWidth(),

--- a/japl-android-graphs/src/main/java/co/japl/android/graphs/pieceofpie/PieceOfPie.kt
+++ b/japl-android-graphs/src/main/java/co/japl/android/graphs/pieceofpie/PieceOfPie.kt
@@ -175,9 +175,14 @@ class PieceOfPie(val context:Context):IGraph{
     }
 
     private fun descriptionPieceOfPie(title:String,value:Double,total:Double,canvas: Canvas,paint4:Paint){
-        val percent = calculations.calculatePercent(value!!,total).toBigDecimal().round(
-            MathContext(5)
-        )
+        val percentFloat = calculations.calculatePercent(value!!,total)
+        val percent = if (percentFloat.isNaN() || percentFloat.isInfinite()) {
+            BigDecimal.ZERO
+        } else {
+            percentFloat.toBigDecimal().round(
+                MathContext(5)
+            )
+        }
         val value= DecimalFormat("#,###.###").format(value).toString()
         val longText = getLongText(title,value,percent)
         val longHigh = Paint().fontSpacing

--- a/japl-android-graphs/src/main/java/co/japl/android/graphs/pieceofpie/calculations/Calculate.kt
+++ b/japl-android-graphs/src/main/java/co/japl/android/graphs/pieceofpie/calculations/Calculate.kt
@@ -3,10 +3,13 @@ package co.japl.android.graphs.pieceofpie.calculations
 class Calculate {
 
     fun calculatePercent(valuePiece:Double,totalValue:Double):Float{
-        return ((valuePiece * 100) / totalValue).toFloat()
+        if (totalValue == 0.0) return 0.0f
+        val res = ((valuePiece * 100) / totalValue).toFloat()
+        return if (res.isNaN() || res.isInfinite()) 0.0f else res
     }
 
     fun calculate(percent:Float):Float{
+        if (percent.isNaN() || percent.isInfinite()) return 0.0f
         return (percent * 360) / 100
     }
 

--- a/ui/src/main/java/co/com/japl/ui/components/MoreOptionsDialog.kt
+++ b/ui/src/main/java/co/com/japl/ui/components/MoreOptionsDialog.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.BasicAlertDialog
+import androidx.compose.ui.window.Dialog
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -27,7 +27,7 @@ import co.com.japl.ui.enums.IMoreOptions
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MoreOptionsDialog(listOptions:List<IMoreOptions>,onDismiss:()->Unit,onClick: (IMoreOptions) -> Unit){
-    BasicAlertDialog(onDismissRequest = onDismiss) {
+    Dialog(onDismissRequest = onDismiss) {
         Surface {
             Column(
                 modifier = Modifier.fillMaxWidth(),
@@ -50,7 +50,7 @@ fun MoreOptionsDialog(listOptions:List<IMoreOptions>,onDismiss:()->Unit,onClick:
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MoreOptionsDialogPair(listOptions:List<Pair<Int,String>>,onDismiss:()->Unit,onClick: (Pair<Int,String>) -> Unit){
-    BasicAlertDialog(onDismissRequest = onDismiss) {
+    Dialog(onDismissRequest = onDismiss) {
         Surface {
             Column(
                 modifier = Modifier.fillMaxWidth(),
@@ -73,7 +73,7 @@ fun MoreOptionsDialogPair(listOptions:List<Pair<Int,String>>,onDismiss:()->Unit,
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MoreOptionsDialogPair(listOptions:SnapshotStateList<Pair<Int,String>>,onDismiss:()->Unit,onClick: (Pair<Int,String>) -> Unit){
-    BasicAlertDialog(onDismissRequest = onDismiss) {
+    Dialog(onDismissRequest = onDismiss) {
         Surface {
             Column(
                 modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
This submission resolves three distinct runtime crashes reported in the application crash logs:
1. NoSuchMethodError with BasicAlertDialog is fixed by migrating MoreOptionsDialog to the standard androidx.compose.ui.window.Dialog.
2. NumberFormatException with "Character N" inside PieceOfPie chart drawing is fixed by validating and checking for division-by-zero, NaN, and Infinite Float results before conversion to BigDecimal.
3. NumberFormatException with whitespace/newline input like "500000 \n" is fixed by using NumbersUtil.toBigDecimal(it) inside ProjectionFormViewModel instead of calling the strict BigDecimal constructor directly.

---
*PR created automatically by Jules for task [12501437324355408826](https://jules.google.com/task/12501437324355408826) started by @nano871022*